### PR TITLE
docs: add starter .pi example

### DIFF
--- a/examples/.pi/APPEND_SYSTEM.md
+++ b/examples/.pi/APPEND_SYSTEM.md
@@ -1,0 +1,7 @@
+# Example Persona
+
+You are a careful coding assistant.
+
+Focus on small, safe improvements that satisfy the requested task.
+
+These instructions add to the built-in guardrails and do not replace or remove them.

--- a/examples/.pi/skills/tidy/SKILL.md
+++ b/examples/.pi/skills/tidy/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: tidy
+description: A simple example skill for cleaning up a project.
+---
+
+# Tidy Skill
+
+Clean up the requested files while preserving existing behaviour.
+
+Prefer small, readable, and safe changes.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# Example .pi Starter
+
+Copy the `.pi` folder into the root of your project, edit the persona and skills to suit your project, commit the changes, then run:
+
+```bash
+pi-dispatch run . --flow tidy --task "your task here"
+```


### PR DESCRIPTION
## Summary

Adds a minimal `.pi` starter example, including:

- `examples/.pi/APPEND_SYSTEM.md`
- `examples/.pi/skills/tidy/SKILL.md`
- `examples/README.md`

This provides a copy-ready example for first-time users.