### PR TITLE
2026-07-17-cron-trigger-plan.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ PI_CONCURRENCY=3       # how many jobs run in parallel
 VALKEY_URL=redis://127.0.0.1:6379
 PI_JOB_IMAGE=pi-job:latest          # the image you built:  docker build -f image/Dockerfile -t pi-job:latest .
 # PI_JOBS_DIR=                      # where per-job /job inputs live (default: your OS temp dir)
+# PI_SCHEDULES_FILE=                # ABSOLUTE path to schedules.json; unset disables cron (a relative path resolves against the worker's WorkingDirectory)
+PI_SCHEDULER_STALL_MAX=2            # tear down a scheduler after N consecutive stalls (money backstop)
 
 # --- GitHub trigger (receiver + worker auth) ---
 # Webhook receiver

--- a/.github/workflows/pi-upgrade-check.yml
+++ b/.github/workflows/pi-upgrade-check.yml
@@ -107,7 +107,13 @@ jobs:
       # PI_DISPATCH_REQUIRE_*_TESTS=1 turns a skip into a hard failure. A skipped assertion is an
       # UNVERIFIED assertion, and "skipped = pass" is precisely the reasoning that lets a
       # guardrail-less agent ship green. VALKEY_TEST_URL activates the queue integration test.
-      - name: Contract tests -- guardrails, -nc, exit codes, env allowlist, queue, receiver enqueue (all required)
+      #
+      # Cron/scheduler assumptions this run pins (BullMQ 5.80.4), each SILENT if it drifts:
+      #   - no-backfill / no-overlap / deterministic repeat: jobId  -> specs/design.md:206-216
+      #   - must-handle -10/-11 (schedule edit else silent no-op)   -> specs/design.md:231
+      #   - scheduler jobs bypass maxStalledCount (stall carve-out)  -> specs/constitution.md:203-216
+      # Exercised by worker/test/cron.integration.test.mjs (VALKEY_TEST_URL + PI_DISPATCH_REQUIRE_WORKER_TESTS gate it live).
+      - name: Contract tests -- guardrails, -nc, exit codes, env allowlist, queue, receiver enqueue, cron (all required)
         env:
           PI_DISPATCH_REQUIRE_LOADER_TESTS: "1"
           PI_DISPATCH_REQUIRE_WORKER_TESTS: "1"

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ coverage/
 .env.*
 !.env.example
 
+# Cron schedule list. Holds host paths and per-schedule tasks; the committed
+# schedules.example.json is the template.
+schedules.json
+!schedules.example.json
+
 # Python — bytecode and tool caches from the skill scripts under .claude/skills/
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,32 @@ flowchart LR
 
 Read [`SECURITY.md`](SECURITY.md) before you rely on it — it states plainly what is and is not defended.
 
+## Scheduling recurring jobs
+
+A cron schedule is a trigger, not a new job kind: each entry runs a local folder through a flow on a cron
+pattern. Cron is **off by default** — the worker reads schedules only when `PI_SCHEDULES_FILE` points at a
+file.
+
+```bash
+# 1. Copy the template and edit it
+cp schedules.example.json schedules.json   # then edit "folder" to a REAL absolute path
+
+# 2. Point the worker at it (absolute path), and restart the worker
+#    In .env:  PI_SCHEDULES_FILE=/absolute/path/to/schedules.json
+npx pi-dispatch worker
+```
+
+Each entry sets `id`, `cron` (5 or 6 fields), `folder`, `flow`, and `task`; `provider`, `model`, and
+`maxTurns` are optional and fall back to the worker's defaults. A schedule's `folder` is a **host path** —
+the worker runs on the host ([`DES-WORKER-ON-HOST`](specs/design.md)) and mounts that folder into the job
+container, so it must be readable by the worker's user.
+
+- **Local schedules only this slice.** `kind` must be `"local"`; the loader rejects `kind:"github"` at
+  startup — a schedule has no webhook delivery, issue number, or body to work.
+- **Editing `folder` is mandatory.** Copying `schedules.example.json` verbatim makes the worker **refuse
+  to start** with `configError: folder does not exist` until `folder` names a real path. This is
+  fail-loud on purpose: a broken schedule never silently fails to fire.
+
 ## Advanced: GitHub automation
 
 pi-dispatch can also be triggered by GitHub — label an issue, and a container works it on a fresh clone,
@@ -132,9 +158,9 @@ minutes.
 
 ## Status
 
-The local-folder path (image, worker, `pi-dispatch run` / `worker`) and the GitHub webhook path
-(receiver → queue → clone → PR) are built and work. The admin panel and scheduled (cron) triggers are in
-progress. The design is specified in
+The local-folder path (image, worker, `pi-dispatch run` / `worker`), the GitHub webhook path
+(receiver → queue → clone → PR), and scheduled (cron) triggers for local folders are built and work. The
+admin panel is in progress. The design is specified in
 [`specs/`](specs/) — start with [`specs/constitution.md`](specs/constitution.md) for the non-negotiables
 and [`specs/design.md`](specs/design.md) for the decisions and what was rejected.
 

--- a/schedules.example.json
+++ b/schedules.example.json
@@ -1,0 +1,15 @@
+{
+  "schedules": [
+    {
+      "id": "nightly-tidy",
+      "kind": "local",
+      "cron": "0 3 * * *",
+      "folder": "/absolute/path/to/your/project",
+      "flow": "tidy",
+      "task": "dedupe imports and run the formatter",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-5-20250929",
+      "maxTurns": 30
+    }
+  ]
+}

--- a/specs/design.md
+++ b/specs/design.md
@@ -214,6 +214,15 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
     one under load, so the panel should surface `next` drift rather than let it look healthy.
   - **Deterministic `jobId`** — `repeat:<schedulerId>:<nextMillis>` — so scheduler jobs get
     `REQ-DEDUP-BY-DELIVERY-GUID`-equivalent dedup for free, with no GUID to supply.
+  - **Local-only this slice.** A `kind:"github"` schedule is rejected at load. A scheduled GitHub job has
+    no webhook delivery, issue number, title, or body to supply, and post-integration the github path would
+    perform a real host clone and per-job token mint before failing every tick — spend and side effects for
+    a trigger that cannot complete. GitHub scheduling is deferred to a later slice.
+  - **Two distinct enqueue paths, not duplication.** The interactive `enqueueLocalJob` sets `attempts: 2`
+    with backoff; the scheduled path (`upsertJobScheduler`) passes retention-only opts with a single
+    attempt. For an unattended recurring trigger the **cadence is the retry**, so a failing tick must not
+    multiply spend within one tick — two distinct triggers with different retry semantics, not two
+    implementations of one thing.
   **Legacy `repeat:` is deprecated and slated for removal in v6** — starting on it would be adopting a
   known-dead API.
 - **Evidence (upstream)**: `taskforcesh/bullmq @ v5.80.4 → src/classes/queue.ts:468-495 → upsertJobScheduler`

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -468,12 +468,41 @@ Evidence convention as in `constitution.md`.
 - **Traces to**: `CONST-HMAC-OVER-RAW-BODY`, `REQ-TRIGGER-AUTHOR-GATE`, `REQ-DEDUP-BY-DELIVERY-GUID`
 - **Acceptance**: Given a payload with unknown extra fields, behaviour is unchanged.
 
+## INT-SCHEDULES-FILE-CONTRACT
+
+**operator → worker.**
+
+- **Contract**:
+  ```
+  schedules.json  (path via PI_SCHEDULES_FILE; absolute; unset = cron disabled)
+  { "schedules": [
+    { "id": "<[A-Za-z0-9._-]+, no ':' , unique>",
+      "kind": "local",                     // only "local"; "github" rejected at load
+      "cron": "<5 or 6 space-separated fields>",
+      "folder": "<absolute HOST path, must exist>",
+      "flow": "<flow name>",
+      "task": "<operator-authored prompt text — DATA, lands in /job/prompt.md>",
+      "provider": "<optional>", "model": "<optional>", "maxTurns": <optional> } ] }
+  ```
+- **Why**: The operator's schedule set is a host file — diffable, reviewable, and git-trackable — rather
+  than API state, so a schedule change is a reviewed edit. `id` must be `:`-free because the stall guard
+  parses BullMQ's deterministic `repeat:<id>:<millis>` job id by splitting on `:`; a colon in the id would
+  corrupt that parse. `task` is operator-authored natural language and is therefore **DATA**
+  (`CONST-ISSUE-TEXT-IS-DATA`): it lands in `/job/prompt.md` as the user prompt, never in a system prompt
+  or persona.
+- **Traces to**: `DES-CRON-VIA-BULLMQ-SCHEDULER`, `CONST-ISSUE-TEXT-IS-DATA`
+- **Acceptance**: Given an entry that is malformed, has `kind:"github"`, a duplicate `id`, a `:` in its
+  `id`, or a `folder` that does not exist, when the config loads, then load throws a
+  `piDispatchConfig`-tagged error. Given a valid `local` entry, when it fires, then the emitted job's
+  `data` byte-matches the shape produced by the interactive local (`enqueueLocalJob`) path.
+
 ---
 
 ## Revision History
 
 | Date | Change |
 |---|---|
+| 2026-07-17 | Added INT-SCHEDULES-FILE-CONTRACT, documenting the implemented `schedules.json` host-file shape (`PI_SCHEDULES_FILE`): `local`-only, `:`-free unique `id`, `task` as DATA, and load-time rejection of malformed/`github`/duplicate/missing-folder entries. |
 | 2026-07-15 | Initial. Extracted from `DESIGN.md` v0.1 §5.1, §5.3, §5.4, §5.5. `INT-SDK-SESSION-OPTIONS` is **new** — the source doc left the SDK option set unverified (its §10) and was wrong about the print-mode flag shape and the mode union. `PLAYWRIGHT_BROWSERS_PATH` added to the runtime contract: the source doc's Dockerfile was broken as written for non-root execution. The source doc's code sketches are deliberately **not** carried over — the real Dockerfile and handler are the truth, and a spec that mirrors them drifts on the first commit. |
 | 2026-07-16 | **Correction — "pi never throws" was FALSE**, and it was in this file for a day as the justification for forbidding `try`/`catch` outright. Adversarial re-verification refuted it: `agent-session.ts:1242-1244` is `catch (error) { preflightResult?.(false); throw error; }`, and pi's **own JSDoc** (`:1099-1100`) documents throws on no-model, no-API-key, and missing `streamingBehavior`; `agent.ts:470-471` throws `"Agent is already processing."` outside the lifecycle try entirely. The rule as written would have produced a runner that dies of an unhandled rejection on a missing API key, exiting Node's default `1` = *retryable*, so the queue pays to retry a job that can never succeed. **Both mechanisms are required and cover disjoint sets: preflight throws, the loop swallows.** Also corrected: `StopReason` has **five** values (`packages/ai/src/types.ts:380`) — the entry handled three, and a default branch silently maps `"length"` (truncated output) to success. `reload()` has **no early return** — a second call fully re-runs everything; the earlier "the `loaded` guard makes a double call safe" framing was wrong. The lesson is the file's own: this entry was written from source and still asserted an absolute from a partial read. `INT-CONTAINER-RUNTIME-CONTRACT` gained `--init`, `--shm-size` (explicitly **not** `--ipc=host`, which Playwright recommends but which would share the host IPC namespace with an adversarial container), fonts (absent ⇒ tofu-box screenshots that silently gut `REQ-FRONTEND-VISUAL-VERIFY`), and the fact that **`COPY --chown` does not fix the EACCES trap** because it skips auto-created parent dirs. |
 | 2026-07-15 | `INT-RUNNER-EXIT-CODE-PROTOCOL` gained its **mechanism**, which was the missing half. The codes were right; nothing said how to produce them, and **the obvious implementation produces them wrong**. ~~`pi never throws`~~ (**refuted the next day — see above**): `agent.ts:485-491` catches and `handleRunFailure` does not rethrow, so abort / 429 / 5xx / dead network all resolve `await session.prompt()` normally — and `prompt()` returns `Promise<void>`, so there is no return value either. A `try`/`catch` runner exits `0` on every infrastructure failure: queue records success, never retries, job did nothing — verbatim the worst failure class this project names. The exit code must be derived from `stopReason` on the terminal message, captured via `subscribe()`. Also recorded: the `subscribe()` listener is **sync and unawaited**, so a budget check that awaits will overshoot. `INT-CONTAINER-RUNTIME-CONTRACT` gained two runtime facts that fail *inside the container* where no Dockerfile hints at them: the agent dir must be **writable** by the non-root user (pi lazily writes `auth.json` on first credential touch), and Chromium needs **`--no-sandbox`** because `--cap-drop=ALL` denies it the seccomp/`SYS_ADMIN` its own sandbox requires — the container is the sandbox, and re-granting caps to Chromium would invert the security model. Two cited paths were **dead** (`packages/ai/src/api/env-api-keys.ts`, `packages/coding-agent/src/core/config.ts`); claims and line numbers were correct, only the addresses were wrong — the sneakiest defect class, since it reads as verified and cannot be followed. All cited paths now resolve. Good news recorded too: `before_agent_start` fires strictly before any provider HTTP call, so the assembled-prompt assertion costs **zero tokens**. |

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -227,6 +227,40 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
   completion or failure line carrying the job id and outcome; during the run, the container's output is
   visible there.
 
+## REQ-CRON-SCHEDULED-JOBS
+
+- **Statement**: Scheduled jobs shall be driven by BullMQ **Job Schedulers** (`upsertJobScheduler`), one
+  per configured schedule. A schedule is a **trigger, not a job kind**: on each tick it emits an ordinary
+  `kind:"local"` job that flows through the **same** processor as an interactively-triggered local job.
+- **Why**: An unattended recurring trigger spends real money against a paid provider with nobody watching,
+  so every failure mode of the scheduler is a money-or-silence failure. Job Schedulers are a Redis-resident
+  object (survives worker and Redis-under-AOF restart) and give no-backfill and structural no-overlap for
+  free — reimplementing those is the four-mechanism drowning `DES-CRON-VIA-BULLMQ-SCHEDULER` refused. The
+  scheduler is also the one path that **bypasses `maxStalledCount`** (`CONST-RETRY-INFRA-ONLY`), so the
+  stall backstop must be rebuilt explicitly; and because it fires while nobody watches, a `-10`/`-11`
+  silent no-op or an in-tick retry storm would be invisible without the loud-surfacing and no-retry rules
+  below.
+- **Traces to**: `DES-CRON-VIA-BULLMQ-SCHEDULER`, `CONST-RETRY-INFRA-ONLY`, `CONST-BUDGET-BEFORE-TOKENS`,
+  `REQ-RUNNER-TURN-BUDGET`
+- **Acceptance**:
+  - Given a config with N schedules, when the worker loads them, then it calls `upsertJobScheduler` once
+    per schedule; a `-10` (`SchedulerJobIdCollision`) or `-11` (`SchedulerJobSlotsBusy`) result — whether
+    thrown or returned — is surfaced loudly (logged and the load fails), never swallowed into a silent
+    no-op.
+  - Given a scheduler whose per-scheduler stall counter exceeds `PI_SCHEDULER_STALL_MAX`, when the next
+    stall is observed, then the scheduler is torn down via `removeJobScheduler` — the explicit backstop for
+    the `maxStalledCount` carve-out.
+  - Given a worker that was down across one or more due ticks, when it restarts, then exactly one job is
+    emitted (no backfill) and no second job for a schedule is created while that schedule's prior job is
+    still processing (no overlap).
+  - Given a scheduler resident in Redis but absent from the current config, when the worker performs its
+    startup reconcile, then the orphaned scheduler is removed.
+  - Given a schedule entry with `kind:"github"`, when the config loads, then the entry is rejected — a
+    scheduled trigger supplies no webhook delivery, issue number, title, or body, so only `kind:"local"`
+    is admissible.
+  - Given a scheduled occurrence that fails (including an infra fault), when the tick concludes, then the
+    occurrence is **not** retried within the tick — the schedule's own cadence is the retry.
+
 ---
 
 ## Notes (not requirements)
@@ -248,4 +282,5 @@ wait-list working as designed, not a failure — see `README.md`.
 |---|---|
 | 2026-07-15 | Initial. Extracted from `DESIGN.md` v0.1 §1, §5.1–5.2, §5.6, §7, §8. `REQ-RUNNER-TURN-BUDGET` and `REQ-UPSTREAM-CONTRACT-TESTS` are **new** — both exist because source-verification refuted design assumptions the doc had marked "verify". §8's failure-mode table was the richest source; one of its rows ("verify: pi max-turns option") was wrong. |
 | 2026-07-17 | Added REQ-BRANCH-PROTECTION-PRECONDITION, formalizing the branch-protection refusal already enforced in `processor.mjs`/`github-host.mjs` (was a dangling code citation). |
+| 2026-07-17 | Added REQ-CRON-SCHEDULED-JOBS, formalizing the implemented BullMQ Job Scheduler cron path: `local`-only triggers, loud `-10`/`-11` handling, per-scheduler stall teardown, startup orphan reconcile, and no in-tick retry. |
 | 2026-07-16 | **Scope de-GitHub-ified.** It said "triggers on GitHub issue activity" and never mentioned local folders, the CLI/panel, or cron -- stale, since local is now first-class and built. Rewritten as trigger × target. `REQ-JOB-STATUS-COMMENTS` scoped to GitHub jobs explicitly (a local job has no issue). New `REQ-LOCAL-JOB-VISIBILITY`: local jobs surface their outcome on the worker console (and later the panel) -- the local counterpart of the issue comment and the same signal for `CONST-PI-VERSION-PINNED`'s silent-no-op mode. Code updated to match: startWorker now logs one terminal line per job. |

--- a/worker/src/config.mjs
+++ b/worker/src/config.mjs
@@ -42,6 +42,8 @@ export function loadConfig(env = process.env, { fileExists = existsSync } = {}) 
 		maxTurns: positiveInt(env, "PI_MAX_TURNS", 30), // pi has no turn limit; we impose one
 		jobImage: env.PI_JOB_IMAGE ?? "pi-job:latest",
 		jobsDir: env.PI_JOBS_DIR ?? defaultJobsDir(),
+		schedulesFile: env.PI_SCHEDULES_FILE ?? null, // DES-CRON-VIA-BULLMQ-SCHEDULER: schedule list is a host file; null = cron disabled
+		schedulerStallMax: positiveInt(env, "PI_SCHEDULER_STALL_MAX", 2), // CONST-RETRY-INFRA-ONLY: per-scheduler stall backstop; positiveInt rejects <1 so a 0 threshold fails closed
 		github: loadGitHubAuth(env, fileExists),
 	};
 }

--- a/worker/src/cron.mjs
+++ b/worker/src/cron.mjs
@@ -1,0 +1,67 @@
+/**
+ * Reconcile the Redis-resident BullMQ job schedulers with the host-side schedule config
+ * (DES-CRON-VIA-BULLMQ-SCHEDULER). Given the normalized schedules from schedules.mjs, upsert each one
+ * and prune any resident scheduler the config no longer names. Idempotency is BullMQ's: upsert is keyed
+ * by schedulerId, so re-running with unchanged config installs the same set and removes nothing.
+ *
+ * The queue is injected, so this module carries no bullmq import and runs anywhere -- the whole
+ * reconcile is exercised in tier-1 tests against a fake queue, with no real Valkey.
+ *
+ * A `-10` (SchedulerJobIdCollision) or `-11` (SchedulerJobSlotsBusy) from upsertJobScheduler is a
+ * sentinel, not a success: swallowing it makes a schedule edit a silent no-op that looks identical to a
+ * clean install (design.md:231-232). Whether the SDK throws or returns the sentinel is unconfirmed until
+ * it runs against live Valkey, so BOTH the thrown path and the negative-return path are loud failures.
+ */
+
+import { configError } from "./config.mjs";
+
+function sentinelName(code) {
+	if (code === -10) return "SchedulerJobIdCollision";
+	if (code === -11) return "SchedulerJobSlotsBusy";
+	return "unknown scheduler sentinel";
+}
+
+/**
+ * Install `schedules` (the normalized `{ schedulerId, name, pattern, data, opts }` shape from
+ * schedules.mjs) and prune orphans. `queue` supplies `upsertJobScheduler` / `getJobSchedulers` /
+ * `removeJobScheduler`; `log(event, fields)` records stable scheduler ids only. Returns
+ * `{ installed, removed }`.
+ */
+export async function reconcile(queue, schedules, { log = () => {} } = {}) {
+	for (const { schedulerId, name, pattern, data, opts } of schedules) {
+		let res;
+		try {
+			// No custom jobId: BullMQ mints the deterministic repeat:<schedulerId>:<nextMillis> id itself.
+			res = await queue.upsertJobScheduler(schedulerId, { pattern }, { name, data, opts });
+		} catch (error) {
+			const loud = configError(`scheduler "${schedulerId}": upsertJobScheduler threw: ${error?.message ?? error}`);
+			loud.cause = error;
+			throw loud;
+		}
+
+		if (typeof res === "number" && res < 0) {
+			throw configError(
+				`scheduler "${schedulerId}": upsertJobScheduler returned ${res} (${sentinelName(res)}); a schedule edit would be a silent no-op`,
+			);
+		}
+	}
+
+	const resident = await queue.getJobSchedulers(0, -1, true);
+	const configIds = new Set(schedules.map((s) => s.schedulerId));
+
+	// Custom: trivial set-diff over getJobSchedulers; no package warranted
+	const orphanIds = resident
+		.map((d) => (typeof d === "string" ? d : (d.key ?? d.id ?? d.name)))
+		.filter((rid) => !configIds.has(rid));
+
+	for (const rid of orphanIds) {
+		try {
+			await queue.removeJobScheduler(rid);
+		} catch {
+			// A scheduler already gone (a concurrent reconcile pruned it) is the goal state, not an error.
+		}
+		log("scheduler_removed_orphan", { schedulerId: rid });
+	}
+
+	return { installed: schedules.length, removed: orphanIds.length };
+}

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -53,7 +53,7 @@ export function makeProcessor({ cancelJob, stopContainer, redis, cap, deps, time
 	};
 }
 
-export function createWorker({ connection, concurrency, cap, redis, deps, limiter }) {
+export function createWorker({ connection, concurrency, cap, redis, deps, limiter, extraClosers = [] }) {
 	let worker; // referenced by cancelJob before assignment; only called later, so the TDZ is fine
 	const processor = makeProcessor({
 		cancelJob: (id, reason) => worker.cancelJob(id, reason),
@@ -76,6 +76,10 @@ export function createWorker({ connection, concurrency, cap, redis, deps, limite
 		// worker.close() would wait up to 30 minutes for the container.
 		await Promise.resolve(worker.cancelAllJobs?.("shutdown")).catch(() => {});
 		await worker.close();
+		// Close auxiliary resources (e.g. a cron scheduler) after the worker drains. Per-item catch
+		// so one failing or absent closer never strands the others or blocks exit -- matches the
+		// swallow posture on cancelAllJobs above.
+		await Promise.all(extraClosers.map((c) => Promise.resolve(c.close?.()).catch(() => {})));
 		process.exit(0);
 	};
 	process.once("SIGTERM", shutdown);

--- a/worker/src/scheduler-stall-guard.mjs
+++ b/worker/src/scheduler-stall-guard.mjs
@@ -1,0 +1,65 @@
+/**
+ * Per-scheduler stall accounting -- the money backstop for cron (constitution.md:203-216).
+ *
+ * BullMQ's `maxStalledCount` does not cover scheduler jobs: `moveStalledJobsToWait` derives
+ * `isRepeatableJob` from the job's `rjk` field and skips the stall-fail for a live scheduler, so a
+ * wedged scheduled run is re-processed -- paid -- on every stall, indefinitely. `maxStalledCount: 0`
+ * bounds ordinary jobs; nothing in BullMQ bounds scheduler jobs. This guard counts stalls per
+ * scheduler over a rolling window and tears the scheduler down once the count exceeds a threshold.
+ *
+ * Injected `redis` (ioredis-compatible), `removeJobScheduler`, and `log` keep the logic testable with
+ * no queue, no bullmq import, and no real Valkey.
+ *
+ * Custom: per-scheduler stall accounting; BullMQ's maxStalledCount does not cover scheduler jobs -- constitution.md:203-216 carve-out ("BullMQ will never do this for us")
+ */
+
+const STALL_KEY = "pi-dispatch:sched-stalls";
+
+// A rolling window: the EXPIRE is re-set on every stall, so a scheduler that stops stalling for a full
+// day drops back to zero. This prevents unrelated transient stalls weeks apart from accumulating into a
+// false teardown -- only sustained stalling inside one window trips the threshold.
+const STALL_WINDOW_SECONDS = 24 * 60 * 60;
+
+/**
+ * Build the `stalled` listener. `threshold` is how many stalls a single scheduler may accrue before
+ * teardown, compared STRICT `>` to mirror BullMQ's own `stalledCount > maxStalledJobCount`.
+ * `removeJobScheduler(schedulerId)` tears a scheduler down; `log(event, fields)` records stable ids
+ * only, never task or body content.
+ *
+ * The returned `onStalled` never rejects: BullMQ's `stalled` event is fire-and-forget (void-invoked),
+ * so a rejection here would surface as an unhandled rejection with no handler to catch it.
+ */
+export function makeStallGuard({ redis, threshold, removeJobScheduler, log }) {
+	return async function onStalled(jobId) {
+		try {
+			// Ordinary jobs are bounded by `maxStalledCount: 0`; only scheduler jobs reach this accounting.
+			if (!jobId.startsWith("repeat:")) return;
+
+			const schedulerId = jobId.slice("repeat:".length, jobId.lastIndexOf(":"));
+			if (schedulerId === "") {
+				// Degenerate `repeat:<n>` / `repeat::<n>` with no scheduler segment: an empty hash field would
+				// pool every such id into one counter, so log and skip rather than hincrby an empty key.
+				log("scheduler_stall_unparsed", { jobId });
+				return;
+			}
+
+			const count = Number(await redis.hincrby(STALL_KEY, schedulerId, 1));
+			await redis.expire(STALL_KEY, STALL_WINDOW_SECONDS);
+
+			if (count > threshold) {
+				try {
+					await removeJobScheduler(schedulerId);
+				} catch (error) {
+					// A scheduler already gone (removed concurrently, or between the stall and now) is the goal
+					// state, not an error -- swallow it so hdel and the teardown alert still run.
+					log("scheduler_teardown_remove_failed", { schedulerId, error: error?.message });
+				}
+				await redis.hdel(STALL_KEY, schedulerId);
+				// The loud log is the "alert" half of the constitution's "removeJobScheduler -- or alert".
+				log("scheduler_torn_down", { schedulerId, stalls: count });
+			}
+		} catch (error) {
+			log("scheduler_stall_guard_error", { jobId, error: error?.message });
+		}
+	};
+}

--- a/worker/src/schedules.mjs
+++ b/worker/src/schedules.mjs
@@ -1,0 +1,117 @@
+/**
+ * Load and validate the host-side schedule list (DES-CRON-VIA-BULLMQ-SCHEDULER). A schedule is a
+ * trigger, not a job kind: each entry names a local folder + flow + task and a cron pattern, and
+ * normalizes to the shape the caller hands to BullMQ's `upsertJobScheduler`
+ * (`schedulerId`, `name`, `pattern`, and the `data`/`opts` job template).
+ *
+ * Fail-loud, like config.mjs: a misconfigured schedule file makes the worker refuse to start with a
+ * clear message rather than upserting a broken scheduler that silently never fires. Every load-time
+ * rejection is a `configError` so the CLI/entry prints it cleanly and exits non-zero.
+ *
+ * Kept free of any bullmq import (mirrors job-id.mjs) so validation is testable everywhere, not only
+ * where the queue's dependencies are installed.
+ *
+ * Custom: schedules validated inline per config.mjs precedent; zod not in deps
+ */
+
+import { existsSync as fsExistsSync, readFileSync as fsReadFileSync } from "node:fs";
+import { configError } from "./config.mjs";
+
+// A schedulerId flows into BullMQ's deterministic `repeat:<id>:<nextMillis>` jobId, so a `:` in the
+// id would corrupt that parsing. The charset also excludes `:`; the dedicated check names the reason.
+const ID_CHARSET = /^[A-Za-z0-9._-]+$/;
+
+function isNonEmptyString(value) {
+	return typeof value === "string" && value.trim() !== "";
+}
+
+/**
+ * Parse, validate, and normalize the schedule file named by `config.schedulesFile`. Returns `[]` when
+ * cron is disabled (`schedulesFile` null/absent). `readFileSync`/`existsSync` are injectable so tests
+ * exercise the full validation path with no real filesystem.
+ */
+export function loadSchedules(config, { readFileSync = fsReadFileSync, existsSync = fsExistsSync } = {}) {
+	const path = config.schedulesFile;
+	if (path === null || path === undefined) return []; // cron disabled
+
+	if (!existsSync(path)) {
+		throw configError(`schedules file does not exist: ${path}`);
+	}
+
+	let parsed;
+	try {
+		parsed = JSON.parse(readFileSync(path, "utf8"));
+	} catch (error) {
+		throw configError(`schedules file is not valid JSON: ${path} (${error.message})`);
+	}
+
+	const entries = parsed?.schedules;
+	if (!Array.isArray(entries)) {
+		throw configError(`schedules file must have a "schedules" array: ${path}`);
+	}
+
+	const seenIds = new Set();
+	return entries.map((entry, index) => normalizeSchedule(entry, index, config, seenIds, existsSync));
+}
+
+function normalizeSchedule(entry, index, config, seenIds, existsSync) {
+	const at = `schedule at index ${index}`;
+
+	if (entry === null || typeof entry !== "object") {
+		throw configError(`${at}: must be an object`);
+	}
+
+	const { id, kind, cron, folder, flow, task } = entry;
+
+	if (!isNonEmptyString(id)) {
+		throw configError(`${at}: id must be a non-empty string`);
+	}
+	if (id.includes(":")) {
+		throw configError(`schedule "${id}": id must not contain ":" -- it corrupts the repeat:<id>:<millis> jobId parsing in the stall guard`);
+	}
+	if (!ID_CHARSET.test(id)) {
+		throw configError(`schedule "${id}": id must match [A-Za-z0-9._-]+`);
+	}
+	if (seenIds.has(id)) {
+		throw configError(`schedule "${id}": duplicate id (ids must be unique)`);
+	}
+	seenIds.add(id);
+
+	if (kind !== "local") {
+		throw configError(`schedule "${id}": scheduled github jobs are not supported: a schedule has no webhook delivery, issue number, title, or body; use a local schedule (kind must be "local", got ${JSON.stringify(kind)})`);
+	}
+
+	if (!isNonEmptyString(cron)) {
+		throw configError(`schedule "${id}": cron must be a non-empty string`);
+	}
+	const fieldCount = cron.trim().split(/\s+/).length;
+	if (fieldCount !== 5 && fieldCount !== 6) {
+		throw configError(`schedule "${id}": cron must have 5 or 6 space-separated fields, got ${fieldCount}`);
+	}
+
+	if (!isNonEmptyString(folder)) {
+		throw configError(`schedule "${id}": folder must be a non-empty string`);
+	}
+	if (!existsSync(folder)) {
+		throw configError(`schedule "${id}": folder does not exist: ${folder}`);
+	}
+
+	if (!isNonEmptyString(flow)) {
+		throw configError(`schedule "${id}": flow must be a non-empty string`);
+	}
+	if (!isNonEmptyString(task)) {
+		throw configError(`schedule "${id}": task must be a non-empty string`);
+	}
+
+	const provider = entry.provider ?? config.provider;
+	const model = entry.model ?? config.model;
+	const maxTurns = entry.maxTurns ?? config.maxTurns;
+
+	// data key order matches queue.mjs:21 -- the shape the processor's runJob consumes.
+	const data = { kind: "local", folder, flow, task, provider, model, maxTurns };
+	// Retention only; the deterministic repeat:<id>:<millis> jobId supplies dedup, so no jobId here,
+	// and scheduler jobs are not retried (DES-CRON-VIA-BULLMQ-SCHEDULER) so no attempts/backoff.
+	const opts = { removeOnComplete: { age: 24 * 3600 }, removeOnFail: { age: 7 * 24 * 3600 } };
+
+	return { schedulerId: id, name: "local", pattern: cron, data, opts };
+}

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -1,10 +1,14 @@
 import { configError, loadConfig } from "./config.mjs";
 import { makeRedisClient, parseConnection } from "./connection.mjs";
+import { reconcile } from "./cron.mjs";
 import { makeGitHubAuth } from "./get-token.mjs";
 import { makeGitHubHost } from "./github-host.mjs";
 import { createWorker } from "./index.mjs";
 import { cleanup, makePrepareWorkspace } from "./prepare.mjs";
+import { makeQueue } from "./queue.mjs";
 import { makeRunContainer } from "./run-container.mjs";
+import { loadSchedules } from "./schedules.mjs";
+import { makeStallGuard } from "./scheduler-stall-guard.mjs";
 
 /**
  * The runnable worker. Reads config, connects to Valkey, wires every REAL dependency the processor
@@ -23,6 +27,11 @@ export async function startWorker(
 	const config = loadConfig(env);
 	const log = (event, fields = {}) => process.stdout.write(`${JSON.stringify({ event, ...fields })}\n`);
 
+	// DES-CRON-VIA-BULLMQ-SCHEDULER: load and validate the schedule file with the operator present and
+	// before any Valkey contact, so a misconfigured schedule refuses startup loudly (configError) rather
+	// than upserting a broken scheduler. [] means cron disabled (no PI_SCHEDULES_FILE).
+	const schedules = loadSchedules(config);
+
 	let gh = null;
 	try {
 		gh = await makeAuth(config.github);
@@ -32,11 +41,19 @@ export async function startWorker(
 	}
 	const host = makeHost();
 
+	// One raw Redis client, shared by the budget (via the worker) and the scheduler stall guard, so it is
+	// hoisted out of the createWorkerFn arg object.
+	const redis = makeRedisClient(config.valkeyUrl);
+	// The persistent runtime queue the stall guard tears schedulers down through. Non-failFast: a long-lived
+	// handle rides out a Valkey blip. Registered as an extraCloser so shutdown drains it after the worker.
+	const schedulerQueue = makeQueue(parseConnection(config.valkeyUrl));
+
 	const worker = createWorkerFn({
 		connection: parseConnection(config.valkeyUrl),
 		concurrency: config.concurrency,
 		cap: config.dailyCap,
-		redis: makeRedisClient(config.valkeyUrl),
+		redis,
+		extraClosers: [schedulerQueue],
 		deps: {
 			runContainer: makeRunContainer({ image: config.jobImage, hostEnv: env }),
 			prepareWorkspace: makePrepareWorkspace({
@@ -78,6 +95,32 @@ export async function startWorker(
 	worker.on("failed", (job, err) =>
 		log("job_failed", { jobId: job?.id, attempt: job?.attemptsMade, reason: String(err?.message ?? err).slice(0, 120) }),
 	);
+
+	// CONST-RETRY-INFRA-ONLY money backstop: BullMQ's maxStalledCount does not bound scheduler jobs, so a
+	// wedged scheduled run is re-paid on every stall. The guard counts stalls per scheduler and tears the
+	// scheduler down past the threshold. Keyed on "stalled", not "failed" -- only a stall is the unbounded re-run.
+	const guard = makeStallGuard({
+		redis,
+		threshold: config.schedulerStallMax,
+		removeJobScheduler: (id) => schedulerQueue.removeJobScheduler(id),
+		log,
+	});
+	worker.on("stalled", (jobId) => void guard.onStalled(jobId));
+
+	// DES-CRON-VIA-BULLMQ-SCHEDULER: install the schedule set (and prune orphans) before announcing the
+	// worker is up, so schedules_installed always precedes worker_started. An empty set skips the reconcile
+	// queue entirely -- no getJobSchedulers Redis hit -- but still logs {0,0} so the operator sees cron is off.
+	if (schedules.length > 0) {
+		const rq = makeQueue(parseConnection(config.valkeyUrl, { failFast: true }));
+		try {
+			const r = await reconcile(rq, schedules, { log });
+			log("schedules_installed", { installed: r.installed, removed: r.removed });
+		} finally {
+			await rq.close().catch(() => {});
+		}
+	} else {
+		log("schedules_installed", { installed: 0, removed: 0 });
+	}
 
 	log("worker_started", {
 		queue: "pi-jobs",

--- a/worker/test/config.test.mjs
+++ b/worker/test/config.test.mjs
@@ -12,6 +12,8 @@ test("loads conservative defaults with an empty-ish env", () => {
 	assert.equal(c.valkeyUrl, "redis://127.0.0.1:6379");
 	assert.equal(c.jobImage, "pi-job:latest");
 	assert.ok(c.jobsDir.length > 0);
+	assert.equal(c.schedulesFile, null);
+	assert.equal(c.schedulerStallMax, 2);
 });
 
 test("env overrides every field", () => {
@@ -40,6 +42,19 @@ test("a malformed integer is a config error, not a silent NaN", () => {
 
 test("cap 0 is rejected -- it would fail closed, and is more likely a typo than intent", () => {
 	assert.throws(() => loadConfig({ PI_DAILY_CAP: "0" }), (e) => e.piDispatchConfig === true);
+});
+
+test("scheduler stall max 0 is rejected -- a 0 threshold would fail closed", () => {
+	assert.throws(() => loadConfig({ PI_SCHEDULER_STALL_MAX: "0" }), (e) => e.piDispatchConfig === true);
+});
+
+test("scheduler stall max non-integer is a config error, not a silent NaN", () => {
+	assert.throws(() => loadConfig({ PI_SCHEDULER_STALL_MAX: "abc" }), (e) => e.piDispatchConfig === true);
+});
+
+test("schedules file is honored verbatim -- no default path, null means cron disabled", () => {
+	const c = loadConfig({ PI_SCHEDULES_FILE: "/abs/x.json" });
+	assert.equal(c.schedulesFile, "/abs/x.json");
 });
 
 test("configError is tagged for clean CLI reporting", () => {

--- a/worker/test/cron.integration.test.mjs
+++ b/worker/test/cron.integration.test.mjs
@@ -1,0 +1,349 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+/**
+ * Tier-3, real-Valkey integration for the cron path (DES-CRON-VIA-BULLMQ-SCHEDULER). It runs the
+ * actual BullMQ v5.80.4 Job Scheduler against a live Valkey, with runContainer/prepareWorkspace/
+ * cleanup/comment stubbed -- no docker, no provider key, offline and free.
+ *
+ * This EXTENDS the REQ-UPSTREAM-CONTRACT-TESTS pattern (pin pi/BullMQ, then verify the upstream
+ * contract in CI rather than trust it) to the three scheduler properties DES-CRON-VIA-BULLMQ-SCHEDULER
+ * (design.md:207) commits to and calls out as "verified rather than assumed": no-backfill, no-overlap,
+ * and the deterministic repeat:<id>:<millis> jobId. The tier-1 cron.test.mjs proves reconcile's LOGIC
+ * against a fake queue; only a live Valkey can retire the two "unconfirmed until it runs against live
+ * Valkey" caveats written into cron.mjs:
+ *   1. the -10/-11 throw-vs-return path (cron.mjs:10-13), and
+ *   2. the getJobSchedulers descriptor id-field that `d.key ?? d.id ?? d.name` (cron.mjs:54) depends on.
+ * Both are pinned to concrete findings below.
+ *
+ * ISOLATION: real Valkey persists schedulers and the shared budget / stall keys across runs, so every
+ * test uses a UNIQUE queue name (module-level counter + Date.now()/Math.random(), which are fine in a
+ * test file) and a teardown that removes every resident scheduler, deletes the stall key and any budget
+ * keys it created, obliterates the queue, and closes the worker/queue/redis handles -- no leaked handle,
+ * no cross-test contamination.
+ */
+
+const url = process.env.VALKEY_TEST_URL;
+if (!url && process.env.PI_DISPATCH_REQUIRE_WORKER_TESTS === "1") {
+	throw new Error("cron.integration REQUIRES VALKEY_TEST_URL when PI_DISPATCH_REQUIRE_WORKER_TESTS=1");
+}
+const skip = url ? false : "VALKEY_TEST_URL not set; cron integration skipped locally";
+
+const STALL_KEY = "pi-dispatch:sched-stalls";
+// A far-future pattern: its single upcoming slot stays DELAYED and is never promoted, so a scheduler
+// installed with it holds one stable resident that a no-worker test can inspect without racing a tick.
+const FAR_FUTURE = "0 0 1 1 *"; // 00:00 on Jan 1, yearly
+const RETENTION = { removeOnComplete: { age: 3600 }, removeOnFail: { age: 3600 } };
+
+// Unique per run so parallel/repeated Valkey tests cannot see each other's jobs or schedulers.
+let queueCounter = 0;
+function uniqueQueueName() {
+	return `pi-jobs-test-${Date.now()}-${queueCounter++}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Bounded poll to a deadline -- never a fixed sleep. Resolves with the first truthy value fn() yields;
+// rejects at the deadline so a wedged expectation fails loudly instead of hanging CI.
+async function waitFor(fn, { timeoutMs = 6000, intervalMs = 50 } = {}) {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		const value = await fn();
+		if (value) return value;
+		if (Date.now() >= deadline) throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+		await sleep(intervalMs);
+	}
+}
+
+// Dynamic imports of bullmq/ioredis-backed modules, deferred to test-run time so a SKIPPED run imports
+// nothing heavy and exits clean. Mirrors queue.test.mjs's freshGitHubQueue.
+async function load() {
+	const { Queue, Worker } = await import("bullmq");
+	const { parseConnection, makeRedisClient } = await import("../src/connection.mjs");
+	const { makeProcessor } = await import("../src/index.mjs");
+	const { reconcile } = await import("../src/cron.mjs");
+	const { makeStallGuard } = await import("../src/scheduler-stall-guard.mjs");
+	const { dayKey } = await import("../src/budget.mjs");
+	return { Queue, Worker, parseConnection, makeRedisClient, makeProcessor, reconcile, makeStallGuard, dayKey };
+}
+
+// afterEach-equivalent teardown, in the order the isolation contract requires: drain every resident
+// scheduler, delete the shared stall key and any budget keys the test created, obliterate the queue,
+// then close the worker, the queue, and the raw redis client so no handle is left open.
+async function teardown({ queue, worker, redis, budgetKeys = [] }) {
+	if (queue) {
+		const resident = await queue.getJobSchedulers(0, -1, true).catch(() => []);
+		for (const d of resident) {
+			const id = typeof d === "string" ? d : (d.key ?? d.id ?? d.name);
+			await queue.removeJobScheduler(id).catch(() => {});
+		}
+	}
+	if (redis) {
+		await redis.del(STALL_KEY).catch(() => {});
+		for (const key of budgetKeys) await redis.del(key).catch(() => {});
+	}
+	await queue?.obliterate({ force: true }).catch(() => {});
+	await worker?.close().catch(() => {});
+	await queue?.close().catch(() => {});
+	await redis?.quit().catch(() => {});
+}
+
+// A normalized local-job template, the shape schedules.mjs emits and runJob consumes.
+function localTemplate(task = "nightly") {
+	return { kind: "local", folder: "/proj", flow: "tidy", task, provider: "anthropic", model: "m", maxTurns: 7 };
+}
+
+// The injected deps runJob needs for a LOCAL job: no token, no branch check, workspace/cleanup/comment
+// stubbed. `runContainer` is supplied per test. `now` fixes the budget key deterministically.
+function localDeps({ runContainer, now }) {
+	return {
+		mintToken: async () => null,
+		isDefaultBranchProtected: async () => true,
+		prepareWorkspace: async () => ({ workspace: "/tmp/ws", jobDir: "/tmp/job" }),
+		runContainer,
+		cleanup: async () => {},
+		comment: async () => {},
+		log: () => {},
+		now,
+	};
+}
+
+// 1. END-TO-END DRAIN + BUDGET-BEFORE-CONTAINER. A real Worker (makeProcessor + new Worker) drains one
+//    scheduled job; the stub runContainer reads the budget key at call time to prove the INCR already
+//    happened before the container ran (CONST-BUDGET-BEFORE-TOKENS), and the deterministic jobId, name,
+//    and data template are asserted against what BullMQ actually enqueued.
+test("scheduled job drains through a real Worker; budget INCR precedes the container", { skip }, async () => {
+	const { Queue, Worker, parseConnection, makeRedisClient, makeProcessor, dayKey } = await load();
+	const name = uniqueQueueName();
+	const conn = parseConnection(url);
+	const redis = makeRedisClient(url);
+	const queue = new Queue(name, { connection: conn });
+	let worker;
+	// runJob does NOT forward keyPrefix to reserveBudget (processor.mjs:80), so the prefix is the default
+	// "budget"; a fixed far-future `now` makes the key deterministic and collision-free with any real day.
+	const fixedNow = new Date(Date.UTC(2099, 0, 1, 12, 0, 0));
+	const budgetKey = dayKey(fixedNow); // "budget:2099-01-01"
+	try {
+		await redis.del(budgetKey).catch(() => {});
+		await queue.obliterate({ force: true }).catch(() => {});
+
+		const template = localTemplate("nightly");
+		let budgetAtContainer = null;
+		const runContainer = async () => {
+			// The reservation must be visible before the only money-spending step runs.
+			budgetAtContainer = Number(await redis.get(budgetKey));
+			return { code: 0, aborted: false };
+		};
+		const baseProcessor = makeProcessor({
+			cancelJob: () => {},
+			stopContainer: () => {},
+			redis,
+			cap: 100,
+			deps: localDeps({ runContainer, now: fixedNow }),
+		});
+		let drainedJob = null;
+		// Arity 3 so BullMQ allocates the AbortController exactly as production does; captures the raw
+		// BullMQ Job (with .id/.name/.data) as it enters processing.
+		const processor = (job, token, signal) => {
+			drainedJob = job;
+			return baseProcessor(job, token, signal);
+		};
+		worker = new Worker(name, processor, { connection: { ...conn, maxRetriesPerRequest: null } });
+
+		await queue.upsertJobScheduler("t", { every: 800 }, { name: "local", data: template, opts: RETENTION });
+
+		// Wait until the container stub ran (=> reserveBudget already executed), then assert.
+		await waitFor(() => budgetAtContainer !== null, { timeoutMs: 6000 });
+
+		assert.ok(drainedJob, "a job drained");
+		assert.equal(drainedJob.name, "local");
+		assert.match(drainedJob.id, /^repeat:t:/, "deterministic repeat:<schedulerId>:<millis> jobId");
+		assert.deepEqual(drainedJob.data, template, "job data is the upserted template verbatim");
+		assert.ok(budgetAtContainer >= 1, `budget INCR must precede the container; saw ${budgetAtContainer}`);
+	} finally {
+		await teardown({ queue, worker, redis, budgetKeys: [budgetKey] });
+	}
+});
+
+// 2. NO BACKFILL. A fresh scheduler yields exactly ONE upcoming slot, not N catch-up ticks -- the
+//    property that turns "six hours down" into one paid run, not six (design.md:207).
+test("a fresh scheduler installs exactly one upcoming slot (no backfill)", { skip }, async () => {
+	const { Queue, parseConnection, makeRedisClient } = await load();
+	const name = uniqueQueueName();
+	const conn = parseConnection(url);
+	const redis = makeRedisClient(url);
+	const queue = new Queue(name, { connection: conn });
+	try {
+		await queue.obliterate({ force: true }).catch(() => {});
+		await queue.upsertJobScheduler("nb", { pattern: FAR_FUTURE }, { name: "local", data: localTemplate("t"), opts: RETENTION });
+
+		const delayed = await queue.getDelayed();
+		assert.equal(delayed.length, 1, "exactly one upcoming job, never N backfilled catch-ups");
+		const scheduler = await queue.getJobScheduler("nb");
+		assert.equal(typeof scheduler.next, "number", "scheduler resolves a single next slot");
+		assert.ok(scheduler.next > Date.now(), "that slot is in the future");
+	} finally {
+		await teardown({ queue, redis });
+	}
+});
+
+// 3. DESCRIPTOR ID-FIELD (LOAD-BEARING). cron.mjs prunes orphans via `d.key ?? d.id ?? d.name`; this
+//    pins the CONCRETE field the live API populates, then drives a real prune to prove the fallback
+//    resolves against reality.
+test("getJobSchedulers descriptor carries the schedulerId on `.key`; reconcile prunes the orphan", { skip }, async () => {
+	const { Queue, parseConnection, makeRedisClient, reconcile } = await load();
+	const name = uniqueQueueName();
+	const conn = parseConnection(url);
+	const redis = makeRedisClient(url);
+	const queue = new Queue(name, { connection: conn });
+	try {
+		await queue.obliterate({ force: true }).catch(() => {});
+		await queue.upsertJobScheduler("a", { pattern: FAR_FUTURE }, { name: "local", data: localTemplate("a"), opts: RETENTION });
+		await queue.upsertJobScheduler("b", { pattern: FAR_FUTURE }, { name: "local", data: localTemplate("b"), opts: RETENTION });
+
+		const descriptors = await queue.getJobSchedulers(0, -1, true);
+		// Log one raw descriptor so the discovered shape is visible in CI output.
+		console.log("bullmq 5.80.4 getJobSchedulers descriptor:", JSON.stringify(descriptors[0]));
+		assert.equal(descriptors.length, 2);
+		for (const d of descriptors) {
+			assert.equal(typeof d.key, "string", ".key carries the schedulerId (transformSchedulerData)");
+			assert.equal(d.id, undefined, ".id is absent on the new job-scheduler path (only legacy keyToData sets it)");
+		}
+		assert.deepEqual(descriptors.map((d) => d.key).sort(), ["a", "b"]);
+
+		// Config names only "a": reconcile must prune orphan "b", which requires `d.key` to resolve.
+		const schedule = { schedulerId: "a", name: "local", pattern: FAR_FUTURE, data: localTemplate("a"), opts: RETENTION };
+		const res = await reconcile(queue, [schedule], { log: () => {} });
+		assert.equal(res.removed, 1);
+		const after = await queue.getJobSchedulers(0, -1, true);
+		assert.deepEqual(after.map((d) => d.key), ["a"], "orphan b pruned, a kept -- d.key matched the live shape");
+	} finally {
+		await teardown({ queue, redis });
+	}
+});
+
+// 4. STALL -> REMOVE. The money backstop BullMQ does not provide for scheduler jobs: past the
+//    threshold, makeStallGuard tears the scheduler down through the REAL removeJobScheduler and logs
+//    the alert (constitution.md:203-216).
+test("stall guard tears a scheduler down past the threshold (real removeJobScheduler + alert)", { skip }, async () => {
+	const { Queue, parseConnection, makeRedisClient, makeStallGuard } = await load();
+	const name = uniqueQueueName();
+	const conn = parseConnection(url);
+	const redis = makeRedisClient(url);
+	const queue = new Queue(name, { connection: conn });
+	try {
+		await redis.del(STALL_KEY).catch(() => {});
+		await queue.obliterate({ force: true }).catch(() => {});
+		await queue.upsertJobScheduler("s", { pattern: FAR_FUTURE }, { name: "local", data: localTemplate("t"), opts: RETENTION });
+		assert.deepEqual((await queue.getJobSchedulers(0, -1, true)).map((d) => d.key), ["s"]);
+
+		const events = [];
+		const threshold = 2;
+		const onStalled = makeStallGuard({
+			redis,
+			threshold,
+			removeJobScheduler: (id) => queue.removeJobScheduler(id),
+			log: (event, fields) => events.push({ event, fields }),
+		});
+		// count reaches threshold+1 on the last call -> teardown fires exactly once.
+		for (let i = 0; i < threshold + 1; i++) await onStalled("repeat:s:123");
+
+		assert.deepEqual(await queue.getJobSchedulers(0, -1, true), [], "scheduler s removed from Valkey");
+		const torn = events.filter((e) => e.event === "scheduler_torn_down");
+		assert.equal(torn.length, 1, "scheduler_torn_down alert fired once");
+		assert.equal(torn[0].fields.schedulerId, "s");
+	} finally {
+		await teardown({ queue, redis });
+	}
+});
+
+// 5. NO OVERLAP / NO STACK. With a blocking runContainer on a short `every`, the scheduler yields at
+//    most one active run and at most one pending next tick -- BullMQ creates the following tick only
+//    when the current one starts processing, so ticks do not stack into a pile of concurrent runs.
+test("a blocking scheduled run never overlaps or stacks", { skip }, async () => {
+	const { Queue, Worker, parseConnection, makeRedisClient, makeProcessor } = await load();
+	const name = uniqueQueueName();
+	const conn = parseConnection(url);
+	const redis = makeRedisClient(url);
+	const queue = new Queue(name, { connection: conn });
+	let worker;
+	let releaseBlock;
+	const blockGate = new Promise((resolve) => {
+		releaseBlock = resolve;
+	});
+	// Cap the block so a bug cannot hang CI: even if the sampling path throws before releasing, the held
+	// run resolves and the worker can close.
+	const safety = setTimeout(() => releaseBlock?.(), 4000);
+	const fixedNow = new Date(Date.UTC(2099, 0, 2, 12, 0, 0));
+	const budgetKey = `budget:2099-01-02`;
+	try {
+		await redis.del(budgetKey).catch(() => {});
+		await queue.obliterate({ force: true }).catch(() => {});
+
+		const runContainer = async () => {
+			await blockGate; // hold the single active slot open across many `every:300` ticks
+			return { code: 0, aborted: false };
+		};
+		const processor = makeProcessor({
+			cancelJob: () => {},
+			stopContainer: () => {},
+			redis,
+			cap: 1000,
+			deps: localDeps({ runContainer, now: fixedNow }),
+		});
+		worker = new Worker(name, processor, { connection: { ...conn, maxRetriesPerRequest: null }, concurrency: 1 });
+
+		await queue.upsertJobScheduler("ov", { every: 300 }, { name: "local", data: localTemplate("t"), opts: RETENTION });
+
+		await waitFor(async () => (await queue.getActiveCount()) >= 1, { timeoutMs: 4000 });
+
+		// Sample across a window in which ~5 `every:300` ticks would elapse. A backfill/overlap bug shows
+		// >1 active or a growing pile of ready jobs; the scheduler must yield neither.
+		const deadline = Date.now() + 1500;
+		let maxActive = 0;
+		while (Date.now() < deadline) {
+			const active = await queue.getActiveCount();
+			maxActive = Math.max(maxActive, active);
+			assert.ok(active <= 1, `at most one active scheduled run; saw ${active}`);
+			const pending = (await queue.getWaitingCount()) + (await queue.getDelayedCount());
+			assert.ok(pending <= 1, `the next tick does not stack; pending=${pending}`);
+			await sleep(100);
+		}
+		assert.equal(maxActive, 1, "exactly one run was ever active during the block");
+	} finally {
+		clearTimeout(safety);
+		releaseBlock?.();
+		await teardown({ queue, worker, redis, budgetKeys: [budgetKey] });
+	}
+});
+
+// 6. -10 / -11 SENTINEL. Assert the happy path (a clean, idempotent install) against the LIVE upsert,
+//    and document the sentinel behavior rather than assert a non-reproducible throw-vs-return gate.
+//
+// FINDING (bullmq 5.80.4): SchedulerJobIdCollision(-10) / SchedulerJobSlotsBusy(-11) is NOT returned as
+// a negative number. scripts.addJobScheduler (node_modules/bullmq/.../scripts.js:321-322) does
+// `if (typeof result === 'number' && result < 0) throw this.finishedErrors(...)`, so the SDK THROWS.
+// cron.mjs therefore trips its try/catch (thrown) path; its `typeof res === "number" && res < 0` branch
+// (cron.mjs:42) is defensive insurance against a future upstream that RETURNS the sentinel instead of
+// throwing. Forcing the sentinel deterministically requires a job pinned at the exact nextMillis in a
+// non-updatable (active/completed/failed) state (addJobScheduler-11.lua:150-191) -- timing-dependent and
+// inherently flaky -- so this asserts the reproducible happy path instead.
+test("reconcile installs cleanly and idempotently against live upsert (sentinel behavior documented)", { skip }, async () => {
+	const { Queue, parseConnection, makeRedisClient, reconcile } = await load();
+	const name = uniqueQueueName();
+	const conn = parseConnection(url);
+	const redis = makeRedisClient(url);
+	const queue = new Queue(name, { connection: conn });
+	try {
+		await queue.obliterate({ force: true }).catch(() => {});
+		const schedule = { schedulerId: "sentinel", name: "local", pattern: FAR_FUTURE, data: localTemplate("t"), opts: RETENTION };
+
+		const first = await reconcile(queue, [schedule], { log: () => {} });
+		assert.deepEqual(first, { installed: 1, removed: 0 }, "clean install");
+		const second = await reconcile(queue, [schedule], { log: () => {} });
+		assert.deepEqual(second, { installed: 1, removed: 0 }, "idempotent re-run installs the same set, removes nothing");
+		assert.deepEqual((await queue.getJobSchedulers(0, -1, true)).map((d) => d.key), ["sentinel"]);
+	} finally {
+		await teardown({ queue, redis });
+	}
+});

--- a/worker/test/cron.test.mjs
+++ b/worker/test/cron.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { reconcile } from "../src/cron.mjs";
+
+// reconcile is pure over the injected queue -- no bullmq, no real Valkey. The fake queue captures every
+// call so tests assert on exact arguments, and its return values / throws are configurable per case.
+function makeFakeQueue({ upsertResult = "scheduler-key", upsertThrows = false, residents = [], removeThrows = false } = {}) {
+	const calls = { upsert: [], getJobSchedulers: [], removed: [] };
+	return {
+		calls,
+		async upsertJobScheduler(id, repeatOpts, tmpl) {
+			calls.upsert.push({ id, repeatOpts, tmpl });
+			if (upsertThrows) throw new Error("upstream upsert boom");
+			return upsertResult;
+		},
+		async getJobSchedulers(start, end, asc) {
+			calls.getJobSchedulers.push({ start, end, asc });
+			return residents;
+		},
+		async removeJobScheduler(id) {
+			calls.removed.push(id);
+			if (removeThrows) throw new Error("scheduler not found");
+		},
+	};
+}
+
+// A normalized schedule as schedules.mjs emits it.
+const sched = (id, pattern = "0 3 * * *") => ({
+	schedulerId: id,
+	name: "local",
+	pattern,
+	data: { kind: "local", folder: "/proj", flow: "tidy", task: "t", provider: "anthropic", model: "m", maxTurns: 30 },
+	opts: { removeOnComplete: { age: 24 * 3600 }, removeOnFail: { age: 7 * 24 * 3600 } },
+});
+
+const noLog = () => {};
+
+test("upserts once per schedule with {pattern} as 2nd arg and {name,data,opts} as 3rd", async () => {
+	const q = makeFakeQueue();
+	const schedules = [sched("a"), sched("b", "0 4 * * *")];
+	await reconcile(q, schedules, { log: noLog });
+
+	assert.equal(q.calls.upsert.length, 2);
+	const first = q.calls.upsert[0];
+	assert.equal(first.id, "a");
+	assert.deepEqual(first.repeatOpts, { pattern: "0 3 * * *" });
+	assert.deepEqual(Object.keys(first.tmpl).sort(), ["data", "name", "opts"]);
+	assert.equal(first.tmpl.name, "local");
+	assert.equal(first.tmpl.data.folder, "/proj");
+
+	const second = q.calls.upsert[1];
+	assert.equal(second.id, "b");
+	assert.deepEqual(second.repeatOpts, { pattern: "0 4 * * *" });
+});
+
+test("no jobId is passed anywhere in the upsert opts", async () => {
+	const q = makeFakeQueue();
+	await reconcile(q, [sched("a")], { log: noLog });
+	for (const c of q.calls.upsert) {
+		assert.equal("jobId" in c.repeatOpts, false);
+		assert.equal("jobId" in c.tmpl, false);
+		assert.equal("jobId" in (c.tmpl.opts ?? {}), false);
+	}
+});
+
+test("upsertJobScheduler returning -10 (SchedulerJobIdCollision) rejects, naming the schedulerId and code", async () => {
+	const q = makeFakeQueue({ upsertResult: -10 });
+	await assert.rejects(
+		() => reconcile(q, [sched("collide")], { log: noLog }),
+		(e) => e.message.includes("collide") && e.message.includes("-10") && e.message.includes("SchedulerJobIdCollision"),
+	);
+});
+
+test("upsertJobScheduler returning -11 (SchedulerJobSlotsBusy) rejects, naming the schedulerId and code", async () => {
+	const q = makeFakeQueue({ upsertResult: -11 });
+	await assert.rejects(
+		() => reconcile(q, [sched("busy")], { log: noLog }),
+		(e) => e.message.includes("busy") && e.message.includes("-11") && e.message.includes("SchedulerJobSlotsBusy"),
+	);
+});
+
+test("upsertJobScheduler throwing rejects loudly, naming the schedulerId", async () => {
+	const q = makeFakeQueue({ upsertThrows: true });
+	await assert.rejects(
+		() => reconcile(q, [sched("kaboom")], { log: noLog }),
+		(e) => e.piDispatchConfig === true && e.message.includes("kaboom"),
+	);
+});
+
+test("prunes resident schedulers absent from config (.key shape): removes b, keeps a", async () => {
+	const q = makeFakeQueue({ residents: [{ key: "a" }, { key: "b" }] });
+	const res = await reconcile(q, [sched("a")], { log: noLog });
+	assert.deepEqual(q.calls.removed, ["b"]);
+	assert.equal(res.removed, 1);
+});
+
+test("robust id extraction from .id-shaped descriptors", async () => {
+	const q = makeFakeQueue({ residents: [{ id: "a" }, { id: "b" }] });
+	await reconcile(q, [sched("a")], { log: noLog });
+	assert.deepEqual(q.calls.removed, ["b"]);
+});
+
+test("robust id extraction from bare-string descriptors", async () => {
+	const q = makeFakeQueue({ residents: ["a", "b"] });
+	await reconcile(q, [sched("a")], { log: noLog });
+	assert.deepEqual(q.calls.removed, ["b"]);
+});
+
+test("empty config prunes all residents (orphan prune covers empty config)", async () => {
+	const q = makeFakeQueue({ residents: [{ key: "x" }] });
+	const res = await reconcile(q, [], { log: noLog });
+	assert.deepEqual(q.calls.removed, ["x"]);
+	assert.deepEqual(res, { installed: 0, removed: 1 });
+});
+
+test("config matching residents removes nothing (idempotent re-run)", async () => {
+	const q = makeFakeQueue({ residents: [{ key: "a" }, { key: "b" }] });
+	const res = await reconcile(q, [sched("a"), sched("b")], { log: noLog });
+	assert.deepEqual(q.calls.removed, []);
+	assert.equal(res.removed, 0);
+});
+
+test("removeJobScheduler throwing not-found is tolerated; reconcile resolves with correct counts", async () => {
+	const q = makeFakeQueue({ residents: [{ key: "orphan" }], removeThrows: true });
+	const res = await reconcile(q, [], { log: noLog });
+	assert.deepEqual(q.calls.removed, ["orphan"]); // removal was attempted
+	assert.deepEqual(res, { installed: 0, removed: 1 }); // counted despite the throw
+});
+
+test("queries residents with getJobSchedulers(0, -1, true)", async () => {
+	const q = makeFakeQueue();
+	await reconcile(q, [sched("a")], { log: noLog });
+	assert.deepEqual(q.calls.getJobSchedulers, [{ start: 0, end: -1, asc: true }]);
+});
+
+test('logs "scheduler_removed_orphan" with the pruned id', async () => {
+	const events = [];
+	const q = makeFakeQueue({ residents: [{ key: "b" }] });
+	await reconcile(q, [], { log: (event, fields) => events.push({ event, fields }) });
+	assert.deepEqual(events, [{ event: "scheduler_removed_orphan", fields: { schedulerId: "b" } }]);
+});
+
+test("returns {installed, removed} reflecting config size and orphan count", async () => {
+	const q = makeFakeQueue({ residents: [{ key: "a" }, { key: "gone1" }, { key: "gone2" }] });
+	const res = await reconcile(q, [sched("a"), sched("new")], { log: noLog });
+	assert.equal(res.installed, 2); // both schedules upserted
+	assert.equal(res.removed, 2); // gone1 + gone2 pruned
+	assert.deepEqual(q.calls.removed, ["gone1", "gone2"]);
+});

--- a/worker/test/scheduler-stall-guard.test.mjs
+++ b/worker/test/scheduler-stall-guard.test.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { makeStallGuard } from "../src/scheduler-stall-guard.mjs";
+
+const STALL_KEY = "pi-dispatch:sched-stalls";
+const WINDOW_SECONDS = 24 * 60 * 60;
+
+/** Minimal ioredis-compatible fake: a hash store plus per-method call counters. */
+function fakeRedis() {
+	const hashes = new Map(); // key -> Map(field -> number)
+	const calls = { hincrby: 0, expire: 0, hdel: 0 };
+	const expires = []; // { key, seconds } per expire call
+	return {
+		hashes,
+		calls,
+		expires,
+		field(key, f) {
+			return hashes.get(key)?.get(f);
+		},
+		async hincrby(key, field, n) {
+			calls.hincrby++;
+			let h = hashes.get(key);
+			if (!h) {
+				h = new Map();
+				hashes.set(key, h);
+			}
+			const v = (h.get(field) ?? 0) + n;
+			h.set(field, v);
+			return v;
+		},
+		async expire(key, seconds) {
+			calls.expire++;
+			expires.push({ key, seconds });
+		},
+		async hdel(key, field) {
+			calls.hdel++;
+			hashes.get(key)?.delete(field);
+		},
+	};
+}
+
+/** removeJobScheduler spy; records ids, optionally rejects as if the scheduler were already gone. */
+function makeRemoveSpy({ throwNotFound = false } = {}) {
+	const removed = [];
+	const fn = async (id) => {
+		removed.push(id);
+		if (throwNotFound) throw new Error(`Job scheduler ${id} not found`);
+	};
+	fn.removed = removed;
+	return fn;
+}
+
+/** log spy: keeps every (event, fields) call and offers a per-event filter. */
+function makeLog() {
+	const entries = [];
+	const fn = (event, fields) => entries.push({ event, fields });
+	fn.entries = entries;
+	fn.of = (event) => entries.filter((e) => e.event === event);
+	return fn;
+}
+
+test("ordinary (non-repeat) jobId is a no-op -- no hincrby, no teardown", async () => {
+	const redis = fakeRedis();
+	const removeJobScheduler = makeRemoveSpy();
+	const log = makeLog();
+	const onStalled = makeStallGuard({ redis, threshold: 3, removeJobScheduler, log });
+
+	await onStalled("local-abc");
+
+	assert.equal(redis.calls.hincrby, 0);
+	assert.equal(redis.calls.expire, 0);
+	assert.deepEqual(removeJobScheduler.removed, []);
+	assert.equal(log.entries.length, 0);
+});
+
+test("repeat:<id>:<millis> increments the counter under the scheduler-id hash field", async () => {
+	const redis = fakeRedis();
+	const onStalled = makeStallGuard({ redis, threshold: 3, removeJobScheduler: makeRemoveSpy(), log: makeLog() });
+
+	await onStalled("repeat:nightly-tidy:1699999999999");
+
+	assert.equal(redis.calls.hincrby, 1);
+	assert.equal(redis.field(STALL_KEY, "nightly-tidy"), 1);
+});
+
+test("N stalls at or below threshold do not tear down", async () => {
+	const redis = fakeRedis();
+	const removeJobScheduler = makeRemoveSpy();
+	const log = makeLog();
+	const onStalled = makeStallGuard({ redis, threshold: 3, removeJobScheduler, log });
+
+	for (let i = 0; i < 3; i++) await onStalled("repeat:nightly-tidy:1699999999999");
+
+	assert.equal(redis.field(STALL_KEY, "nightly-tidy"), 3);
+	assert.deepEqual(removeJobScheduler.removed, []);
+	assert.equal(redis.calls.hdel, 0);
+	assert.equal(log.of("scheduler_torn_down").length, 0);
+});
+
+test("the stall that crosses threshold (count === threshold+1) tears down exactly once", async () => {
+	const redis = fakeRedis();
+	const removeJobScheduler = makeRemoveSpy();
+	const log = makeLog();
+	const onStalled = makeStallGuard({ redis, threshold: 3, removeJobScheduler, log });
+
+	for (let i = 0; i < 4; i++) await onStalled("repeat:nightly-tidy:1699999999999");
+
+	assert.deepEqual(removeJobScheduler.removed, ["nightly-tidy"]);
+	assert.equal(redis.calls.hdel, 1);
+	const torn = log.of("scheduler_torn_down");
+	assert.equal(torn.length, 1);
+	assert.deepEqual(torn[0].fields, { schedulerId: "nightly-tidy", stalls: 4 });
+});
+
+test("expire is set on every hincrby, with the rolling-window TTL", async () => {
+	const redis = fakeRedis();
+	const onStalled = makeStallGuard({ redis, threshold: 10, removeJobScheduler: makeRemoveSpy(), log: makeLog() });
+
+	for (let i = 0; i < 3; i++) await onStalled("repeat:nightly-tidy:1699999999999");
+
+	assert.equal(redis.calls.expire, redis.calls.hincrby);
+	assert.equal(redis.calls.expire, 3);
+	for (const e of redis.expires) {
+		assert.equal(e.key, STALL_KEY);
+		assert.equal(e.seconds, WINDOW_SECONDS);
+	}
+});
+
+test("a removeJobScheduler not-found rejection is swallowed; teardown still completes", async () => {
+	const redis = fakeRedis();
+	const removeJobScheduler = makeRemoveSpy({ throwNotFound: true });
+	const log = makeLog();
+	const onStalled = makeStallGuard({ redis, threshold: 3, removeJobScheduler, log });
+
+	// resolves despite removeJobScheduler throwing
+	for (let i = 0; i < 4; i++) await onStalled("repeat:nightly-tidy:1699999999999");
+
+	assert.deepEqual(removeJobScheduler.removed, ["nightly-tidy"]);
+	assert.equal(redis.calls.hdel, 1, "hdel runs even though remove threw");
+	assert.equal(log.of("scheduler_torn_down").length, 1, "torn_down logged even though remove threw");
+	assert.equal(log.of("scheduler_teardown_remove_failed").length, 1);
+});
+
+test("empty schedulerId (repeat::123) is logged and never hincrby'd", async () => {
+	const redis = fakeRedis();
+	const removeJobScheduler = makeRemoveSpy();
+	const log = makeLog();
+	const onStalled = makeStallGuard({ redis, threshold: 3, removeJobScheduler, log });
+
+	await onStalled("repeat::123");
+
+	assert.equal(redis.calls.hincrby, 0);
+	assert.deepEqual(removeJobScheduler.removed, []);
+	assert.equal(log.of("scheduler_stall_unparsed").length, 1);
+});
+
+test("degenerate repeat:<n> (single colon) is also treated as empty schedulerId", async () => {
+	const redis = fakeRedis();
+	const log = makeLog();
+	const onStalled = makeStallGuard({ redis, threshold: 3, removeJobScheduler: makeRemoveSpy(), log });
+
+	await onStalled("repeat:123");
+
+	assert.equal(redis.calls.hincrby, 0);
+	assert.equal(log.of("scheduler_stall_unparsed").length, 1);
+});
+
+test("a redis.hincrby that throws does not reject onStalled -- error is swallowed and logged", async () => {
+	const redis = {
+		async hincrby() {
+			throw new Error("redis down");
+		},
+		async expire() {},
+		async hdel() {},
+	};
+	const log = makeLog();
+	const onStalled = makeStallGuard({ redis, threshold: 3, removeJobScheduler: makeRemoveSpy(), log });
+
+	await assert.doesNotReject(onStalled("repeat:nightly-tidy:1699999999999"));
+	assert.equal(log.of("scheduler_stall_guard_error").length, 1);
+});
+
+test("a schedulerId with valid internal chars parses correctly", async () => {
+	const redis = fakeRedis();
+	const onStalled = makeStallGuard({ redis, threshold: 3, removeJobScheduler: makeRemoveSpy(), log: makeLog() });
+
+	await onStalled("repeat:my.flow-1:123");
+
+	assert.equal(redis.field(STALL_KEY, "my.flow-1"), 1);
+});

--- a/worker/test/schedules.test.mjs
+++ b/worker/test/schedules.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadSchedules } from "../src/schedules.mjs";
+
+// loadSchedules is pure over injected fs -- no real filesystem, no bullmq. A stub config supplies the
+// defaults that entry-level provider/model/maxTurns fall back to.
+const CONFIG = {
+	schedulesFile: "/schedules.json",
+	provider: "anthropic",
+	model: "claude-sonnet-4-5-20250929",
+	maxTurns: 30,
+};
+
+const VALID = { id: "nightly-tidy", kind: "local", cron: "0 3 * * *", folder: "/proj", flow: "tidy", task: "run the tidy pass" };
+
+// Serialize `schedules` and feed it through injected fakes. existsSync defaults to true for both the
+// schedules file and every folder; override it to fail a specific path.
+function load(schedules, { existsSync = () => true, config = CONFIG } = {}) {
+	return loadSchedules(config, {
+		readFileSync: () => JSON.stringify({ schedules }),
+		existsSync,
+	});
+}
+
+const isConfigError = (e) => e.piDispatchConfig === true;
+
+test("null schedulesFile -> [] (cron disabled)", () => {
+	assert.deepEqual(loadSchedules({ ...CONFIG, schedulesFile: null }, { readFileSync: () => "", existsSync: () => true }), []);
+});
+
+test("absent schedulesFile -> [] (cron disabled)", () => {
+	const { schedulesFile, ...rest } = CONFIG;
+	assert.deepEqual(loadSchedules(rest, { readFileSync: () => "", existsSync: () => true }), []);
+});
+
+test("set-but-missing schedules file is a config error naming the path", () => {
+	assert.throws(
+		() => loadSchedules(CONFIG, { readFileSync: () => "", existsSync: () => false }),
+		(e) => isConfigError(e) && e.message.includes("/schedules.json"),
+	);
+});
+
+test("malformed JSON is a config error naming the file", () => {
+	assert.throws(
+		() => loadSchedules(CONFIG, { readFileSync: () => "{ not json", existsSync: () => true }),
+		(e) => isConfigError(e) && e.message.includes("/schedules.json"),
+	);
+});
+
+test('missing "schedules" array is a config error', () => {
+	assert.throws(
+		() => loadSchedules(CONFIG, { readFileSync: () => JSON.stringify({ nope: [] }), existsSync: () => true }),
+		isConfigError,
+	);
+});
+
+test('kind:"github" is rejected -- a schedule has no webhook/issue payload', () => {
+	assert.throws(() => load([{ ...VALID, kind: "github" }]), (e) => isConfigError(e) && /github/.test(e.message));
+});
+
+test("any non-local kind is rejected", () => {
+	assert.throws(() => load([{ ...VALID, kind: "remote" }]), isConfigError);
+});
+
+test("duplicate id is a config error", () => {
+	assert.throws(() => load([VALID, { ...VALID, folder: "/other" }]), (e) => isConfigError(e) && /duplicate/.test(e.message));
+});
+
+test('id containing ":" is a config error (would corrupt repeat:<id>:<millis>)', () => {
+	assert.throws(() => load([{ ...VALID, id: "night:tidy" }]), (e) => isConfigError(e) && e.message.includes(":"));
+});
+
+test("id with an out-of-charset character is a config error", () => {
+	assert.throws(() => load([{ ...VALID, id: "night tidy" }]), isConfigError); // space is not allowed
+	assert.throws(() => load([{ ...VALID, id: "night/tidy" }]), isConfigError);
+});
+
+test("empty or non-string id is a config error", () => {
+	assert.throws(() => load([{ ...VALID, id: "" }]), isConfigError);
+	assert.throws(() => load([{ ...VALID, id: 7 }]), isConfigError);
+});
+
+test("cron with the wrong field count is a config error", () => {
+	assert.throws(() => load([{ ...VALID, cron: "0 3 * *" }]), isConfigError); // 4 fields
+	assert.throws(() => load([{ ...VALID, cron: "0 3 * * * * *" }]), isConfigError); // 7 fields
+});
+
+test("empty or non-string cron is a config error", () => {
+	assert.throws(() => load([{ ...VALID, cron: "" }]), isConfigError);
+	assert.throws(() => load([{ ...VALID, cron: 5 }]), isConfigError);
+});
+
+test("missing folder is a config error", () => {
+	const { folder, ...noFolder } = VALID;
+	assert.throws(() => load([noFolder]), isConfigError);
+});
+
+test("nonexistent folder (existsSync -> false) is a config error", () => {
+	// The schedules file exists; only the folder is missing.
+	assert.throws(() => load([VALID], { existsSync: (p) => p === "/schedules.json" }), (e) => isConfigError(e) && e.message.includes("/proj"));
+});
+
+test("missing or empty flow is a config error", () => {
+	const { flow, ...noFlow } = VALID;
+	assert.throws(() => load([noFlow]), isConfigError);
+	assert.throws(() => load([{ ...VALID, flow: "" }]), isConfigError);
+});
+
+test("missing or empty task is a config error", () => {
+	const { task, ...noTask } = VALID;
+	assert.throws(() => load([noTask]), isConfigError);
+	assert.throws(() => load([{ ...VALID, task: "   " }]), isConfigError);
+});
+
+test("a valid local entry normalizes to the scheduler shape with config defaults resolved", () => {
+	const result = load([VALID]);
+	assert.equal(result.length, 1);
+	const s = result[0];
+
+	assert.equal(s.schedulerId, "nightly-tidy");
+	assert.equal(s.name, "local");
+	assert.equal(s.pattern, "0 3 * * *");
+
+	// data deep-equals the queue.mjs:21 shape, defaults pulled from CONFIG.
+	assert.deepEqual(s.data, {
+		kind: "local",
+		folder: "/proj",
+		flow: "tidy",
+		task: "run the tidy pass",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5-20250929",
+		maxTurns: 30,
+	});
+
+	// opts: retention only -- no jobId, attempts, or backoff.
+	assert.equal("jobId" in s.opts, false);
+	assert.equal("attempts" in s.opts, false);
+	assert.equal("backoff" in s.opts, false);
+	assert.equal(s.opts.removeOnComplete.age, 24 * 3600);
+	assert.equal(s.opts.removeOnFail.age, 7 * 24 * 3600);
+});
+
+test("entry-level provider/model/maxTurns override the config defaults", () => {
+	const [s] = load([{ ...VALID, provider: "openai", model: "gpt-x", maxTurns: 5 }]);
+	assert.equal(s.data.provider, "openai");
+	assert.equal(s.data.model, "gpt-x");
+	assert.equal(s.data.maxTurns, 5);
+});
+
+test("a 6-field cron (with seconds) is accepted", () => {
+	const [s] = load([{ ...VALID, cron: "0 0 3 * * *" }]);
+	assert.equal(s.pattern, "0 0 3 * * *");
+});
+
+test("multiple valid entries with distinct ids all normalize", () => {
+	const result = load([VALID, { ...VALID, id: "weekly-audit", cron: "0 4 * * 0" }]);
+	assert.equal(result.length, 2);
+	assert.deepEqual(result.map((s) => s.schedulerId), ["nightly-tidy", "weekly-audit"]);
+});

--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -30,9 +30,16 @@ function fakeHost(overrides = {}) {
 // startWorker constructs via makeRedisClient is torn down so it leaves no dangling handle.
 async function runStart({ env = {}, makeAuth, makeHost }) {
 	const calls = [];
+	const registered = {};
 	const createWorkerFn = (arg) => {
 		calls.push(arg);
-		return { on() {} }; // startWorker calls worker.on("completed"/"failed", ...)
+		// Record listener registrations so tests can assert startWorker wired worker.on("stalled", ...)
+		// (the scheduler stall guard) alongside the completed/failed handlers.
+		return {
+			on(evt, fn) {
+				registered[evt] = fn;
+			},
+		};
 	};
 
 	const lines = [];
@@ -49,6 +56,8 @@ async function runStart({ env = {}, makeAuth, makeHost }) {
 
 	const captured = calls[0];
 	captured?.redis?.disconnect?.(); // release the background reconnect handle
+	// The persistent schedulerQueue opens its own ioredis connection; close it so the suite leaks no handle.
+	await captured?.extraClosers?.[0]?.close?.().catch(() => {});
 
 	const logs = lines.map((l) => {
 		try {
@@ -57,7 +66,7 @@ async function runStart({ env = {}, makeAuth, makeHost }) {
 			return { raw: l };
 		}
 	});
-	return { captured, deps: captured?.deps, logs };
+	return { captured, deps: captured?.deps, logs, registered };
 }
 
 test("github configured: real mintToken and the host's isDefaultBranchProtected are wired", { skip }, async () => {
@@ -115,4 +124,36 @@ test("resolveDefaultBranchSha is threaded into prepareWorkspace (C2)", { skip },
 	// startWorker completed and a prepareWorkspace function was built from the host's resolver.
 	assert.ok(captured, "startWorker completed");
 	assert.equal(typeof deps.prepareWorkspace, "function", "a prepareWorkspace dep must be wired");
+});
+
+// Cron wiring. DEFAULT env => no PI_SCHEDULES_FILE => schedules=[] => reconcile is skipped, so these
+// assert the wiring that runs even with cron disabled: no live Valkey required.
+test("cron wiring: a stalled listener is registered and schedules_installed precedes worker_started", { skip }, async () => {
+	const makeAuth = async () => ({ mintToken: async () => "tok", selfId: 9, source: "gh" });
+	const { captured, logs, registered } = await runStart({ makeAuth, makeHost: () => fakeHost() });
+
+	// (a) the money backstop is keyed on "stalled" -- the guard's onStalled is registered there.
+	assert.equal(typeof registered.stalled, "function", "a stalled listener (the scheduler stall guard) must be registered");
+
+	// (c) the persistent schedulerQueue is handed to createWorker as an extraCloser so shutdown drains it.
+	assert.equal(
+		typeof captured.extraClosers?.[0]?.close,
+		"function",
+		"the schedulerQueue must be registered as extraClosers[0] with a close()",
+	);
+
+	// (d) empty schedule set still emits schedules_installed {0,0} so the operator sees cron is off.
+	const installed = logs.find((l) => l.event === "schedules_installed");
+	assert.ok(installed, "a schedules_installed log must be emitted even when cron is disabled");
+	assert.deepEqual(
+		{ installed: installed.installed, removed: installed.removed },
+		{ installed: 0, removed: 0 },
+		"an empty schedule set must log schedules_installed {installed:0, removed:0}",
+	);
+
+	// (b) schedules must be reconciled and logged before the worker announces itself.
+	const installedIdx = logs.findIndex((l) => l.event === "schedules_installed");
+	const startedIdx = logs.findIndex((l) => l.event === "worker_started");
+	assert.ok(startedIdx !== -1, "a worker_started log must be emitted");
+	assert.ok(installedIdx < startedIdx, "schedules_installed must be logged before worker_started");
 });

--- a/worker/test/wiring.test.mjs
+++ b/worker/test/wiring.test.mjs
@@ -88,3 +88,34 @@ test("an abort stops the container", { skip }, async () => {
 	assert.equal(stopped, "pi-job-j2");
 	await running;
 });
+
+test("shutdown closes each extraCloser after the worker drains", { skip }, async () => {
+	// A cron scheduler (or any auxiliary resource) is handed to createWorker as an extraCloser so it
+	// is torn down on SIGTERM/SIGINT alongside the worker. This proves close() runs during shutdown.
+	const origExit = process.exit;
+	const beforeTerm = new Set(process.listeners("SIGTERM"));
+	const beforeInt = new Set(process.listeners("SIGINT"));
+	let closed = false;
+	let worker;
+	try {
+		process.exit = () => {}; // shutdown ends in process.exit(0); neutralise it for the test
+		worker = mod.createWorker({
+			connection: { host: "127.0.0.1", port: 1 },
+			concurrency: 1,
+			cap: 10,
+			redis: {},
+			deps: {},
+			extraClosers: [{ close: async () => { closed = true; } }],
+		});
+		worker.on("error", () => {}); // swallow the connection-refused error against the dead port
+		const shutdown = process.listeners("SIGTERM").find((l) => !beforeTerm.has(l));
+		assert.ok(shutdown, "createWorker must register a SIGTERM shutdown handler");
+		await shutdown();
+		assert.equal(closed, true, "extraCloser.close() must run during shutdown");
+	} finally {
+		process.exit = origExit;
+		for (const l of process.listeners("SIGTERM")) if (!beforeTerm.has(l)) process.removeListener("SIGTERM", l);
+		for (const l of process.listeners("SIGINT")) if (!beforeInt.has(l)) process.removeListener("SIGINT", l);
+		await Promise.resolve(worker?.close()).catch(() => {});
+	}
+});


### PR DESCRIPTION
Adds a **cron trigger**: scheduled `kind:"local"` jobs via BullMQ Job Schedulers, configured by a JSON file (`schedules.json`, path in `PI_SCHEDULES_FILE`). A schedule is a trigger, not a job kind — each tick mints an ordinary local job that drains through the existing `runJob → reserveBudget → runContainer` path (no second processor, budget gate intact). Purely additive; no new dependencies (BullMQ 5.80.4 owns scheduling); the deprecated `repeat:` API is not introduced.

The money-critical piece is a **per-scheduler stall guard**: BullMQ structurally exempts scheduler (`repeat:`) jobs from `maxStalledCount`, so a wedged scheduled job would re-run *paid* indefinitely. A Redis-backed `HINCRBY`+`EXPIRE` counter tears the schedule down (`removeJobScheduler`) past `PI_SCHEDULER_STALL_MAX` (default 2). Startup reconcile installs schedules idempotently and prunes orphans (a schedule removed from config); `-10`/`-11` from `upsertJobScheduler` are surfaced loudly, never swallowed. `kind:"github"` schedules are rejected at load (a schedule has no webhook delivery/issue/title/body).

Scope: `worker/` only, plus docs/config, a CI comment, and spec additions. `image/` unchanged; `receiver/`/`cli.mjs` untouched.

## Verification
| Check | Baseline | Final |
|-------|----------|-------|
| typecheck/lint/test | npm test green, 251 pass / 0 fail / 6 skip | 301 pass / 0 fail / 12 env-gated skips (+50 from new cron suites), clean exit — 0 regressions |
| E2E — Queue Verification | N/A | PASS (cron.integration.test.mjs vs real Valkey, 6/6, run twice, zero residue): byte-identical local drain, budget-INCR-before-container, no-backfill, orphan reconcile + live descriptor id-field=`.key`, stall→teardown, no-overlap; `-10`/`-11` = SDK throws (never swallowed) |
| E2E — Container Smoke | N/A | N/A (image unchanged) |
| E2E — Webhook | N/A | N/A (receiver untouched) |
| Legacy sweep | — | PASS (additive; no add-alongside, no deprecated `repeat:`, no dead code) |

New spec surface: `REQ-CRON-SCHEDULED-JOBS`, `INT-SCHEDULES-FILE-CONTRACT`, and reject-github/dual-enqueue bullets under `DES-CRON-VIA-BULLMQ-SCHEDULER`. `detect_drift.py` stays exit 0.

Two known pre-existing issues are documented but out of scope: the `releaseBudget` cap-starvation leak (cross-cutting, all job kinds) and a `queue.test.mjs` dedup test-hygiene flake.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
