### PR TITLE
Background service: daemonize the worker + durable pause/resume switch

### DIFF
--- a/.github/workflows/deploy-lint.yml
+++ b/.github/workflows/deploy-lint.yml
@@ -1,0 +1,64 @@
+# Syntax lint for the deploy/ daemon artifacts.
+#
+# These files are hand-written examples an operator adapts; nothing exercises them in the normal test
+# suite (deploy/** is not in any other workflow's path filter), so a typo'd directive or a malformed
+# plist ships silently and only fails on the operator's box. This workflow is the cheap gate: it checks
+# STRUCTURE, not runtime behaviour.
+#
+#   - worker.service / receiver.service : `systemd-analyze verify` parses the units. The PLACEHOLDER
+#     paths (/opt/pi-dispatch, /usr/bin/node) do not exist on the runner, so path-existence warnings are
+#     EXPECTED and ignored; only genuine syntax errors (unknown directives, parse failures) fail.
+#   - com.pi-dispatch.worker.plist : `xmllint --noout` proves the plist is well-formed XML. plutil is
+#     macOS-only, so xmllint (libxml2-utils) is the Linux stand-in for well-formedness.
+#   - worker-env-wrapper.sh : `sh -n` is a POSIX shell parse check (no execution).
+#
+# The `.cmd` wrappers (worker-env-wrapper.cmd, nssm-install.cmd) have no practical Linux linter and are
+# not checked here -- deliberately, rather than with a flaky approximation.
+
+name: deploy lint
+
+on:
+  push:
+    paths:
+      - "deploy/**"
+      - ".github/workflows/deploy-lint.yml"
+  pull_request:
+    paths:
+      - "deploy/**"
+      - ".github/workflows/deploy-lint.yml"
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: deploy/ artifacts are syntactically valid
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install linters
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+
+      - name: systemd units parse (syntax only; PLACEHOLDER path warnings ignored)
+        run: |
+          # verify exits non-zero for the missing PLACEHOLDER exec paths, which is expected -- so gate on
+          # the CONTENT of the diagnostics, not the exit code. A real defect is an unknown directive or a
+          # parse failure; a missing /opt/pi-dispatch or /usr/bin/node is not.
+          systemd-analyze verify --no-pager deploy/worker.service deploy/receiver.service > verify.log 2>&1 || true
+          cat verify.log
+          if grep -Eiq 'Unknown (key name|lvalue|section)|Failed to parse|Invalid setting|not a valid|expected ' verify.log; then
+            echo "::error::systemd-analyze found a syntax error in a unit file. See the log above."
+            exit 1
+          fi
+          echo "OK: unit files are syntactically valid (path-existence warnings ignored)"
+
+      - name: plist is well-formed XML
+        run: |
+          xmllint --noout deploy/com.pi-dispatch.worker.plist \
+            || { echo "::error::deploy/com.pi-dispatch.worker.plist is not well-formed XML."; exit 1; }
+          echo "OK: plist well-formed"
+
+      - name: POSIX wrapper parses
+        run: |
+          sh -n deploy/worker-env-wrapper.sh \
+            || { echo "::error::deploy/worker-env-wrapper.sh has a shell syntax error."; exit 1; }
+          echo "OK: worker-env-wrapper.sh parses"

--- a/.plan-artifacts/2026-07-16-github-trigger-pluggable-auth-plan/drift-snapshot.json
+++ b/.plan-artifacts/2026-07-16-github-trigger-pluggable-auth-plan/drift-snapshot.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-07-16T00:00:00Z",
+  "planSlug": "2026-07-16-github-trigger-pluggable-auth-plan",
+  "exitCode": 0,
+  "reqStates": {}
+}

--- a/.plan-artifacts/2026-07-17-cron-trigger-plan/drift-snapshot.json
+++ b/.plan-artifacts/2026-07-17-cron-trigger-plan/drift-snapshot.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-07-17T12:57:17Z",
+  "planSlug": "2026-07-17-cron-trigger-plan",
+  "exitCode": 0,
+  "reqStates": {}
+}

--- a/.plan-artifacts/2026-07-17-worker-daemon-pause-resume-plan/drift-snapshot.json
+++ b/.plan-artifacts/2026-07-17-worker-daemon-pause-resume-plan/drift-snapshot.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-07-17T19:14:18Z",
+  "planSlug": "2026-07-17-worker-daemon-pause-resume-plan",
+  "exitCode": 0,
+  "reqStates": {}
+}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,86 @@ flowchart LR
 
 Read [`SECURITY.md`](SECURITY.md) before you rely on it — it states plainly what is and is not defended.
 
+## Run as a service
+
+`pi-dispatch worker` is a long-running process — run it in a terminal, or hand it to your OS's service
+manager so it starts on boot and restarts on a crash. The units in [`deploy/`](deploy/) are **per-host
+templates, not turnkey**: each carries `<PLACEHOLDER>` paths you fill in for your machine. The systemd
+unit's *structure* is checked by `systemd-analyze`; the launchd and nssm units are worked examples. All
+three run the worker on the **host** — it drives the `docker` CLI and is not itself containerised — so
+they need the AOF-enabled Valkey from [`deploy/docker-compose.yml`](deploy/docker-compose.yml) running
+alongside, which is what makes the queue **and the pause state** survive a reboot.
+
+**Steer the running worker** without stopping it — these commands talk to Valkey, so they work whether the
+worker runs in a terminal or under a service manager:
+
+- `pi-dispatch pause` — stop taking new jobs. **Durable**: the pause lives in the queue and survives a
+  worker restart, so a paused worker comes back paused after a reboot. Jobs still enqueue; they just wait.
+- `pi-dispatch resume` — start taking jobs again.
+- `pi-dispatch status` — prints `{ pausedState, waiting, active, paused, delayed, failed }`. `pausedState`
+  is the switch; `paused` is the backlog **count** of jobs that piled up while paused (they land in the
+  `paused` list, not `waiting`).
+
+### Linux (systemd)
+
+Edit [`deploy/worker.service`](deploy/worker.service): set `WorkingDirectory`, `EnvironmentFile`, `User`,
+and the `node` path to your clone. Then install and start it:
+
+```bash
+sudo cp deploy/worker.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now worker
+```
+
+`systemctl stop worker` sends **SIGTERM** — the worker stops accepting jobs and lets the in-flight
+container drain before it exits.
+
+### macOS (launchd)
+
+Edit [`deploy/com.pi-dispatch.worker.plist`](deploy/com.pi-dispatch.worker.plist) and its wrapper
+[`deploy/worker-env-wrapper.sh`](deploy/worker-env-wrapper.sh): set the repo-root and log paths (launchd
+has no `EnvironmentFile`, so the wrapper loads `.env` at runtime). Then bootstrap it:
+
+```bash
+launchctl bootstrap gui/$(id -u) deploy/com.pi-dispatch.worker.plist
+```
+
+`launchctl bootout gui/$(id -u)/com.pi-dispatch.worker` sends **SIGTERM** for the same graceful drain.
+
+### Windows (nssm)
+
+Put `nssm.exe` on PATH ([nssm.cc](https://nssm.cc)), set `SERVICE` / `REPO` / `LOGDIR` in
+[`deploy/nssm-install.cmd`](deploy/nssm-install.cmd), then run it and start the service:
+
+```
+deploy\nssm-install.cmd
+nssm start pi-dispatch-worker
+```
+
+The wrapper [`deploy/worker-env-wrapper.cmd`](deploy/worker-env-wrapper.cmd) loads `.env` at runtime. A
+console-stop (`nssm stop pi-dispatch-worker`) sends the worker a signal it handles, so it drains
+gracefully.
+
+### Drain before a planned restart
+
+A planned restart should abort no in-flight job. Pause, wait for the queue to go idle, restart, then
+resume:
+
+```bash
+pi-dispatch pause                     # stop taking new jobs (durable)
+pi-dispatch status                    # repeat until "active": 0 — nothing in flight
+sudo systemctl restart worker         # (or the launchctl / nssm equivalent)
+pi-dispatch resume                    # take jobs again
+```
+
+Because the pause is durable, the worker comes back paused even if the restart outruns your `resume`, so
+nothing slips through in the gap.
+
+**Windows caveat**: stop the service with nssm's **console-stop** (`nssm stop`), which delivers a signal
+the worker handles and drains gracefully. Task Scheduler is a weaker fallback — it stops a task with a
+hard kill, giving the worker no chance to drain; a job killed mid-flight leaves a stray container that the
+worker's **boot reaper** clears on the next start, rather than draining cleanly.
+
 ## Advanced: GitHub automation
 
 pi-dispatch can also be triggered by GitHub — label an issue, and a container works it on a fresh clone,
@@ -133,7 +213,8 @@ minutes.
 ## Status
 
 The local-folder path (image, worker, `pi-dispatch run` / `worker`) and the GitHub webhook path
-(receiver → queue → clone → PR) are built and work. The admin panel and scheduled (cron) triggers are in
+(receiver → queue → clone → PR) are built and work; the worker runs in a terminal or as an OS service on
+Linux, macOS or Windows (see **Run as a service**). The admin panel and scheduled (cron) triggers are in
 progress. The design is specified in
 [`specs/`](specs/) — start with [`specs/constitution.md`](specs/constitution.md) for the non-negotiables
 and [`specs/design.md`](specs/design.md) for the decisions and what was rejected.

--- a/deploy/com.pi-dispatch.worker.plist
+++ b/deploy/com.pi-dispatch.worker.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  UNTESTED EXAMPLE: a starting point for the macOS (launchd) worker daemon, not a shipped, verified
+  unit. Adapt it. The Linux/systemd equivalent is deploy/worker.service.
+
+  ProgramArguments points at deploy/worker-env-wrapper.sh; that wrapper is what loads `.env`, because
+  launchd has no EnvironmentFile mechanism. NO secrets are inlined here: there is deliberately no
+  EnvironmentVariables dict, since that would commit credentials into this file. The wrapper reads
+  `.env` at runtime instead (note the ANTHROPIC_OAUTH_TOKEN over ANTHROPIC_API_KEY precedence trap
+  documented in the wrapper).
+
+  Graceful shutdown needs NO macOS-specific code: `launchctl bootout` sends SIGTERM, which reaches node
+  through the wrapper's `exec`, and the worker drains in-flight work on SIGTERM. ExitTimeOut 30 gives it
+  room (at least the 5s docker-stop grace) before launchd escalates to SIGKILL.
+
+  KeepAlive restarts on a crash (SuccessfulExit false) but NOT on a clean exit, so a deliberate stop
+  stays stopped.
+
+  Per-host PLACEHOLDERS: replace /opt/pi-dispatch (the repo root, used in ProgramArguments and
+  WorkingDirectory) and /opt/pi-dispatch/logs (StandardOutPath, StandardErrorPath) with your paths.
+
+  One worker per host (DES-CONCURRENCY-3): parallelism is PI_CONCURRENCY inside the one process.
+  Requires the AOF-enabled Valkey from deploy/docker-compose.yml.
+-->
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.pi-dispatch.worker</string>
+
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/sh</string>
+		<string>/opt/pi-dispatch/deploy/worker-env-wrapper.sh</string>
+	</array>
+
+	<key>WorkingDirectory</key>
+	<string>/opt/pi-dispatch</string>
+
+	<key>RunAtLoad</key>
+	<true/>
+
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+
+	<key>ExitTimeOut</key>
+	<integer>30</integer>
+
+	<key>StandardOutPath</key>
+	<string>/opt/pi-dispatch/logs/worker.out.log</string>
+
+	<key>StandardErrorPath</key>
+	<string>/opt/pi-dispatch/logs/worker.err.log</string>
+</dict>
+</plist>

--- a/deploy/nssm-install.cmd
+++ b/deploy/nssm-install.cmd
@@ -1,0 +1,51 @@
+@echo off
+REM UNTESTED EXAMPLE -- a starting point for the Windows worker service, not a shipped, verified unit.
+REM Adapt it. The Linux/systemd equivalent is deploy/worker.service; the macOS one is
+REM deploy/com.pi-dispatch.worker.plist.
+REM
+REM Registers the pi-dispatch worker as a Windows service via nssm (the Non-Sucking Service Manager).
+REM nssm is an operator-downloaded binary (https://nssm.cc) -- it is documented here, NOT vendored into
+REM this repo; put nssm.exe on PATH before running this. The service's Application is the `.cmd` wrapper
+REM (deploy/worker-env-wrapper.cmd), which loads `.env` at runtime -- so NO secrets are inlined here or
+REM passed via AppEnvironmentExtra. `.env` is gitignored; nothing in this file is a credential.
+REM
+REM Why nssm over Task Scheduler: Task Scheduler stops a task with TerminateProcess (a hard kill), which
+REM gives the worker no chance to drain the in-flight job -- it then relies on the queue's boot reaper to
+REM recover the orphaned container. nssm's AppStopMethodConsole sends a real Ctrl-C first, which node
+REM receives as SIGINT for a graceful drain. Task Scheduler is a weaker fallback, not the recommended
+REM path.
+REM
+REM One worker per host (DES-CONCURRENCY-3): parallelism is PI_CONCURRENCY inside the one process, not
+REM multiple services. Requires the AOF-enabled Valkey from deploy/docker-compose.yml.
+REM
+REM Per-host PLACEHOLDERS: set SERVICE / REPO / LOGDIR below for your host before running.
+
+setlocal
+
+set "SERVICE=pi-dispatch-worker"
+set "REPO=C:\pi-dispatch"
+set "LOGDIR=C:\pi-dispatch\logs"
+
+REM Application is the wrapper (loads `.env`), not node directly and not an env dict with real values.
+nssm install %SERVICE% "%REPO%\deploy\worker-env-wrapper.cmd"
+nssm set %SERVICE% AppDirectory "%REPO%"
+nssm set %SERVICE% AppStdout "%LOGDIR%\worker.out.log"
+nssm set %SERVICE% AppStderr "%LOGDIR%\worker.err.log"
+
+REM Stop = send Ctrl-C (node SIGINT, graceful drain), wait 15000ms (>= the 5s docker-stop grace) before
+REM nssm escalates to a hard kill.
+nssm set %SERVICE% AppStopMethodConsole 15000
+
+REM StartLimit analogue: pause 5000ms between restarts so a crash loop does not spin the provider bill
+REM (mirrors StartLimitIntervalSec/StartLimitBurst + RestartSec in deploy/worker.service).
+nssm set %SERVICE% AppThrottle 5000
+
+REM Restart on a crash by default...
+nssm set %SERVICE% AppExit Default Restart
+REM ...but exit 2 is EXIT_POLICY: a determinate config/budget refusal, never retried. Do NOT restart it
+REM (mirrors RestartPreventExitStatus=2 in deploy/worker.service).
+nssm set %SERVICE% AppExit 2 Exit
+
+echo Installed service "%SERVICE%". Start it with:  nssm start %SERVICE%
+
+endlocal

--- a/deploy/receiver.service
+++ b/deploy/receiver.service
@@ -1,8 +1,10 @@
-# UNTESTED EXAMPLE (design.md:483-484) -- a starting point, not a shipped, verified unit. Adapt it.
+# UNTESTED EXAMPLE (DES-WORKER-ON-HOST) -- a starting point, not a shipped, verified unit. Adapt it.
 #
 # The receiver runs on the HOST as the public edge: it verifies GitHub deliveries and enqueues jobs.
 # Requires node >=22.19.0 on PATH for User=pi -- or pin an absolute `ExecStart=/usr/bin/node ...`.
-# This is a Linux/systemd unit; a launchd (macOS) / nssm (Windows) equivalent is left to the operator.
+# This is a Linux/systemd unit. The worker ships cross-platform daemon artifacts under deploy/
+# (com.pi-dispatch.worker.plist for launchd, nssm-install.cmd for Windows); receiver daemonization is
+# out of scope, but a launchd/nssm receiver would follow the same .env-wrapper pattern those use.
 #
 # NAT / tunnel: the receiver binds `RECEIVER_BIND` (default 0.0.0.0) and must be reachable by GitHub's
 # webhook delivery. On a home machine behind NAT, put it behind a tunnel (cloudflared / ngrok /

--- a/deploy/worker-env-wrapper.cmd
+++ b/deploy/worker-env-wrapper.cmd
@@ -1,0 +1,34 @@
+@echo off
+REM UNTESTED EXAMPLE -- a starting point for a Windows service, not a shipped, verified unit. Adapt it.
+REM
+REM pi-dispatch worker launcher for Windows service managers (nssm; see deploy/nssm-install.cmd). Windows
+REM services have no `.env` mechanism, so this wrapper loads `.env` from the repo root itself, then
+REM launches node. It reads ONLY the declared `.env` (see `.env.example`), never the host user profile:
+REM the container-boundary rules require an explicit, auditable variable set. Nothing here contains a
+REM credential -- the secrets live in `.env`, which is gitignored and read at runtime.
+REM
+REM TRAP: inside pi, ANTHROPIC_OAUTH_TOKEN silently takes precedence over ANTHROPIC_API_KEY. Set exactly
+REM one in `.env`.
+REM
+REM `.env` FORMAT for this loader: KEY=VALUE, one per line. Values MUST be UNQUOTED -- cmd's `set` keeps
+REM surrounding quotes as part of the value. `eol=#` skips `#` comment lines; blank lines are ignored.
+REM `tokens=1,* delims==` splits on the FIRST `=` only, so values containing `=` (base64, API keys)
+REM survive intact.
+REM
+REM One worker per host (DES-CONCURRENCY-3): parallelism is PI_CONCURRENCY inside the single process, not
+REM multiple services. Requires the AOF-enabled Valkey from deploy/docker-compose.yml.
+
+setlocal
+
+REM Resolve repo root relative to this script (deploy\ is one level down).
+cd /d "%~dp0.." || exit /b 1
+
+if not exist ".env" (
+  echo worker-env-wrapper: .env not found in "%CD%" 1>&2
+  exit /b 1
+)
+
+for /f "usebackq eol=# tokens=1,* delims==" %%A in (".env") do set "%%A=%%B"
+
+node worker\src\cli.mjs worker
+exit /b %ERRORLEVEL%

--- a/deploy/worker-env-wrapper.sh
+++ b/deploy/worker-env-wrapper.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# UNTESTED EXAMPLE -- a starting point for a non-systemd daemon, not a shipped, verified unit. Adapt it.
+#
+# pi-dispatch worker launcher for daemon managers that have NO EnvironmentFile mechanism. systemd reads
+# `.env` for you via `EnvironmentFile=` (see deploy/worker.service); launchd (macOS) has no equivalent --
+# a plist's ProgramArguments cannot name a `.env`. This wrapper closes that gap: launchd execs THIS
+# script, which loads the explicit `.env` from the repo root and then hands off to node.
+#
+# It sources ONLY the declared `.env` (see `.env.example`), never the host login shell: the
+# container-boundary rules require an explicit, auditable variable set, not whatever the operator's
+# profile happens to export. Nothing here contains a credential -- the secrets live in `.env`, which is
+# gitignored and read at runtime.
+#
+# TRAP: inside pi, `ANTHROPIC_OAUTH_TOKEN` silently takes precedence over `ANTHROPIC_API_KEY`. Set exactly
+# one in `.env`; this wrapper only ADDS the `.env` vars on top of the current environment, it does not
+# clear a stray pre-existing one, so a leaked host `ANTHROPIC_OAUTH_TOKEN` would still win.
+#
+# `exec` is load-bearing: it REPLACES this shell with node, so SIGTERM (e.g. from `launchctl bootout`)
+# reaches node directly for a graceful drain instead of dying at the shell and orphaning the worker.
+#
+# One worker per host (DES-CONCURRENCY-3): parallelism is PI_CONCURRENCY inside the single process, not
+# multiple daemons. Requires the AOF-enabled Valkey from deploy/docker-compose.yml.
+
+# Resolve repo root relative to this script (deploy/ is one level down).
+cd "$(dirname "$0")/.." || exit 1
+if [ ! -f .env ]; then echo "worker-env-wrapper: .env not found in $(pwd)" >&2; exit 1; fi
+set -a; . ./.env; set +a
+exec node worker/src/cli.mjs worker

--- a/deploy/worker.service
+++ b/deploy/worker.service
@@ -1,4 +1,4 @@
-# UNTESTED EXAMPLE (design.md:483-484) -- a starting point, not a shipped, verified unit. Adapt it.
+# TEMPLATE — verified structure (systemd-analyze); set the <PLACEHOLDER> values for your host.
 #
 # The worker runs on the HOST, not in a container (DES-WORKER-ON-HOST): it drives the `docker` CLI to
 # launch one job container per job, and the CLI is what translates bind-mount paths cross-platform.
@@ -6,7 +6,8 @@
 #
 # Requires node >=22.19.0 (worker/package.json engines) on PATH for User=pi -- or pin an absolute
 # `ExecStart=/usr/bin/node ...` if PATH is not reliable under systemd. This is a Linux/systemd unit;
-# a launchd (macOS) / nssm (Windows) equivalent is left to the operator.
+# the launchd (macOS) equivalent is deploy/com.pi-dispatch.worker.plist and the Windows (nssm) one is
+# deploy/nssm-install.cmd.
 #
 # Env vars come from your `.env` (see `.env.example`) via EnvironmentFile -- never commit real secrets.
 # WorkingDirectory / EnvironmentFile / User / node path below are PLACEHOLDERS: set them to wherever
@@ -18,6 +19,11 @@ After=network-online.target docker.service
 Wants=network-online.target
 # Valkey must be reachable (docker compose -f deploy/docker-compose.yml up -d), but it is a separate
 # unit/container -- not ordered here since it may be remote.
+# Crash-loop bound: at most StartLimitBurst restarts within StartLimitIntervalSec, then systemd stops
+# trying. A restart loop against a paid provider is a bill, not just log noise. Pairs with
+# Restart=on-failure below.
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -27,6 +33,10 @@ EnvironmentFile=/opt/pi-dispatch/.env
 ExecStart=/usr/bin/node worker/src/cli.mjs worker
 Restart=on-failure
 RestartSec=5
+# Exit 2 is EXIT_POLICY (worker/src/exit-code.mjs): a determinate config/budget refusal, not infra.
+# Never restart it -- retrying pays again for the same broken config. Only infra failures are worth a
+# restart, and Restart=on-failure already covers those.
+RestartPreventExitStatus=2
 # The worker handles SIGTERM: it stops accepting new jobs and lets the in-flight container finish or
 # abort cleanly. Give it room before SIGKILL.
 KillSignal=SIGTERM

--- a/specs/design.md
+++ b/specs/design.md
@@ -192,6 +192,12 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   throttles concurrent streams and tokens-per-minute long before Docker runs out of memory. A **config
   knob rather than a constant** because one of the two inputs is an unmeasured guess (`OQ-002`), so
   re-tuning after measurement should be a deploy, not a code change.
+- **Boot-reaper invariant — single worker per docker daemon**: The knob is parallelism *within* one worker
+  process; the design assumes exactly one worker per docker daemon. The boot reaper clears every stray
+  `pi-job-*` container on start (a leaked container keeps spending, so it must go before any new job
+  launches) — a co-located second worker sharing the daemon would read the first's in-flight container as
+  its own to remove and kill a live job. Per-host is the common case, but the docker daemon, not the host,
+  is the true boundary.
 - **Traces to**: `OQ-002`, `REQ-QUEUE-BURST-NO-DROP`
 
 ## DES-CRON-VIA-BULLMQ-SCHEDULER
@@ -481,7 +487,8 @@ pi-dispatch/
   flows/          # frontend-fix.md, bug-fix.md, triage.md — DEFAULTS, seeded into the data volume
   persona/        # hard rules; baked into the image. Not runtime-editable
   deploy/         # docker-compose runs Valkey only; worker/receiver/panel are host Node processes
-                  #   (DES-WORKER-ON-HOST). systemd units ship as untested examples.
+                  #   (DES-WORKER-ON-HOST). The systemd unit is a verified-structure per-host template;
+                  #   launchd (.plist) and Windows (nssm) units are added as untested examples.
   .env.example    # provider key, spend/concurrency knobs, VALKEY_URL, PI_JOB_IMAGE
   docs/
 ```
@@ -498,8 +505,11 @@ it is where the SDK traps in `INT-SDK-SESSION-OPTIONS` live, and they are cheape
 else in the frame.
 
 **Platform**: Windows, macOS and Linux, wherever Docker runs. `docker-compose` is the supported
-deployment; systemd units ship as untested examples. Two consequences are not incidental and are tracked
-where they bite: a containerised worker talking to the Docker socket resolves bind-mount paths in the
+deployment; the systemd unit is a verified-structure per-host template — its structure statically checked
+by `systemd-analyze`, its placeholders unresolved, so it is neither turnkey nor end-to-end tested — and
+the launchd (`.plist`) and Windows (nssm) units are added as untested examples. Two consequences are not
+incidental and are tracked where they bite: a containerised worker talking to the Docker socket resolves
+bind-mount paths in the
 *daemon's* namespace, not its own; and a home machine behind NAT cannot receive GitHub webhooks without
 a tunnel.
 

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -219,9 +219,11 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
   nothing. Streaming the container output is not a debug nicety — on the operator's own machine, watching
   the agent work on their own folder is the primary feedback surface, and a missing completion line is
   what tells them a run did nothing.
-- **Note on logs**: this is the operator's own terminal for their own folder, not a persistent multi-user
-  log; `no-pii-in-logs` still applies to any *stored* worker logs (log the stable job id and outcome,
-  not task bodies).
+- **Note on logs**: in a terminal this is the operator's own console for their own folder, not a
+  persistent multi-user log. **Under a service manager it becomes one**: the console is the manager's
+  captured, persistent log (systemd's journald, launchd's `StandardOutPath`, nssm's `AppStdout`), so
+  `no-pii-in-logs` applies to it directly — not only to hypothetical *stored* logs. Log the stable job id
+  and outcome, not task bodies.
 - **Traces to**: `CONST-PI-VERSION-PINNED`, `DES-CLI-TRIGGER-FOR-LOCAL`, `INT-RUNNER-EXIT-CODE-PROTOCOL`
 - **Acceptance**: Given a local job reaching a terminal state, the worker console shows exactly one
   completion or failure line carrying the job id and outcome; during the run, the container's output is

--- a/worker/src/cli.mjs
+++ b/worker/src/cli.mjs
@@ -4,12 +4,16 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { loadConfig } from "./config.mjs";
+import { EXIT_POLICY } from "./exit-code.mjs";
 
 const USAGE = `pi-dispatch — run pi coding-agent flows on your own folders
 
   pi-dispatch run <folder> --task "<what to do>" [--flow <name>]
                            [--provider <p>] [--model <m>] [--max-turns <n>] [--force]
   pi-dispatch worker       drain the queue (run this in another terminal, or as a service)
+  pi-dispatch pause        stop taking new jobs (durable; survives worker restart)
+  pi-dispatch resume       resume taking jobs
+  pi-dispatch status       show paused state + job counts
 
 Config comes from the environment (see .env.example); flags override it per run.`;
 
@@ -71,6 +75,39 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
 		return 0;
 	}
 
+	if (cmd === "pause" || cmd === "resume" || cmd === "status") {
+		// The kill switch reads ONLY VALKEY_URL, not the full loadConfig -- it must work even when
+		// GitHub auth is misconfigured, so an operator can always stop the queue.
+		const url = env.VALKEY_URL ?? "redis://127.0.0.1:6379";
+		const { parseConnection } = await import("./connection.mjs");
+		const { makeQueue } = await import("./queue.mjs");
+		// failFast: reach the kill switch in seconds when Valkey is down, not a hang. makeQueue pins
+		// the "pi-jobs" name -- a different name would pause an empty queue (silent no-op).
+		const queue = makeQueue(parseConnection(url, { failFast: true }));
+		try {
+			if (cmd === "pause") {
+				await queue.pause();
+				process.stdout.write("paused — worker will stop taking new jobs (jobs still enqueue)\n");
+			} else if (cmd === "resume") {
+				await queue.resume();
+				process.stdout.write("resumed\n");
+			} else {
+				// "paused" is included in the counts because jobs enqueued while paused land in the
+				// `paused` list, not `wait` -- omitting it would report backlog 0 in the exact state
+				// the pause switch creates. `pausedState` (the boolean) is named apart from the
+				// `paused` count `getJobCounts` returns, so the two do not collide in the output.
+				const pausedState = await queue.isPaused();
+				const counts = await queue.getJobCounts("waiting", "active", "paused", "delayed", "failed");
+				process.stdout.write(`${JSON.stringify({ pausedState, ...counts })}\n`);
+			}
+		} catch (error) {
+			return fail(`could not reach Valkey at ${url} — is it running? (docker compose up)\n  ${error.message}`);
+		} finally {
+			await queue.close().catch(() => {});
+		}
+		return 0;
+	}
+
 	process.stdout.write(`${USAGE}\n`);
 	return cmd ? 1 : 0;
 }
@@ -78,6 +115,15 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
 function fail(message) {
 	process.stderr.write(`error: ${message}\n`);
 	return 1;
+}
+
+/**
+ * Exit code for an error that escaped main() as a rejection. A tagged config error (loadConfig's
+ * `piDispatchConfig`) is a determinate refusal -> EXIT_POLICY (2, never retried); anything else is
+ * infra -> 1 (retryable). Mirrors INT-RUNNER-EXIT-CODE-PROTOCOL for the CLI's own exit space.
+ */
+export function entryExitCode(err) {
+	return err?.piDispatchConfig ? EXIT_POLICY : 1;
 }
 
 /** true = dirty, false = clean, null = not a working git repo. */
@@ -92,7 +138,12 @@ function gitDirty(folder) {
 
 // Entry point when run as a bin. Kept out of the exported main so tests can call main() directly.
 if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("cli.mjs")) {
-	main().then((code) => {
-		if (code) process.exitCode = code;
-	});
+	main()
+		.then((code) => {
+			if (code) process.exitCode = code;
+		})
+		.catch((err) => {
+			process.stderr.write(`error: ${err.message}\n`);
+			process.exitCode = entryExitCode(err);
+		});
 }

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -80,6 +80,10 @@ export function createWorker({ connection, concurrency, cap, redis, deps, limite
 	};
 	process.once("SIGTERM", shutdown);
 	process.once("SIGINT", shutdown);
+	// Windows never delivers an external SIGTERM. nssm's console-stop delivers Ctrl-C => SIGINT
+	// (handled above); SIGBREAK covers console-close. Route it to the same shutdown so a stopped
+	// worker still aborts in-flight jobs and docker-stops their containers rather than orphaning them.
+	if (process.platform === "win32") process.once("SIGBREAK", shutdown);
 
 	return worker;
 }

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -1,3 +1,5 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { configError, loadConfig } from "./config.mjs";
 import { makeRedisClient, parseConnection } from "./connection.mjs";
 import { makeGitHubAuth } from "./get-token.mjs";
@@ -5,6 +7,42 @@ import { makeGitHubHost } from "./github-host.mjs";
 import { createWorker } from "./index.mjs";
 import { cleanup, makePrepareWorkspace } from "./prepare.mjs";
 import { makeRunContainer } from "./run-container.mjs";
+
+const exec = promisify(execFile);
+
+/**
+ * Boot-time reaper: clear stray `pi-job-*` containers a previous worker crash left behind, before
+ * the new worker starts draining. A leaked container keeps spending, so it must go before any new
+ * job launches.
+ *
+ * It runs `docker ps` / `docker rm -f` ONLY. It never inspects a container's exit code, never touches
+ * the queue, and never re-enqueues -- queue and retry state belong to Redis, not to docker
+ * (INT-RUNNER-EXIT-CODE-PROTOCOL / CONST-RETRY-INFRA-ONLY). It logs container names only (no PII).
+ *
+ * It assumes ONE worker per docker daemon: a co-located second worker's boot would remove the first's
+ * in-flight `pi-job-*` container. That is the accepted v1 shape (DES-CONCURRENCY-3, single worker per
+ * host).
+ *
+ * `reap()` NEVER throws: a missing docker binary or a down daemon is caught, logged as
+ * `reaper_skipped`, and boot continues to the worker.
+ */
+export function makeReaper({ log }) {
+	return async function reap() {
+		try {
+			const { stdout } = await exec("docker", ["ps", "--filter", "name=pi-job-", "--format", "{{.Names}}"]);
+			const names = stdout
+				.split("\n")
+				.map((n) => n.trim())
+				.filter(Boolean);
+			for (const name of names) {
+				await exec("docker", ["rm", "-f", name]);
+				log("reaped_container", { name });
+			}
+		} catch (err) {
+			log("reaper_skipped", { reason: err?.message });
+		}
+	};
+}
 
 /**
  * The runnable worker. Reads config, connects to Valkey, wires every REAL dependency the processor
@@ -18,7 +56,7 @@ import { makeRunContainer } from "./run-container.mjs";
  */
 export async function startWorker(
 	env = process.env,
-	{ makeAuth = makeGitHubAuth, makeHost = makeGitHubHost, createWorkerFn = createWorker } = {},
+	{ makeAuth = makeGitHubAuth, makeHost = makeGitHubHost, createWorkerFn = createWorker, makeReaper: makeReaperFn = makeReaper } = {},
 ) {
 	const config = loadConfig(env);
 	const log = (event, fields = {}) => process.stdout.write(`${JSON.stringify({ event, ...fields })}\n`);
@@ -31,6 +69,14 @@ export async function startWorker(
 		log("github_auth_unavailable", { reason: err?.message });
 	}
 	const host = makeHost();
+
+	// Clear strays left by a previous crash before the worker starts draining. Best-effort: the reaper
+	// swallows its own docker errors; this guard keeps any reaper failure from blocking boot.
+	try {
+		await makeReaperFn({ log })();
+	} catch (err) {
+		log("reaper_skipped", { reason: err?.message });
+	}
 
 	const worker = createWorkerFn({
 		connection: parseConnection(config.valkeyUrl),
@@ -74,7 +120,12 @@ export async function startWorker(
 	// comment and the signal for CONST-PI-VERSION-PINNED's silent-no-op mode -- a missing line is
 	// what tells a human a run did nothing. The container's own output already streams via
 	// runContainer's onOutput during the run.
-	worker.on("completed", (job, result) => log("job_completed", { jobId: job?.id, outcome: result?.outcome }));
+	// `reason` is a fixed enum (worker-abort | over-budget | unprotected-branch | runner-policy), never
+	// user content. Included only when present so success lines stay clean; a shutdown-aborted job logs
+	// { outcome: "policy", reason: "worker-abort" }, making a restart-dropped job visible.
+	worker.on("completed", (job, result) =>
+		log("job_completed", { jobId: job?.id, outcome: result?.outcome, ...(result?.reason ? { reason: result.reason } : {}) }),
+	);
 	worker.on("failed", (job, err) =>
 		log("job_failed", { jobId: job?.id, attempt: job?.attemptsMade, reason: String(err?.message ?? err).slice(0, 120) }),
 	);

--- a/worker/test/cli-control.test.mjs
+++ b/worker/test/cli-control.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { entryExitCode, main } from "../src/cli.mjs";
+
+// pause/resume/status dynamic-import bullmq/ioredis only when they reach the queue. The USAGE,
+// entryExitCode, and unknown-command paths return before any import, so they run everywhere; the
+// fail-fast-against-a-down-Valkey path needs the deps and is gated below the node floor.
+let depsOk = false;
+try {
+	await import("../src/connection.mjs");
+	depsOk = true;
+} catch {}
+const needsDeps = depsOk ? false : `queue deps not installed (node ${process.version} < 22.19.0); CI runs these`;
+
+/** Run `fn` with process.stdout.write captured; returns the concatenated output. */
+async function captureStdout(fn) {
+	const original = process.stdout.write.bind(process.stdout);
+	let out = "";
+	process.stdout.write = (chunk) => {
+		out += chunk;
+		return true;
+	};
+	try {
+		await fn();
+	} finally {
+		process.stdout.write = original;
+	}
+	return out;
+}
+
+test("usage lists the pause/resume/status control commands", async () => {
+	let code;
+	const out = await captureStdout(async () => {
+		code = await main([], {});
+	});
+	assert.equal(code, 0);
+	assert.match(out, /\bpause\b/);
+	assert.match(out, /\bresume\b/);
+	assert.match(out, /\bstatus\b/);
+});
+
+test("entryExitCode maps a tagged config error to EXIT_POLICY (2), everything else to 1", () => {
+	// A config error is a determinate refusal (never retried); anything else is infra (retryable).
+	assert.equal(entryExitCode({ piDispatchConfig: true }), 2);
+	assert.equal(entryExitCode(new Error("x")), 1);
+	assert.equal(entryExitCode(undefined), 1);
+});
+
+test("an unknown command still exits 1", async () => {
+	assert.equal(await main(["frobnicate"], {}), 1);
+});
+
+test("pause fails fast (does not hang) when Valkey is unreachable", { skip: needsDeps }, async () => {
+	const start = Date.now();
+	const code = await main(["pause"], { VALKEY_URL: "redis://127.0.0.1:1" });
+	assert.equal(code, 1, "an unreachable Valkey is a clean error, not a hang");
+	assert.ok(Date.now() - start < 15000, "must fail fast, well under any CI timeout");
+});
+
+test("resume fails fast (does not hang) when Valkey is unreachable", { skip: needsDeps }, async () => {
+	const start = Date.now();
+	const code = await main(["resume"], { VALKEY_URL: "redis://127.0.0.1:1" });
+	assert.equal(code, 1);
+	assert.ok(Date.now() - start < 15000, "must fail fast");
+});
+
+test("status fails fast (does not hang) when Valkey is unreachable", { skip: needsDeps }, async () => {
+	const start = Date.now();
+	const code = await main(["status"], { VALKEY_URL: "redis://127.0.0.1:1" });
+	assert.equal(code, 1);
+	assert.ok(Date.now() - start < 15000, "must fail fast");
+});

--- a/worker/test/pause-durability.test.mjs
+++ b/worker/test/pause-durability.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseConnection } from "../src/connection.mjs";
+
+// Durability of the pause switch against a real Valkey (REQ-QUEUE-BURST-NO-DROP). Gated on
+// VALKEY_TEST_URL; CI provides a service, and it skips cleanly otherwise. Each test uses a
+// throwaway queue name so a run never disturbs a live "pi-jobs" queue -- the durability SEMANTICS
+// are what we exercise here; the real CLI's fixed "pi-jobs" name is covered by cli-control.test.mjs.
+const url = process.env.VALKEY_TEST_URL;
+const skip = url ? false : "needs VALKEY_TEST_URL";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll `pred` (may be async) until truthy or `timeout` ms elapse. Returns the last predicate value. */
+async function waitFor(pred, { timeout, interval = 100 }) {
+	const start = Date.now();
+	let last = await pred();
+	while (!last && Date.now() - start < timeout) {
+		await sleep(interval);
+		last = await pred();
+	}
+	return last;
+}
+
+function throwawayName() {
+	return `pi-jobs-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+test("enqueue while paused: jobs pile up pending, none active, each add resolves with an id", { skip }, async () => {
+	const { Queue } = await import("bullmq");
+	const connection = parseConnection(url); // maxRetriesPerRequest: null -- bullmq requirement
+	const queue = new Queue(throwawayName(), { connection });
+	try {
+		await queue.pause();
+		const added = await Promise.all([queue.add("t", { n: 1 }), queue.add("t", { n: 2 }), queue.add("t", { n: 3 })]);
+		for (const job of added) assert.ok(job.id, "every enqueue while paused still resolves with a job id");
+
+		// BullMQ v5 parks jobs enqueued while paused in the `paused` list, not `wait`
+		// (getTargetQueueList.lua). The durability invariant is: all 3 pending, NONE active. Assert the
+		// sum so it holds regardless of which internal list BullMQ uses, plus the exact placement.
+		const counts = await queue.getJobCounts("waiting", "active", "paused");
+		assert.equal(counts.active, 0, "nothing runs while paused");
+		assert.equal(counts.waiting + counts.paused, 3, "all 3 enqueued-while-paused jobs are pending");
+		assert.equal(counts.paused, 3, "bullmq 5.80.4 parks enqueued-while-paused jobs in the paused list");
+	} finally {
+		await queue.resume().catch(() => {});
+		await queue.obliterate({ force: true }).catch(() => {});
+		await queue.close().catch(() => {});
+	}
+});
+
+test("resume drains: a worker processes the parked jobs once resumed", { skip }, async () => {
+	const { Queue, Worker } = await import("bullmq");
+	const connection = parseConnection(url);
+	const name = throwawayName();
+	const queue = new Queue(name, { connection });
+	let processed = 0;
+	const worker = new Worker(name, async () => { processed += 1; }, { connection });
+	try {
+		await queue.pause();
+		await Promise.all([queue.add("t", { n: 1 }), queue.add("t", { n: 2 }), queue.add("t", { n: 3 })]);
+		assert.equal(processed, 0, "nothing drains while paused");
+
+		await queue.resume();
+		const drained = await waitFor(async () => processed === 3, { timeout: 10000 });
+		assert.ok(drained, `resume must drain all 3 jobs within 10s (processed ${processed})`);
+		const counts = await queue.getJobCounts("waiting", "active", "paused");
+		assert.equal(counts.waiting + counts.paused + counts.active, 0, "queue is empty once drained");
+	} finally {
+		await worker.close().catch(() => {});
+		await queue.resume().catch(() => {});
+		await queue.obliterate({ force: true }).catch(() => {});
+		await queue.close().catch(() => {});
+	}
+});
+
+test("pause survives worker restart: a fresh worker on a paused queue still does not drain", { skip }, async () => {
+	const { Queue, Worker } = await import("bullmq");
+	const connection = parseConnection(url);
+	const name = throwawayName();
+	const queue = new Queue(name, { connection });
+	let processed = 0;
+	const processor = async () => { processed += 1; };
+	let w1;
+	let w2;
+	try {
+		await queue.pause();
+		await queue.add("t", { n: 1 });
+
+		// The pause marker lives in Redis (meta.paused), not in any worker -- so a worker that starts
+		// AFTER the pause reads it and refuses to drain. This is the durable kill-switch guarantee.
+		w1 = new Worker(name, processor, { connection });
+		await sleep(2000);
+		assert.equal(processed, 0, "W1 must not drain a paused queue");
+		await w1.close();
+
+		w2 = new Worker(name, processor, { connection });
+		await sleep(2000);
+		assert.equal(processed, 0, "a brand-new W2 must still not drain -- pause is durable across restart");
+
+		const counts = await queue.getJobCounts("waiting", "active", "paused");
+		assert.equal(counts.active, 0, "the job never went active");
+		assert.equal(counts.waiting + counts.paused, 1, "the job still sits pending across both workers");
+	} finally {
+		await w1?.close().catch(() => {});
+		await w2?.close().catch(() => {});
+		await queue.resume().catch(() => {});
+		await queue.obliterate({ force: true }).catch(() => {});
+		await queue.close().catch(() => {});
+	}
+});

--- a/worker/test/pause-durability.test.mjs
+++ b/worker/test/pause-durability.test.mjs
@@ -7,6 +7,11 @@ import { parseConnection } from "../src/connection.mjs";
 // throwaway queue name so a run never disturbs a live "pi-jobs" queue -- the durability SEMANTICS
 // are what we exercise here; the real CLI's fixed "pi-jobs" name is covered by cli-control.test.mjs.
 const url = process.env.VALKEY_TEST_URL;
+// A skipped assertion is an UNVERIFIED assertion. In CI, PI_DISPATCH_REQUIRE_WORKER_TESTS=1 turns a
+// missing VALKEY_TEST_URL into a hard failure so the durability guarantee can never silently no-op.
+if (!url && process.env.PI_DISPATCH_REQUIRE_WORKER_TESTS === "1") {
+	throw new Error("pause-durability REQUIRES VALKEY_TEST_URL when PI_DISPATCH_REQUIRE_WORKER_TESTS=1");
+}
 const skip = url ? false : "needs VALKEY_TEST_URL";
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));

--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -28,12 +28,24 @@ function fakeHost(overrides = {}) {
 // Drive startWorker with injected fakes and capture the exact object handed to createWorker
 // (deps are nested under `deps`). No real Redis: createWorkerFn is faked. The real ioredis client
 // startWorker constructs via makeRedisClient is torn down so it leaves no dangling handle.
-async function runStart({ env = {}, makeAuth, makeHost }) {
+async function runStart({ env = {}, makeAuth, makeHost, makeReaper, order } = {}) {
 	const calls = [];
+	const handlers = {};
 	const createWorkerFn = (arg) => {
+		if (order) order.push("createWorker");
 		calls.push(arg);
-		return { on() {} }; // startWorker calls worker.on("completed"/"failed", ...)
+		// startWorker calls worker.on("completed"/"failed", ...); capture the handlers so a test can
+		// drive them and inspect the emitted log line.
+		return {
+			on(event, handler) {
+				handlers[event] = handler;
+			},
+		};
 	};
+
+	// Default to a no-op reaper so the wiring tests never shell out to docker; ordering/throwing tests
+	// inject their own.
+	const reaper = makeReaper ?? (() => async () => {});
 
 	const lines = [];
 	const origWrite = process.stdout.write;
@@ -42,7 +54,7 @@ async function runStart({ env = {}, makeAuth, makeHost }) {
 		return true;
 	};
 	try {
-		await mod.startWorker(env, { makeAuth, makeHost, createWorkerFn });
+		await mod.startWorker(env, { makeAuth, makeHost, createWorkerFn, makeReaper: reaper });
 	} finally {
 		process.stdout.write = origWrite;
 	}
@@ -57,7 +69,29 @@ async function runStart({ env = {}, makeAuth, makeHost }) {
 			return { raw: l };
 		}
 	});
-	return { captured, deps: captured?.deps, logs };
+	return { captured, deps: captured?.deps, logs, handlers };
+}
+
+// Capture the JSON log lines a synchronous fn emits via process.stdout.write, then restore it.
+function captureLogs(fn) {
+	const lines = [];
+	const origWrite = process.stdout.write;
+	process.stdout.write = (chunk) => {
+		lines.push(String(chunk));
+		return true;
+	};
+	try {
+		fn();
+	} finally {
+		process.stdout.write = origWrite;
+	}
+	return lines.map((l) => {
+		try {
+			return JSON.parse(l);
+		} catch {
+			return { raw: l };
+		}
+	});
 }
 
 test("github configured: real mintToken and the host's isDefaultBranchProtected are wired", { skip }, async () => {
@@ -115,4 +149,40 @@ test("resolveDefaultBranchSha is threaded into prepareWorkspace (C2)", { skip },
 	// startWorker completed and a prepareWorkspace function was built from the host's resolver.
 	assert.ok(captured, "startWorker completed");
 	assert.equal(typeof deps.prepareWorkspace, "function", "a prepareWorkspace dep must be wired");
+});
+
+test("the boot reaper runs BEFORE the worker starts draining (strays cleared first)", { skip }, async () => {
+	const order = [];
+	const makeAuth = async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" });
+	const makeReaper = () => async () => {
+		order.push("reap");
+	};
+	await runStart({ makeAuth, makeHost: () => fakeHost(), makeReaper, order });
+	assert.deepEqual(order, ["reap", "createWorker"], "reap must clear strays before the worker is created");
+});
+
+test("a reaper that throws does NOT reject startWorker (boot is best-effort)", { skip }, async () => {
+	const makeAuth = async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" });
+	const makeReaper = () => async () => {
+		throw new Error("docker daemon down");
+	};
+	const { captured, logs } = await runStart({ makeAuth, makeHost: () => fakeHost(), makeReaper });
+	assert.ok(captured, "startWorker must still construct the worker when the reaper throws");
+	assert.ok(logs.some((l) => l.event === "reaper_skipped"), "a throwing reaper must be logged as reaper_skipped");
+});
+
+test("job_completed carries reason when the result has one and omits it otherwise", { skip }, async () => {
+	const makeAuth = async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" });
+	const { handlers } = await runStart({ makeAuth, makeHost: () => fakeHost() });
+	assert.equal(typeof handlers.completed, "function", "startWorker must register a completed handler");
+
+	const withReason = captureLogs(() => handlers.completed({ id: "j1" }, { outcome: "policy", reason: "worker-abort" }));
+	const wr = withReason.find((l) => l.event === "job_completed");
+	assert.equal(wr?.outcome, "policy");
+	assert.equal(wr?.reason, "worker-abort", "reason must be logged when the result carries one");
+
+	const noReason = captureLogs(() => handlers.completed({ id: "j2" }, { outcome: "success" }));
+	const nr = noReason.find((l) => l.event === "job_completed");
+	assert.equal(nr?.outcome, "success");
+	assert.ok(!("reason" in nr), "reason must be omitted from a clean success line");
 });

--- a/worker/test/wiring.test.mjs
+++ b/worker/test/wiring.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 // index.mjs imports bullmq, so this skips below the node floor / without deps and runs in CI,
@@ -14,6 +15,23 @@ if (!mod && process.env.PI_DISPATCH_REQUIRE_WORKER_TESTS === "1") {
 	throw new Error(`worker wiring tests are REQUIRED here but bullmq could not import.\n${importError}`);
 }
 const skip = mod ? false : `bullmq not installed (node ${process.version} < 22.19.0); CI runs these`;
+
+test("createWorker registers a win32-guarded SIGBREAK shutdown alongside SIGTERM/SIGINT", () => {
+	// The signal registration lives inside createWorker, AFTER `new Worker(...)`. Constructing a real
+	// Worker to observe process.once at runtime leaves a dangling ioredis reconnect handle that keeps
+	// `node --test` from exiting (verified), so this asserts the contract against the source instead:
+	// SIGTERM/SIGINT register unconditionally, SIGBREAK only on win32, and all three route to the same
+	// `shutdown` closure (Windows never delivers an external SIGTERM; SIGBREAK covers console-close).
+	// No bullmq import here, so this runs even below the node floor where the other tests skip.
+	const src = readFileSync(new URL("../src/index.mjs", import.meta.url), "utf8");
+	assert.match(src, /process\.once\("SIGTERM", shutdown\)/, "SIGTERM must route to shutdown");
+	assert.match(src, /process\.once\("SIGINT", shutdown\)/, "SIGINT must route to shutdown");
+	assert.match(
+		src,
+		/process\.platform === "win32"\)\s*\{?\s*process\.once\("SIGBREAK", shutdown\)/,
+		"SIGBREAK must be win32-guarded and route to the same shutdown closure",
+	);
+});
 
 test("the processor declares arity 3 -- the silent trap that would disable the timeout", { skip }, () => {
 	// BullMQ only allocates an AbortController when processor.length >= 3. If a refactor drops the


### PR DESCRIPTION
Daemonizes the worker across Linux/macOS/Windows and adds a durable pause/resume switch built on BullMQ's own `queue.pause()` (a durable Valkey key), exposed as `pi-dispatch pause|resume|status`. "Off" stops the worker draining without rejecting enqueues, and the paused state survives a worker restart — verified live. Also hardens the daemon path: a Windows `SIGBREAK` handler, a boot-time reaper for orphaned `pi-job-*` containers, a config-error exit-code fix so systemd can't hot-loop, and cross-platform service artifacts (systemd unit, launchd plist, nssm installer) with secrets sourced from `.env` at runtime (never committed).

## What's in it
- **CLI** (`worker/src/cli.mjs`): `pause`/`resume`/`status` on `queue.pause()`/`resume()`/`isPaused()` (reads only `VALKEY_URL`, failFast); `entryExitCode()` + `.catch()` maps a config error to exit 2 (non-retryable).
- **Worker robustness** (`index.mjs`, `start.mjs`): win32 `SIGBREAK` → existing graceful shutdown; injectable boot reaper (`docker ps`/`rm -f` of strays, never throws, awaited before draining); `reason` on the completion log so a restart-dropped job is visible.
- **Deploy** (`deploy/`): launchd plist + POSIX/Windows `.env` wrappers + nssm installer; `worker.service` gains `StartLimit*` + `RestartPreventExitStatus=2` and is relabeled TEMPLATE; new `deploy-lint.yml` CI (xmllint/sh -n/systemd-analyze).
- **Docs/specs**: README "Run as a service" runbook (drain-before-restart); design.md "untested examples" note graduated; `DES-CONCURRENCY-3` records the single-worker-per-daemon reaper invariant; `REQ-LOCAL-JOB-VISIBILITY` note amended for the daemon's persistent captured log.

## Verification
| Check | Baseline | Final |
|-------|----------|-------|
| typecheck/lint/test | tests: 0 fail (257 pass) | 261 pass / 0 fail / 9 skip |
| E2E — Queue Verification | N/A | PASS — 3 pause-durability tests ran live vs Valkey (enqueue-while-paused / resume-drains / pause-survives-restart / policy-not-retried) |
| E2E — Container Smoke | N/A | N/A (job image unchanged) |
| E2E — Webhook | N/A | N/A (receiver/src untouched) |

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
