### PR TITLE
Durable per-job run history + logs (read model for the panel)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ PI_CONCURRENCY=3       # how many jobs run in parallel
 VALKEY_URL=redis://127.0.0.1:6379
 PI_JOB_IMAGE=pi-job:latest          # the image you built:  docker build -f image/Dockerfile -t pi-job:latest .
 # PI_JOBS_DIR=                      # where per-job /job inputs live (default: your OS temp dir)
+# PI_LOGS_DIR=                      # where per-job status records (and optional raw logs) land (default: OS temp /pi-dispatch/logs)
+# PI_CAPTURE_JOB_LOGS=              # default 0; set 1 to ALSO write raw container output to logs/<jobId>.log -- PII-bearing (issue/comment text), host-only (never mounted into the container), off by default (opt-in)
+# PI_LOG_RETENTION_DAYS=            # default 30; boot-time prune of logs older than N days; 0 = keep forever
 # PI_SCHEDULES_FILE=                # ABSOLUTE path to schedules.json; unset disables cron (a relative path resolves against the worker's WorkingDirectory)
 PI_SCHEDULER_STALL_MAX=2            # tear down a scheduler after N consecutive stalls (money backstop)
 

--- a/.plan-artifacts/2026-07-18-run-history-logs-plan/drift-snapshot.json
+++ b/.plan-artifacts/2026-07-18-run-history-logs-plan/drift-snapshot.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-07-18T00:00:00Z",
+  "planSlug": "2026-07-18-run-history-logs-plan",
+  "exitCode": 0,
+  "reqStates": {}
+}

--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ the worker handles and drains gracefully. Task Scheduler is a weaker fallback â€
 hard kill, giving the worker no chance to drain; a job killed mid-flight leaves a stray container that the
 worker's **boot reaper** clears on the next start, rather than draining cleanly.
 
+## Run history
+
+The worker keeps a durable, per-job record under `PI_LOGS_DIR` (default: your OS temp dir,
+`.../pi-dispatch/logs`). Every job writes an id-only status record `logs/<jobId>.json` â€” stable ids only
+(the delivery GUID, `repo#issue`), never issue or comment text. Set `PI_CAPTURE_JOB_LOGS=1` to **also**
+capture the container's raw stdout/stderr to `logs/<jobId>.log`; this is **opt-in and off by default**,
+because that raw stream can contain issue and comment text (PII). Both files stay host-side, are never
+mounted into the job container, and are gitignored. A boot-time sweep prunes anything older than
+`PI_LOG_RETENTION_DAYS` (default 30; `0` keeps them forever).
+
 ## Scheduling recurring jobs
 
 A cron schedule is a trigger, not a new job kind: each entry runs a local folder through a flow on a cron

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -118,6 +118,13 @@ Stated openly rather than discovered later:
 - **The provider API key is broad.** Unlike the GitHub token it cannot be meaningfully scoped per job —
   the agent needs it to function. It is the one broad secret inside the container. **Set a spend limit
   on it.**
+- **Captured job logs can contain issue and comment text (PII).** By default the worker writes only an
+  id-only status record per job — `logs/<jobId>.json`, keyed on stable ids (the delivery GUID,
+  `repo#issue`) and never on issue or comment bodies. With `PI_CAPTURE_JOB_LOGS=1` (opt-in, **off by
+  default**) it also tees the container's raw stdout/stderr to `logs/<jobId>.log`, and that stream **can**
+  carry issue/comment text. Both live host-side under `PI_LOGS_DIR`, are **never mounted into the job
+  container**, and are **gitignored**; a boot-time sweep prunes them (`PI_LOG_RETENTION_DAYS`, `0` = keep
+  forever). Leave capture off unless you need it, and treat the log directory as personal data while it is on.
 - **Prompt injection is not prevented, only bounded.** Untrusted text is kept out of the trusted region
   of the prompt by *placement*, not by filtering — content-filtering natural language is not a security
   boundary and this project does not pretend otherwise. The bound is the container, the scoped token,

--- a/deploy/com.pi-dispatch.worker.plist
+++ b/deploy/com.pi-dispatch.worker.plist
@@ -22,6 +22,10 @@
 
   One worker per host (DES-CONCURRENCY-3): parallelism is PI_CONCURRENCY inside the one process.
   Requires the AOF-enabled Valkey from deploy/docker-compose.yml.
+
+  PI_LOGS_DIR (run-history records; default OS-temp /pi-dispatch/logs) is created and written by the
+  worker at boot, so it must be writable by the account the daemon runs as. Set via `.env` (the wrapper),
+  not a plist change; its default is distinct from the StandardOutPath worker.out.log below.
 -->
 <plist version="1.0">
 <dict>

--- a/deploy/nssm-install.cmd
+++ b/deploy/nssm-install.cmd
@@ -19,6 +19,10 @@ REM One worker per host (DES-CONCURRENCY-3): parallelism is PI_CONCURRENCY insid
 REM multiple services. Requires the AOF-enabled Valkey from deploy/docker-compose.yml.
 REM
 REM Per-host PLACEHOLDERS: set SERVICE / REPO / LOGDIR below for your host before running.
+REM
+REM PI_LOGS_DIR (run-history records; default OS-temp \pi-dispatch\logs) is created and written by the
+REM worker at boot, so it must be writable by the service account. Set via `.env` (the wrapper), not a
+REM change here; its default avoids colliding with the nssm LOGDIR worker.out log set below.
 
 setlocal
 

--- a/deploy/worker.service
+++ b/deploy/worker.service
@@ -12,6 +12,11 @@
 # Env vars come from your `.env` (see `.env.example`) via EnvironmentFile -- never commit real secrets.
 # WorkingDirectory / EnvironmentFile / User / node path below are PLACEHOLDERS: set them to wherever
 # you cloned the repo and whoever owns it.
+#
+# PI_LOGS_DIR (run-history records; default OS-temp /pi-dispatch/logs) is created and written by the
+# worker at boot, so it must be writable by User= (pi) -- do NOT pre-create it as root, or the non-root
+# worker hits EACCES at boot. Set via `.env` (EnvironmentFile), no unit change needed; the default path
+# avoids colliding with the daemon's own logs/worker.out.log.
 
 [Unit]
 Description=pi-dispatch worker (drains the job queue on the host; launches job containers via docker)

--- a/image/runner/test/compose.test.mjs
+++ b/image/runner/test/compose.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import { captureTerminal, decideExit, EXIT_COMPLETED, EXIT_INFRA, EXIT_POLICY } from "../src/outcome.mjs";
 
@@ -42,4 +43,34 @@ test("decideExit: without an abort, the stopReason decides", () => {
 test("decideExit: no terminal message and no abort is infra, not success", () => {
 	// Absence of evidence that the agent ran is not success.
 	assert.equal(decideExit({ budgetAborted: false, terminal: undefined }).code, EXIT_INFRA);
+});
+
+test("decideExit's non-abort branch carries NO turns of its own -- the premise the source-guard rests on", () => {
+	// WHY the guard below exists: on the success path, `turns` reaches the exit log SOLELY from
+	// run-job.mjs's `log("exit", { ...outcome, turns: budget.state.turns })` spread. decideExit's
+	// non-abort branch returns classifyStopReason, which has no `turns` field (only the budget-abort
+	// branch carries one -- see "a blown budget wins" above). So if that spread ever dropped `turns`,
+	// nothing in outcome.mjs would put it back, and the worker's parseExitTurns (which requires a
+	// numeric `turns` on the exit line) would silently read null on every completed run.
+	const outcome = decideExit({ budgetAborted: false, terminal: { stopReason: "stop" } });
+	assert.equal(outcome.code, EXIT_COMPLETED);
+	assert.equal(outcome.turns, undefined, "the non-abort branch of decideExit carries no turns of its own");
+});
+
+test("run-job.mjs staples `turns` onto the success-path exit line -- worker parseExitTurns depends on it", () => {
+	// A stdout-capture test would EXECUTE the runner (main() self-runs on import and `log` is
+	// unexported), so this guards the worker<->runner contract against the source instead -- the same
+	// tactic worker/test/wiring.test.mjs uses for wiring it cannot exercise at runtime. The regex
+	// matches a `log("exit", { ... turns: ... })` call whose object literal carries a `turns:` key
+	// before its closing brace: specific enough that dropping `turns` from the success spread fails
+	// it, tolerant of whitespace and property reordering.
+	const src = readFileSync(new URL("../run-job.mjs", import.meta.url), "utf8");
+	assert.match(
+		src,
+		/log\("exit",\s*\{[^}]*turns:/,
+		"run-job.mjs exit line must carry turns -- worker parseExitTurns depends on it",
+	);
+	// The catch-path exit line (classifyThrow, a preflight throw) legitimately OMITS turns: no budget
+	// exists when the agent loop never started. The regex above matches the success call and does not
+	// require every exit line to carry turns, so that omission is allowed by design.
 });

--- a/specs/design.md
+++ b/specs/design.md
@@ -137,6 +137,33 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
 - **Reference** (no authority): `docs.bullmq.io/guide/rate-limiting`, `/guide/workers/pausing-queues`,
   `/guide/redis-tm-compatibility`.
 
+## DES-RUN-HISTORY-FLAT-FILES-NO-DB
+
+- **Decision**: The per-job run history is a flat `node:fs` sidecar keyed by job id — an id-only status
+  record at `logs/<jobId>.json` (written with `fs.writeFileSync`) plus an optional append-only
+  `logs/<jobId>.log` of raw container output (`fs.createWriteStream`). No database, no logging framework.
+  Retention is a boot-time age sweep (`makeLogReaper`, window `PI_LOG_RETENTION_DAYS`), not a rotation
+  library.
+- **Why**: The record must **outlive the queue entry**. BullMQ evicts completed and failed jobs by age
+  (`removeOnComplete` / `removeOnFail`), so the retained job cannot be the durable store — and it never
+  carries `exitCode`, `turns`, or `budgetReserved` in the first place. The sidecar is justified precisely
+  by what BullMQ lacks: a record that survives eviction and holds the run's outcome fields. Those records
+  are immutable, filename-keyed, and never queried across each other, so a store with query power earns
+  nothing. This is `DES-QUEUE-BULLMQ-OVER-CUSTOM`'s library-first ethos one file down, and the design
+  home for the `document-build-decision` rule that the sidecar's inline `Custom:` comment cites.
+- **Rejected**:
+  - *Querying BullMQ's retained job instead of a sidecar* — BullMQ evicts by age, so it is not the
+    *durable* store, and it never carries `exitCode` / `turns` / `budgetReserved`. It cannot be the
+    record.
+  - *An embedded database (lowdb / better-sqlite3) or a structured-logging library (pino / winston)* —
+    the records are immutable, filename-keyed, with no cross-record query in scope, so neither earns its
+    keep. A DB adds a native build (the ARM / musl / glibc pain the job image exists to avoid) and a
+    second retention authority beside the reaper for zero query benefit; a logging library brings its own
+    rotation as that same second authority. Both violate the deliberate "no database" thinness
+    (`interfaces.md` preamble) and the library-first ethos — the same reasoning as
+    `DES-QUEUE-BULLMQ-OVER-CUSTOM`.
+- **Traces to**: `DES-QUEUE-BULLMQ-OVER-CUSTOM`; implemented in `worker/src/run-history.mjs`.
+
 ## DES-PERSONA-VIA-APPEND-SYSTEM-MD
 
 - **Decision**: Bake the persona into the image at `~/.pi/agent/APPEND_SYSTEM.md`, **and** pass per-flow
@@ -531,3 +558,4 @@ a tunnel.
 | 2026-07-15 | Initial. Extracted from `DESIGN.md` v0.1 (2026-07-14, local, uncommitted) §2, §3, §4, §5, §9, §11. That document recorded "50 claims adversarially verified: 48 confirmed, 2 refuted" — **verified against documentation**. Source-verification at `earendil-works/pi @ 5e336cf` subsequently corrected ~7 points. `DES-PERSONA-VIA-APPEND-SYSTEM-MD` is materially rewritten: the source doc's decisions #1 and #2 were mutually exclusive as written. `DES-NAME-KEEP-PI-DISPATCH` is new. `pi-harness` and `pi-sentry` were absent from the source doc's alternatives and are added. §5.7's "caches roll at midnight" caveat is **dropped** — 0.80.7 removed the date from the default system prompt. |
 | 2026-07-15 | An admin panel and cross-platform (Windows/macOS/Linux + Docker) added to scope. Two new decisions and one **security correction**. `DES-PANEL-SEPARATE-FROM-RECEIVER`: the source doc mounted Bull Board on the receiver — defensible for a read-only dashboard, **not** once the same surface sets the model and rewrites flows, because the receiver is the one process that must be internet-reachable. The panel and the receiver have opposite reachability requirements and cannot share a port. `DES-FLOWS-ARE-DATA-PERSONA-IS-CODE`: the panel requirement collided with keeping flows as reviewed repo markdown; resolved by observing that one file was carrying two jobs — hard rules need immutability, task recipes need editability. Architecture diagram and repo layout updated; the public edge is now drawn explicitly. Build order extended with panel and deploy. |
 | 2026-07-16 | **Resolved a spec/code contradiction.** `DES-WORKER-ON-HOST` added and `DES-JOB-FILES-VIA-VOLUME-SUBPATH` marked SUPERSEDED: the worker runs on the host (the `docker` CLI translates host paths, the daemon does not, and the VM prefix moved between Docker Desktop versions; local-folder jobs also *require* a host bind mount a named volume cannot give). The committed spec had rejected worker-on-host while the code already did it -- caught by a spec-conformance scan. `DES-CLI-TRIGGER-FOR-LOCAL` added: the CLI producer was built (user-directed) but unspecified; recorded with the check that `CONST-BUDGET-BEFORE-TOKENS` still holds because the cap is enforced in the processor, not the trigger. Repo-layout `deploy/` line corrected (compose runs Valkey only). |
+| 2026-07-21 | Added DES-RUN-HISTORY-FLAT-FILES-NO-DB (flat node:fs sidecar over a DB / BullMQ-query for run history). |

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -496,12 +496,62 @@ Evidence convention as in `constitution.md`.
   `piDispatchConfig`-tagged error. Given a valid `local` entry, when it fires, then the emitted job's
   `data` byte-matches the shape produced by the interactive local (`enqueueLocalJob`) path.
 
+## INT-RUN-HISTORY-FILE-CONTRACT
+
+**worker → panel.**
+
+- **Contract**:
+  ```
+  <logsDir>/<sanitizedJobId>.log      append-only container stdout+stderr; untrusted, PII-bearing; written ONLY when PI_CAPTURE_JOB_LOGS=1
+  <logsDir>/<sanitizedJobId>.json     one JSON object, PII-free, overwritten on each terminal state (last-write-wins across retries)
+  (logsDir via PI_LOGS_DIR; empty/unset = <OS temp>/pi-dispatch/logs)
+  { "jobId":   "<raw job id: delivery GUID | local-<hex> | repeat:<sched>:<millis>>",
+    "kind":    "github" | "local" | null,
+    "target":  "<repo>#<issue>"  |  "local:<basename>" | null,
+    "flow":    "<flow name>" | null,
+    "startedAt": "<ISO-8601>", "endedAt": "<ISO-8601>",
+    "outcome":   "completed" | "policy" | "failed",
+    "reason":    "<fixed enum: worker-abort|over-budget|unprotected-branch|runner-policy|container-never-started|...>" | null,
+    "exitCode":  <int> | null,
+    "turns":     <int> | null,
+    "budgetReserved": <bool> | null,
+    "attempt":   <int> }
+  ```
+  Field order is the serialisation order (`JSON.stringify` emits insertion order). The filename uses the
+  **sanitized** id (`:` → `_`, because `repeat:<sched>:<millis>` is NTFS-illegal); the record **body**
+  keeps the raw `jobId`. `reason` is a fixed enum passed through from the terminal outcome — never
+  free-form and never payload text — and `turns` is `null` when the container died before emitting the
+  runner `exit` line.
+- **Why**: The panel is a separate process (`DES-PANEL-SEPARATE-FROM-RECEIVER`) that reads this as a
+  read-model it does not share memory with — the worker writes the files, the panel reads them, and
+  nothing crosses in RAM. The worker writes on both terminal paths: `worker/src/index.mjs` `makeProcessor`
+  calls `recordRun` on the success (`result`) and the failure (`error`) branch alike, and
+  `worker/src/run-history.mjs` `makeRecordWriter` serialises the record with a truncating
+  `fs.writeFileSync`, so a re-run of the same id overwrites — last-write-wins across retries. The `.json`
+  is PII-free **by construction**: `buildRecord` (`worker/src/run-history.mjs`) is an explicit object
+  literal over stable id-only fields and never spreads `job.data`, `result`, or `error`, so a GitHub
+  job's title/body and a local job's `task` or full folder path cannot leak — `target` keeps only
+  `repo#issue` or the folder `basename` (`no-pii-in-logs`, `REQ-LOCAL-JOB-VISIBILITY`). The `.log` is a
+  **separate file** from the `.json` precisely so the untrusted, PII-bearing container stream — teed off
+  each stdout/stderr chunk by the sink in `worker/src/run-container.mjs` — never contaminates the
+  structured record; it is opt-in, host-side (never mounted into the container), and written only under
+  `PI_CAPTURE_JOB_LOGS=1`. This is a **flat per-job file, not a database**: one `.json` (plus the optional
+  `.log`) keyed by the sanitized job id, no schema and no query surface — upholding this file's standing
+  invariant that **there is deliberately no database**.
+- **Traces to**: `REQ-DURABLE-RUN-HISTORY`, `REQ-LOCAL-JOB-VISIBILITY`, `INT-RUNNER-EXIT-CODE-PROTOCOL`
+- **Acceptance**: Given a job reaching a terminal state, exactly one `.json` keyed by its sanitized job
+  id exists; its `outcome` matches the queue outcome (`completed` / `policy` / `failed`); no field carries
+  issue or comment body text (`target` is `repo#issue` / `local:<basename>` only); `turns` is `null` when
+  the container died before emitting the runner `exit` line; the `.log` exists only when
+  `PI_CAPTURE_JOB_LOGS` is set.
+
 ---
 
 ## Revision History
 
 | Date | Change |
 |---|---|
+| 2026-07-21 | Added INT-RUN-HISTORY-FILE-CONTRACT (worker→panel run-history read-model files). |
 | 2026-07-17 | Added INT-SCHEDULES-FILE-CONTRACT, documenting the implemented `schedules.json` host-file shape (`PI_SCHEDULES_FILE`): `local`-only, `:`-free unique `id`, `task` as DATA, and load-time rejection of malformed/`github`/duplicate/missing-folder entries. |
 | 2026-07-15 | Initial. Extracted from `DESIGN.md` v0.1 §5.1, §5.3, §5.4, §5.5. `INT-SDK-SESSION-OPTIONS` is **new** — the source doc left the SDK option set unverified (its §10) and was wrong about the print-mode flag shape and the mode union. `PLAYWRIGHT_BROWSERS_PATH` added to the runtime contract: the source doc's Dockerfile was broken as written for non-root execution. The source doc's code sketches are deliberately **not** carried over — the real Dockerfile and handler are the truth, and a spec that mirrors them drifts on the first commit. |
 | 2026-07-16 | **Correction — "pi never throws" was FALSE**, and it was in this file for a day as the justification for forbidding `try`/`catch` outright. Adversarial re-verification refuted it: `agent-session.ts:1242-1244` is `catch (error) { preflightResult?.(false); throw error; }`, and pi's **own JSDoc** (`:1099-1100`) documents throws on no-model, no-API-key, and missing `streamingBehavior`; `agent.ts:470-471` throws `"Agent is already processing."` outside the lifecycle try entirely. The rule as written would have produced a runner that dies of an unhandled rejection on a missing API key, exiting Node's default `1` = *retryable*, so the queue pays to retry a job that can never succeed. **Both mechanisms are required and cover disjoint sets: preflight throws, the loop swallows.** Also corrected: `StopReason` has **five** values (`packages/ai/src/types.ts:380`) — the entry handled three, and a default branch silently maps `"length"` (truncated output) to success. `reload()` has **no early return** — a second call fully re-runs everything; the earlier "the `loaded` guard makes a double call safe" framing was wrong. The lesson is the file's own: this entry was written from source and still asserted an absolute from a partial read. `INT-CONTAINER-RUNTIME-CONTRACT` gained `--init`, `--shm-size` (explicitly **not** `--ipc=host`, which Playwright recommends but which would share the host IPC namespace with an adversarial container), fonts (absent ⇒ tofu-box screenshots that silently gut `REQ-FRONTEND-VISUAL-VERIFY`), and the fact that **`COPY --chown` does not fix the EACCES trap** because it skips auto-created parent dirs. |

--- a/specs/open-questions.md
+++ b/specs/open-questions.md
@@ -116,6 +116,24 @@ Status values: `OPEN` (unanswered) · `WATCH` (not a question — a known-incomi
   token's short expiry, not network policy, is the exfiltration bound, so the mechanism must keep that
   expiry short and the scope narrow. `OQ-004` remains **ACCEPTED RISK** (unchanged by this entry).
 
+## OQ-007 — Run-history log & record retention: periodic (non-boot) sweep
+
+- **Status**: **OPEN**
+- **Question**: Should the durable run-history sidecars (`logs/<jobId>.{json,log}`) be pruned by a
+  periodic, timer-driven sweep, and if so at what cadence?
+- **Why it matters**: sidecar retention is decoupled from BullMQ's queue eviction — the records are meant
+  to outlive the queue entries. Pruning is a **boot-time** age sweep only (`makeLogReaper`, window
+  `PI_LOG_RETENTION_DAYS`, `0` = keep forever). A worker that runs for a long time without restarting
+  therefore never re-sweeps, so `logs/` can grow between restarts. The boot sweep is the shipped partial
+  answer; the periodic sweep is the unresolved half.
+- **How to answer**: decide whether a timer-driven sweep is warranted and pick a cadence, or ratify
+  boot-only pruning as sufficient given the expected restart frequency.
+- **Secondary note**: `sanitizeJobId` collapses filesystem-illegal characters (e.g. the colons in a
+  `repeat:<sched>:<millis>` scheduler id) to `_`, so two distinct job ids could in principle map to one
+  filename. Considered vanishingly unlikely given the `gh-` / `local-` / `repeat:` id grammars; revisit
+  with a hash suffix only if it is ever observed.
+- **Blocks**: nothing from shipping. The boot sweep bounds growth across restarts today.
+
 ---
 
 ## Retired from the source design document
@@ -155,3 +173,4 @@ adversarial passes did.
 | 2026-07-16 | `OQ-005` **retracted and re-corrected** to `WATCH — NOT IN THE PIN`. The 2026-07-15 "correction" below was itself wrong: it read `sdk.ts` at `5e336cf` (**HEAD**) to describe npm `0.80.7` (**the pin**), concluded `modelRuntime` had already landed, and declared the changelog unreliable. `ModelRuntime` does not exist in `0.80.7` — no `model-runtime` in its `dist/`, not exported from `dist/index.js`. The changelog said `[Unreleased]` and was exactly right. The runner was written against the phantom API, the image built cleanly, and every job would have died on a missing export; CI caught it on the first real container run. `constitution.md`'s evidence convention now requires verification against the **published artifact**, and `pinned-api.test.mjs` asserts `ModelRuntime` is absent so the real migration fails a test instead of a job. |
 | 2026-07-15 | ~~`OQ-005` corrected to **WATCH — PARTIALLY LANDED**~~ — **this entry was wrong; see above.** It claimed `modelRuntime` was already in `CreateAgentSessionOptions` at the pinned sha and that the changelog was not a reliable signal. Both false: the sha was HEAD, not the pin. Kept rather than deleted, because a spec that hides having been wrong teaches the next reader to trust it more than it deserves. |
 | 2026-07-17 | Added OQ-006 recording the GitHub-auth-mechanism decision (default gh/fine-grained PAT single-owner; App mandatory multi-tenant), closed by this plan + the E1 CONST-TOKEN-SCOPED-PER-JOB amendment. |
+| 2026-07-21 | Added OQ-007 (run-history retention: periodic sweep). |

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -263,6 +263,30 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
   - Given a scheduled occurrence that fails (including an infra fault), when the tick concludes, then the
     occurrence is **not** retried within the tick — the schedule's own cadence is the retry.
 
+## REQ-DURABLE-RUN-HISTORY
+
+- **Statement**: For each job reaching a terminal state — completed, policy refusal, or infra failure —
+  the worker shall persist a durable, PII-free status record retrievable by job id, and — when raw
+  capture is explicitly enabled (`PI_CAPTURE_JOB_LOGS`) — capture the container's output to
+  `logs/<jobId>.log`. Records shall survive a worker restart and outlive BullMQ's job-hash eviction. No
+  new datastore.
+- **Scope**: Both GitHub and local jobs. This is a **third, durable** surface — it complements, and does
+  not replace, `REQ-LOCAL-JOB-VISIBILITY` (the ephemeral console line plus live stream) and
+  `REQ-JOB-STATUS-COMMENTS` (the GitHub issue comment).
+- **Why**: The panel and post-hoc debugging need a keyed, structured read-model that a scrolling
+  console/journal cannot provide; the durable record is also a second, persistent signal for
+  `CONST-PI-VERSION-PINNED`'s silent-no-op mode. The id-only record honours `no-pii-in-logs` — log the
+  stable ids (the delivery GUID, `repo#issue`), never issue or comment bodies — while the raw
+  `logs/<jobId>.log` is agent output that may echo issue text, so it is opt-in (default off) and
+  gitignored. Assembled in `worker/src/run-history.mjs` and written at the terminal path in
+  `worker/src/index.mjs`.
+- **Traces to**: `REQ-LOCAL-JOB-VISIBILITY`, `REQ-JOB-STATUS-COMMENTS`, `INT-RUNNER-EXIT-CODE-PROTOCOL`,
+  `INT-RUN-HISTORY-FILE-CONTRACT`, `CONST-PI-VERSION-PINNED`
+- **Acceptance**: Given a job reaching a terminal state, a record keyed by its job id exists carrying the
+  correct outcome and is present after a worker restart; the record contains no issue or comment body,
+  title, or username (`target` is `repo#issue` / `local:<basename>` only); the raw `logs/<jobId>.log`
+  exists only when `PI_CAPTURE_JOB_LOGS` is set and is gitignored.
+
 ---
 
 ## Notes (not requirements)
@@ -285,4 +309,5 @@ wait-list working as designed, not a failure — see `README.md`.
 | 2026-07-15 | Initial. Extracted from `DESIGN.md` v0.1 §1, §5.1–5.2, §5.6, §7, §8. `REQ-RUNNER-TURN-BUDGET` and `REQ-UPSTREAM-CONTRACT-TESTS` are **new** — both exist because source-verification refuted design assumptions the doc had marked "verify". §8's failure-mode table was the richest source; one of its rows ("verify: pi max-turns option") was wrong. |
 | 2026-07-17 | Added REQ-BRANCH-PROTECTION-PRECONDITION, formalizing the branch-protection refusal already enforced in `processor.mjs`/`github-host.mjs` (was a dangling code citation). |
 | 2026-07-17 | Added REQ-CRON-SCHEDULED-JOBS, formalizing the implemented BullMQ Job Scheduler cron path: `local`-only triggers, loud `-10`/`-11` handling, per-scheduler stall teardown, startup orphan reconcile, and no in-tick retry. |
+| 2026-07-21 | Added REQ-DURABLE-RUN-HISTORY (durable per-job run record + opt-in raw log; read model for the panel). |
 | 2026-07-16 | **Scope de-GitHub-ified.** It said "triggers on GitHub issue activity" and never mentioned local folders, the CLI/panel, or cron -- stale, since local is now first-class and built. Rewritten as trigger × target. `REQ-JOB-STATUS-COMMENTS` scoped to GitHub jobs explicitly (a local job has no issue). New `REQ-LOCAL-JOB-VISIBILITY`: local jobs surface their outcome on the worker console (and later the panel) -- the local counterpart of the issue comment and the same signal for `CONST-PI-VERSION-PINNED`'s silent-no-op mode. Code updated to match: startWorker now logs one terminal line per job. |

--- a/worker/src/config.mjs
+++ b/worker/src/config.mjs
@@ -13,17 +13,26 @@ export function configError(message) {
 	return error;
 }
 
-export function positiveInt(env, name, fallback) {
+function boundedInt(env, name, fallback, min, want) {
 	const raw = env[name];
 	if (raw === undefined || raw === "") {
 		if (fallback !== undefined) return fallback;
 		throw configError(`missing required env: ${name}`);
 	}
 	const n = Number.parseInt(raw, 10);
-	if (!Number.isInteger(n) || n < 1 || String(n) !== String(raw).trim()) {
-		throw configError(`invalid ${name}: ${JSON.stringify(raw)} (want a positive integer)`);
+	if (!Number.isInteger(n) || n < min || String(n) !== String(raw).trim()) {
+		throw configError(`invalid ${name}: ${JSON.stringify(raw)} (want ${want})`);
 	}
 	return n;
+}
+
+export function positiveInt(env, name, fallback) {
+	return boundedInt(env, name, fallback, 1, "a positive integer");
+}
+
+// min=0: accepts 0 (a sentinel, e.g. "keep forever" for log retention), still rejects negatives and non-integers.
+function nonNegativeInt(env, name, fallback) {
+	return boundedInt(env, name, fallback, 0, "a non-negative integer");
 }
 
 /**
@@ -44,6 +53,9 @@ export function loadConfig(env = process.env, { fileExists = existsSync } = {}) 
 		jobsDir: env.PI_JOBS_DIR ?? defaultJobsDir(),
 		schedulesFile: env.PI_SCHEDULES_FILE ?? null, // DES-CRON-VIA-BULLMQ-SCHEDULER: schedule list is a host file; null = cron disabled
 		schedulerStallMax: positiveInt(env, "PI_SCHEDULER_STALL_MAX", 2), // CONST-RETRY-INFRA-ONLY: per-scheduler stall backstop; positiveInt rejects <1 so a 0 threshold fails closed
+		logsDir: env.PI_LOGS_DIR || defaultLogsDir(), // || (not ??) so an empty string falls back to the default
+		captureJobLogs: env.PI_CAPTURE_JOB_LOGS === "1", // no-pii-in-logs: raw job-log capture is opt-in; anything but "1" is off
+		logRetentionDays: nonNegativeInt(env, "PI_LOG_RETENTION_DAYS", 30), // 0 = keep forever
 		github: loadGitHubAuth(env, fileExists),
 	};
 }
@@ -91,4 +103,10 @@ function defaultJobsDir() {
 	// Under the OS temp dir by default. Holds only the read-only /job inputs (prompt + .pi/); the
 	// workspace for a local job is the operator's own folder, not here.
 	return `${process.env.TMPDIR ?? process.env.TEMP ?? "/tmp"}/pi-dispatch/jobs`.replace(/\\/g, "/");
+}
+
+function defaultLogsDir() {
+	// Under the OS temp dir by default. Holds durable per-run history/log artifacts written host-side;
+	// a worker-owned path that never enters the container env allowlist (no-broad-env-into-container).
+	return `${process.env.TMPDIR ?? process.env.TEMP ?? "/tmp"}/pi-dispatch/logs`.replace(/\\/g, "/");
 }

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -19,8 +19,9 @@ export const JOB_TIMEOUT_MS = 30 * 60 * 1000; // REQ-JOB-TIMEOUT-30M
  * Dependencies are injected so this is testable without a live queue: `cancelJob` (fired by the
  * timeout), `stopContainer` (fired by the abort), and the orchestration deps.
  */
-export function makeProcessor({ cancelJob, stopContainer, redis, cap, deps, timeoutMs = JOB_TIMEOUT_MS }) {
+export function makeProcessor({ cancelJob, stopContainer, redis, cap, deps, recordRun = () => {}, timeoutMs = JOB_TIMEOUT_MS }) {
 	return async function processor(job, token, signal) {
+		const startedAt = new Date().toISOString();
 		const name = `pi-job-${job.id}`;
 		const timer = setTimeout(() => {
 			// BullMQ has no per-job kill timer; this is ours. cancelJob raises the AbortSignal.
@@ -35,13 +36,16 @@ export function makeProcessor({ cancelJob, stopContainer, redis, cap, deps, time
 		signal.addEventListener("abort", onAbort, { once: true });
 
 		try {
-			return await runJob(job.data, {
+			const result = await runJob(job.data, {
 				redis,
 				cap,
 				...deps,
 				runContainer: (ctx) => deps.runContainer({ ...ctx, name, signal }),
 			});
+			recordRun({ job, result, startedAt, endedAt: new Date().toISOString() });
+			return result;
 		} catch (error) {
+			recordRun({ job, error, startedAt, endedAt: new Date().toISOString() });
 			if (error instanceof InfraRetry) throw error; // retryable: BullMQ retries per attempts
 			// A non-retryable, non-infra error (our bug) must not retry forever. UnrecoverableError
 			// records it as failed-and-distinct on the dashboard without a retry.
@@ -53,7 +57,7 @@ export function makeProcessor({ cancelJob, stopContainer, redis, cap, deps, time
 	};
 }
 
-export function createWorker({ connection, concurrency, cap, redis, deps, limiter, extraClosers = [] }) {
+export function createWorker({ connection, concurrency, cap, redis, deps, recordRun, limiter, extraClosers = [] }) {
 	let worker; // referenced by cancelJob before assignment; only called later, so the TDZ is fine
 	const processor = makeProcessor({
 		cancelJob: (id, reason) => worker.cancelJob(id, reason),
@@ -61,6 +65,7 @@ export function createWorker({ connection, concurrency, cap, redis, deps, limite
 		redis,
 		cap,
 		deps,
+		recordRun,
 	});
 
 	worker = new Worker(QUEUE, processor, {

--- a/worker/src/processor.mjs
+++ b/worker/src/processor.mjs
@@ -30,7 +30,7 @@ export async function runJob(job, deps) {
 		mintToken, // (repo) => scoped short-lived token | null for local-folder jobs
 		isDefaultBranchProtected, // (repo, token) => boolean
 		prepareWorkspace, // (job, token) => { workspaceDir, jobDir }  (clone+materialise+prompt)
-		// runContainer({ job, token, prepared, name, signal }) => { code, aborted }. It MUST honour
+		// runContainer({ job, token, prepared, name, signal }) => { code, aborted, turns }. It MUST honour
 		// `signal`: stop the container on abort, and reject/exit promptly if `signal.aborted` is already
 		// true at entry (the timeout can fire during a slow prepare). The wiring injects name + signal.
 		runContainer,
@@ -63,7 +63,8 @@ export async function runJob(job, deps) {
 			if (!(await isDefaultBranchProtected(job.repo, token))) {
 				await comment(job, "Refused: the default branch is not protected. See SECURITY.md.");
 				log("refused_unprotected", { repo: job.repo });
-				return { outcome: "policy", reason: "unprotected-branch" }; // return => not retried
+				// exitCode/turns null: refused pre-container, so no container exit or turn count exists.
+				return { outcome: "policy", reason: "unprotected-branch", exitCode: null, turns: null, budgetReserved: false }; // return => not retried
 			}
 		}
 
@@ -82,10 +83,11 @@ export async function runJob(job, deps) {
 		if (!budget.allowed) {
 			await comment(job, `Over the daily budget cap (${budget.cap}). Not run.`);
 			log("over_budget", { reserved: budget.reserved, cap: budget.cap });
-			return { outcome: "policy", reason: "over-budget" }; // return => not retried
+			// budgetReserved true: the slot is reserved above and kept (an over-cap reservation still counts).
+			return { outcome: "policy", reason: "over-budget", exitCode: null, turns: null, budgetReserved: true }; // return => not retried
 		}
 
-		const { code, aborted } = await runContainer({ job, token, prepared });
+		const { code, aborted, turns } = await runContainer({ job, token, prepared });
 		log("container_exit", { exitCode: code, aborted });
 
 		// A WORKER-initiated stop (30-min timeout via cancelJob, or graceful-shutdown docker stop) kills
@@ -93,17 +95,18 @@ export async function runJob(job, deps) {
 		// NOT retry, or a wedged job re-runs into a second PR / double spend. Keyed on the abort FLAG,
 		// not the code -- an unbidden 137 (kernel OOM) carries `aborted: false`, falls to the switch, and
 		// stays infra-retryable.
-		if (aborted) return { outcome: "policy", reason: "worker-abort" };
+		// exitCode/turns carry the container's own exit and turn count; budgetReserved true post-reserve.
+		if (aborted) return { outcome: "policy", reason: "worker-abort", exitCode: code, turns, budgetReserved: true };
 
 		switch (code) {
 			case EXIT_COMPLETED:
-				return { outcome: "completed" };
+				return { outcome: "completed", exitCode: code, turns, budgetReserved: true };
 			case EXIT_POLICY:
-				return { outcome: "policy", reason: "runner-policy" };
+				return { outcome: "policy", reason: "runner-policy", exitCode: code, turns, budgetReserved: true };
 			case EXIT_INFRA:
-				throw new InfraRetry(`infra failure, container exit ${code}`);
+				throw new InfraRetry(`infra failure, container exit ${code}`, { exitCode: code, turns });
 			default:
-				throw new InfraRetry(`unknown container exit ${code}`);
+				throw new InfraRetry(`unknown container exit ${code}`, { exitCode: code, turns });
 		}
 	} catch (e) {
 		// A spawn fault (docker daemon down / binary missing) reserved a slot but never started a
@@ -111,6 +114,9 @@ export async function runJob(job, deps) {
 		// here (exit-1 infra, unknown exit) means the container ran and legitimately spent its slot,
 		// so `reason` gates the release to the never-started case only. Guarded on `reserved` and run
 		// once per invocation; a BullMQ retry reserves afresh, so this cannot double-release.
+		// budgetReserved reflects whether a slot stays spent: false when never-started refunds below,
+		// true for a real container that ran and spent (exit-1 infra / unknown exit).
+		if (e instanceof InfraRetry) e.budgetReserved = reserved && e.reason !== "container-never-started";
 		if (reserved && e instanceof InfraRetry && e.reason === "container-never-started") {
 			await releaseBudget(redis, { now });
 		}
@@ -122,11 +128,14 @@ export async function runJob(job, deps) {
 
 /** Thrown for the retryable (infra) class only. The BullMQ processor lets this propagate to retry. */
 export class InfraRetry extends Error {
-	constructor(message, { cause, reason } = {}) {
+	constructor(message, { cause, reason, exitCode, turns, budgetReserved } = {}) {
 		super(message, cause ? { cause } : undefined);
 		this.name = "InfraRetry";
 		this.piDispatchRetry = true;
 		this.reason = reason ?? message;
+		this.exitCode = exitCode ?? null;
+		this.turns = turns ?? null;
+		this.budgetReserved = budgetReserved ?? null;
 	}
 }
 

--- a/worker/src/run-container.mjs
+++ b/worker/src/run-container.mjs
@@ -19,14 +19,22 @@ import { InfraRetry } from "./processor.mjs";
  * container at all.
  *
  * Output is streamed to `onOutput` (default: the worker's stdout) so the operator watches the agent
- * work on their own machine -- the natural local UX. This is the operator's own console for their
- * own folder; it is not a persistent PII log.
+ * work on their own machine -- the natural local UX. When raw capture is enabled
+ * (`PI_CAPTURE_JOB_LOGS`), the same output is tee'd to a host-only, gitignored `logs/<jobId>.log`
+ * that is never mounted into the container and may contain agent-echoed issue text (PII). The
+ * worker's event log and the `.json` status record stay id-only.
  */
-export function makeRunContainer({ image, hostEnv = process.env, onOutput = (c) => process.stdout.write(c), spawnFn = spawn }) {
+export function makeRunContainer({
+	image,
+	hostEnv = process.env,
+	onOutput = (c) => process.stdout.write(c),
+	openJobLog = () => ({ write() {}, close: async () => ({ turns: null }) }),
+	spawnFn = spawn,
+}) {
 	// async so a synchronous throw (e.g. buildContainerEnv on an unconfigured provider) surfaces as
 	// a rejection, uniformly awaitable by the processor and by tests.
 	return async function runContainer({ job, token, prepared, name, signal }) {
-		if (signal?.aborted) return { code: 137, aborted: true }; // killed before it could start
+		if (signal?.aborted) return { code: 137, aborted: true, turns: null }; // killed before it could start
 
 		// Closed env allowlist: only the provider key + the declared PI_* vars. Throws (config) if
 		// the provider is unconfigured -- the processor turns that into a pre-spend refusal.
@@ -47,19 +55,39 @@ export function makeRunContainer({ image, hostEnv = process.env, onOutput = (c) 
 			name,
 		});
 
+		// Host-side per-job log sink, teed off `onOutput`. `name` is `pi-job-<jobId>`; the sink
+		// sanitizes internally. No container mount, no env var -- the sink lives on this side only.
+		const sink = openJobLog(name);
+
 		return await new Promise((resolve, reject) => {
 			const child = spawnFn("docker", args, { stdio: ["ignore", "pipe", "pipe"] });
-			child.stdout?.on("data", onOutput);
-			child.stderr?.on("data", onOutput);
+			// A throwing sink.write is swallowed so a misbehaving sink cannot break the tee or hang the run.
+			const tee = (chunk) => {
+				onOutput(chunk);
+				try {
+					sink.write(chunk);
+				} catch {}
+			};
+			child.stdout?.on("data", tee);
+			child.stderr?.on("data", tee);
 			// docker not found / daemon down -- a transient infra fault, so tag it retryable
 			// (CONST-RETRY-INFRA-ONLY). `reason` also cues the processor to release the budget slot,
 			// since a container that never started spent nothing.
-			child.on("error", (err) =>
-				reject(new InfraRetry("container-never-started", { cause: err, reason: "container-never-started" })),
-			);
-			child.on("close", (code) =>
-				resolve(signal?.aborted ? { code: code ?? 137, aborted: true } : { code: code ?? 1, aborted: false }),
-			);
+			child.on("error", (err) => {
+				sink.close().catch(() => {}); // best-effort teardown; a rejecting close cannot leak an unhandled rejection
+				reject(new InfraRetry("container-never-started", { cause: err, reason: "container-never-started" }));
+			});
+			child.on("close", async (code) => {
+				const aborted = signal?.aborted === true; // capture BEFORE the await
+				// A rejecting sink.close is swallowed so a misbehaving sink cannot hang the run; turns falls back to null.
+				let turns = null;
+				try {
+					({ turns } = await sink.close());
+				} catch {
+					turns = null;
+				}
+				resolve(aborted ? { code: code ?? 137, aborted: true, turns } : { code: code ?? 1, aborted: false, turns });
+			});
 		});
 	};
 }

--- a/worker/src/run-history.mjs
+++ b/worker/src/run-history.mjs
@@ -1,0 +1,268 @@
+import * as nodeFs from "node:fs";
+import { basename, join } from "node:path";
+
+/**
+ * Durable per-run history.
+ *
+ * The PURE HELPERS are total functions over their arguments -- no filesystem, no clock, no
+ * `process.env`, no randomness -- so the record shape and the filename/telemetry parsing are testable
+ * without a container, a queue, or a disk: `sanitizeJobId`, `parseExitTurns`, `buildRecord`.
+ *
+ * The I/O factories -- `makeLogSink`, `makeRecordWriter`, `makeLogReaper` -- each inject their own `fs`
+ * (and, for the reaper, their own clock via `now`), so they too are testable with a fake and no disk.
+ * `makeLogSink` streams a job's raw output to a per-job `.log` and recovers the turn count from a
+ * bounded tail; `makeRecordWriter` serialises a finished run to a JSON sidecar; `makeLogReaper` sweeps
+ * aged `.log`/`.json` files at boot.
+ */
+
+/**
+ * Turn an arbitrary job id into a single legal filename segment.
+ *
+ * BullMQ scheduled ids are `repeat:<schedulerId>:<millis>`; a colon is an illegal NTFS filename
+ * character, so writing `<id>.json` verbatim throws on Windows. A strict allowlist (letters, digits,
+ * dot, underscore, hyphen) is the safe subset across Windows and POSIX; everything else collapses to
+ * `_`. A nullish or empty id yields a fixed sentinel so a downstream writer still produces a file
+ * rather than silently dropping the record.
+ */
+export function sanitizeJobId(id) {
+	if (id === null || id === undefined) return "unknown-job";
+	const s = String(id);
+	if (s === "") return "unknown-job";
+	return s.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+/**
+ * Recover the agent's turn count from buffered container stdout, or `null` if it is not reported.
+ *
+ * The stream interleaves docker/agent noise and other JSON events (`pi_auto_retry`) with the runner's
+ * own lines. Only the success exit line carries `turns` (`image/runner/run-job.mjs:108`); the
+ * catch-path exit line (`:122`) omits it. Scan from the end and return the turns of the last `exit`
+ * event that reports an integer count.
+ *
+ * This is read-only telemetry: it MUST NEVER throw and MUST NOT feed exit-code or retry
+ * classification -- that is the container exit code's job (INT-RUNNER-EXIT-CODE-PROTOCOL). Every parse
+ * is guarded; a truncated or non-JSON line is skipped.
+ */
+export function parseExitTurns(text) {
+	if (typeof text !== "string") return null;
+	const lines = text.split("\n");
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i].trim();
+		if (line === "") continue;
+		let parsed;
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			continue; // docker/agent noise or a truncated final line
+		}
+		if (parsed?.event !== "exit") continue;
+		return Number.isInteger(parsed?.turns) ? parsed.turns : null;
+	}
+	return null;
+}
+
+/**
+ * Build the durable run record from the full BullMQ job wrapper and the run's outcome.
+ *
+ * The record is id-only by construction: an EXPLICIT object literal that reads exactly the stable,
+ * non-PII fields and never spreads `job.data`, `result`, or `error`. Per `no-pii-in-logs` and
+ * `REQ-LOCAL-JOB-VISIBILITY`, a GitHub job's `title`/`body` and a local job's `task` and full `folder`
+ * path stay out of the record -- for local jobs only the folder's `basename` is kept, because the full
+ * path embeds the operator's OS account name.
+ *
+ * `reason` is a fixed enum passthrough (worker-abort | over-budget | unprotected-branch |
+ * runner-policy | ...), never free-form or payload text. `exitCode`, `turns`, and `budgetReserved`
+ * default to `null` when the outcome does not carry them, so the record shape is stable whether or not
+ * the source reports those fields.
+ */
+export function buildRecord({ job, result, error, startedAt, endedAt }) {
+	const data = job.data ?? {};
+	const kind = data.kind ?? job.name;
+	const source = result ?? error ?? {};
+	return {
+		jobId: job.id,
+		kind: kind ?? null,
+		target: targetFor(kind, data),
+		flow: data.flow ?? null,
+		startedAt: startedAt ?? null,
+		endedAt: endedAt ?? null,
+		outcome: result ? (result.outcome ?? null) : "failed",
+		reason: source.reason ?? null,
+		exitCode: source.exitCode ?? null,
+		turns: source.turns ?? null,
+		budgetReserved: source.budgetReserved ?? null,
+		attempt: job.attemptsMade ?? 0,
+	};
+}
+
+/**
+ * A stable, non-PII target label. GitHub jobs read `repo#issue`; local jobs read `local:<basename>` --
+ * basename only, so the full folder path (which on Windows carries the OS account name) never lands in
+ * the record.
+ */
+function targetFor(kind, data) {
+	if (kind === "github") return `${data.repo}#${data.issueNumber}`;
+	if (kind === "local") return `local:${basename(data.folder ?? "")}`;
+	return null;
+}
+
+/** Retain only the last ~8KB of container output for turn recovery, so per-job memory stays flat. */
+const TAIL_CAP_BYTES = 8 * 1024;
+
+/**
+ * The durable log sink: the I/O layer that streams a job's raw container output to a per-job `.log`
+ * file and recovers the turn count from a bounded tail of that same output.
+ *
+ * Fault isolation is the contract, not a nicety. This sits on the money path -- `write` is a stdout
+ * `data` listener (run-container.mjs:52) and `close` runs at teardown -- so a throw or an unbounded
+ * await here corrupts the run outcome or turns a finished job into a 30-minute timeout
+ * (CONST-RETRY-INFRA-ONLY). Therefore `write` and `close` NEVER throw and `close` NEVER hangs: every
+ * body is try/catch-swallowed and the flush is a bounded race. This mirrors the "NEVER throws" posture
+ * of `makeReaper` and the comment adapter in `start.mjs`.
+ *
+ * The raw `.log` is written ONLY when `enabled`: raw container output is user-authored data, so it is
+ * opt-in per `no-pii-in-logs`. When disabled, no file is opened, but the bounded tail still accumulates
+ * so `close` can still report the turn count. The path stays host-side and never reaches the container.
+ *
+ * Memory is flat regardless of job length: the tail keeps only the last `TAIL_CAP_BYTES`, so a 200-turn
+ * job does not accumulate megabytes (REQ-QUEUE-BURST-NO-DROP). The filename runs through `sanitizeJobId`
+ * because scheduled ids carry a colon, illegal on NTFS. `fs` is injectable so the sink is testable with
+ * a fake writable and no disk.
+ */
+export function makeLogSink({ logsDir, enabled, fs = nodeFs, log = () => {} }) {
+	try {
+		fs.mkdirSync(logsDir, { recursive: true });
+	} catch (err) {
+		log("logs_dir_error", { reason: err?.message });
+	}
+
+	return function openJobLog(jobId) {
+		let tail = "";
+		let stream = null;
+
+		function write(chunk) {
+			try {
+				tail += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+				if (tail.length > TAIL_CAP_BYTES) tail = tail.slice(tail.length - TAIL_CAP_BYTES);
+				if (!enabled) return;
+				if (stream === null) {
+					stream = fs.createWriteStream(join(logsDir, `${sanitizeJobId(jobId)}.log`), { flags: "a" });
+					// Attach before the first write so an EPIPE/ENOSPC/EACCES surfaces as a log line rather
+					// than an unhandled 'error' that kills the worker.
+					stream.on("error", (e) => log("log_sink_error", { jobId, reason: e?.message }));
+				}
+				stream.write(chunk);
+			} catch (err) {
+				log("log_sink_error", { jobId, reason: err?.message });
+			}
+		}
+
+		async function close({ timeoutMs = 2000 } = {}) {
+			// Capture turns from the tail first, so the count survives even if the flush errors or times out.
+			const turns = parseExitTurns(tail);
+			try {
+				if (stream !== null) {
+					const s = stream;
+					s.end();
+					let timer;
+					const timeout = new Promise((resolve) => {
+						timer = setTimeout(resolve, timeoutMs);
+					});
+					try {
+						// Bounded race: resolve on flush completion, on stream error, or on the deadline --
+						// whichever is first. An unbounded finish-await would turn a completed job into a timeout.
+						await Promise.race([
+							new Promise((resolve) => s.once("finish", resolve)),
+							new Promise((resolve) => s.once("error", resolve)),
+							timeout,
+						]);
+					} finally {
+						clearTimeout(timer);
+					}
+				}
+			} catch (err) {
+				log("log_sink_error", { jobId, reason: err?.message });
+			}
+			return { turns };
+		}
+
+		return { write, close };
+	};
+}
+
+/**
+ * The durable record writer: serialises a finished run's `buildRecord` output to a per-job JSON sidecar.
+ *
+ * Fault isolation is the contract. The processor wrapper calls `writeRecord` on the money path, so a
+ * throw here corrupts a run outcome or turns a finished job into a retry (CONST-RETRY-INFRA-ONLY).
+ * Therefore construction and `writeRecord` NEVER throw: the whole write body is try/catch-swallowed,
+ * mirroring `makeLogSink`.
+ *
+ * The write is SYNCHRONOUS by design: it must complete before `process.exit(0)` on shutdown
+ * (`index.mjs:83`), and an async write loses that race. `fs.writeFileSync` truncates by default, so a
+ * re-run of the same job id overwrites -- last write wins.
+ *
+ * The failure log carries only `jobId` and `reason`; never the record object or its serialized JSON,
+ * which embed target/flow fields (`no-pii-in-logs`). `sanitizeJobId` is applied only at the filename
+ * boundary; the record body keeps the raw id. `fs` is injectable so the writer is testable with a fake
+ * and no disk.
+ */
+export function makeRecordWriter({ logsDir, fs = nodeFs, log = () => {} }) {
+	try {
+		fs.mkdirSync(logsDir, { recursive: true });
+	} catch (err) {
+		log("logs_dir_error", { reason: err?.message });
+	}
+
+	return function writeRecord(record) {
+		try {
+			// Custom: flat JSON sidecar per job over a DB/logging lib -- records are immutable, filename-keyed
+			// by jobId, no cross-record queries; DES-RUN-HISTORY-FLAT-FILES-NO-DB; specs/interfaces.md:11
+			// (there is deliberately no database).
+			const path = join(logsDir, `${sanitizeJobId(record.jobId)}.json`);
+			const data = `${JSON.stringify(record)}\n`;
+			fs.writeFileSync(path, data);
+		} catch (err) {
+			log("run_record_failed", { jobId: record?.jobId, reason: err?.message });
+		}
+	};
+}
+
+/**
+ * The durable log reaper: a boot-time sweep that deletes `.log` and `.json` history files older than
+ * the retention window, keeping the logs directory bounded across restarts.
+ *
+ * Fault isolation is the contract, mirroring `makeReaper` in `start.mjs`: `reapLogs` NEVER throws under
+ * any input. A missing logs directory on first boot (`readdirSync` ENOENT), an unreadable entry, or an
+ * unlink failure is caught -- logged as `log_reaper_skipped` -- and boot continues. The per-file
+ * try/catch is what keeps one bad entry from aborting the whole sweep.
+ *
+ * `retentionDays === 0` is the documented keep-forever sentinel: the sweep returns early and touches no
+ * file. Age comes from the file's `mtimeMs`, never from any date parsed out of the filename -- the
+ * on-disk mtime is the authority. The `isFile()` guard skips a stray `foo.log/` directory so a
+ * mis-shaped entry raises no EISDIR/EPERM. `fs` and `now` are injectable so the reaper is testable with
+ * a fake and no disk.
+ */
+export function makeLogReaper({ logsDir, retentionDays, fs = nodeFs, log = () => {}, now = () => Date.now() }) {
+	return function reapLogs() {
+		if (retentionDays === 0) return; // keep-forever sentinel: no sweep
+		try {
+			const names = fs.readdirSync(logsDir);
+			const cutoff = now() - retentionDays * 86400000;
+			for (const name of names) {
+				if (!name.endsWith(".log") && !name.endsWith(".json")) continue;
+				try {
+					const st = fs.statSync(join(logsDir, name));
+					if (st.isFile() && st.mtimeMs < cutoff) {
+						fs.unlinkSync(join(logsDir, name));
+						log("reaped_log", { file: name });
+					}
+				} catch (err) {
+					log("log_reaper_skipped", { file: name, reason: err?.message });
+				}
+			}
+		} catch (err) {
+			log("log_reaper_skipped", { reason: err?.message });
+		}
+	};
+}

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -9,6 +9,7 @@ import { createWorker } from "./index.mjs";
 import { cleanup, makePrepareWorkspace } from "./prepare.mjs";
 import { makeQueue } from "./queue.mjs";
 import { makeRunContainer } from "./run-container.mjs";
+import { buildRecord, makeLogReaper, makeLogSink, makeRecordWriter } from "./run-history.mjs";
 import { loadSchedules } from "./schedules.mjs";
 import { makeStallGuard } from "./scheduler-stall-guard.mjs";
 
@@ -60,7 +61,15 @@ export function makeReaper({ log }) {
  */
 export async function startWorker(
 	env = process.env,
-	{ makeAuth = makeGitHubAuth, makeHost = makeGitHubHost, createWorkerFn = createWorker, makeReaper: makeReaperFn = makeReaper } = {},
+	{
+		makeAuth = makeGitHubAuth,
+		makeHost = makeGitHubHost,
+		createWorkerFn = createWorker,
+		makeReaper: makeReaperFn = makeReaper,
+		makeLogSink: makeLogSinkFn = makeLogSink,
+		makeRecordWriter: makeRecordWriterFn = makeRecordWriter,
+		makeLogReaper: makeLogReaperFn = makeLogReaper,
+	} = {},
 ) {
 	const config = loadConfig(env);
 	const log = (event, fields = {}) => process.stdout.write(`${JSON.stringify({ event, ...fields })}\n`);
@@ -87,6 +96,15 @@ export async function startWorker(
 		log("reaper_skipped", { reason: err?.message });
 	}
 
+	// REQ-LOCAL-JOB-VISIBILITY: sweep aged `.log`/`.json` history at boot so the logs directory stays
+	// bounded across restarts. Best-effort with the same double-wrap posture as the container reaper: the
+	// reaper swallows its own fs errors, and this guard keeps any reaper failure from blocking draining.
+	try {
+		await makeLogReaperFn({ logsDir: config.logsDir, retentionDays: config.logRetentionDays, log })();
+	} catch (err) {
+		log("log_reaper_skipped", { reason: err?.message });
+	}
+
 	// One raw Redis client, shared by the budget (via the worker) and the scheduler stall guard, so it is
 	// hoisted out of the createWorkerFn arg object.
 	const redis = makeRedisClient(config.valkeyUrl);
@@ -94,14 +112,25 @@ export async function startWorker(
 	// handle rides out a Valkey blip. Registered as an extraCloser so shutdown drains it after the worker.
 	const schedulerQueue = makeQueue(parseConnection(config.valkeyUrl));
 
+	// REQ-LOCAL-JOB-VISIBILITY durable run history, all host-side. The raw `.log` sink is gated on
+	// captureJobLogs (raw container output is user-authored data, opt-in per no-pii-in-logs); the id-only
+	// `.json` record via recordRun is ALWAYS on, so every run leaves a stable, non-PII trace regardless.
+	// logsDir wires only into these host-side factories and openJobLog into runContainer -- never into the
+	// container env allowlist (no-broad-env-into-container).
+	const openJobLog = makeLogSinkFn({ logsDir: config.logsDir, enabled: config.captureJobLogs, log });
+	const writeRecord = makeRecordWriterFn({ logsDir: config.logsDir, log });
+	const recordRun = ({ job, result, error, startedAt, endedAt }) =>
+		writeRecord(buildRecord({ job, result, error, startedAt, endedAt }));
+
 	const worker = createWorkerFn({
 		connection: parseConnection(config.valkeyUrl),
 		concurrency: config.concurrency,
 		cap: config.dailyCap,
 		redis,
+		recordRun,
 		extraClosers: [schedulerQueue],
 		deps: {
-			runContainer: makeRunContainer({ image: config.jobImage, hostEnv: env }),
+			runContainer: makeRunContainer({ image: config.jobImage, hostEnv: env, openJobLog }),
 			prepareWorkspace: makePrepareWorkspace({
 				jobsDir: config.jobsDir,
 				resolveDefaultBranchSha: host.resolveDefaultBranchSha,
@@ -179,6 +208,9 @@ export async function startWorker(
 		dailyCap: config.dailyCap,
 		image: config.jobImage,
 		valkey: config.valkeyUrl,
+		logsDir: config.logsDir,
+		captureJobLogs: config.captureJobLogs,
+		logRetentionDays: config.logRetentionDays,
 	});
 	return worker;
 }

--- a/worker/test/config.test.mjs
+++ b/worker/test/config.test.mjs
@@ -14,6 +14,47 @@ test("loads conservative defaults with an empty-ish env", () => {
 	assert.ok(c.jobsDir.length > 0);
 	assert.equal(c.schedulesFile, null);
 	assert.equal(c.schedulerStallMax, 2);
+	assert.ok(c.logsDir.endsWith("/pi-dispatch/logs"), c.logsDir);
+	assert.equal(c.captureJobLogs, false);
+	assert.equal(c.logRetentionDays, 30);
+});
+
+test("run-history env overrides logsDir, captureJobLogs, and logRetentionDays", () => {
+	const c = loadConfig({ PI_LOGS_DIR: "/x", PI_CAPTURE_JOB_LOGS: "1", PI_LOG_RETENTION_DAYS: "7" });
+	assert.equal(c.logsDir, "/x");
+	assert.equal(c.captureJobLogs, true);
+	assert.equal(c.logRetentionDays, 7);
+});
+
+test("logsDir uses || so an empty PI_LOGS_DIR falls back to the default", () => {
+	const c = loadConfig({ PI_LOGS_DIR: "" });
+	assert.ok(c.logsDir.endsWith("/pi-dispatch/logs"), c.logsDir);
+});
+
+test("captureJobLogs is strict: only \"1\" enables it, everything else stays off", () => {
+	for (const off of ["0", "true", "yes", "", undefined]) {
+		const c = loadConfig(off === undefined ? {} : { PI_CAPTURE_JOB_LOGS: off });
+		assert.equal(c.captureJobLogs, false, `PI_CAPTURE_JOB_LOGS=${JSON.stringify(off)}`);
+	}
+});
+
+test("logRetentionDays accepts 0 (keep forever)", () => {
+	const c = loadConfig({ PI_LOG_RETENTION_DAYS: "0" });
+	assert.equal(c.logRetentionDays, 0);
+});
+
+test("logRetentionDays rejects negative and non-integer values as config errors", () => {
+	for (const bad of ["-1", "abc", "1.5"]) {
+		assert.throws(
+			() => loadConfig({ PI_LOG_RETENTION_DAYS: bad }),
+			(e) => e.piDispatchConfig === true,
+			`PI_LOG_RETENTION_DAYS=${bad}`,
+		);
+	}
+});
+
+test("positiveInt is unchanged: a spend var of 0 still throws", () => {
+	assert.throws(() => loadConfig({ PI_DAILY_CAP: "0" }), (e) => e.piDispatchConfig === true);
 });
 
 test("env overrides every field", () => {

--- a/worker/test/processor.test.mjs
+++ b/worker/test/processor.test.mjs
@@ -169,4 +169,54 @@ test("InfraRetry back-compat: message-only ctor keeps piDispatchRetry and defaul
 	assert.equal(e.piDispatchRetry, true);
 	assert.equal(e.reason, "x");
 	assert.equal(e.message, "x");
+	assert.equal(e.exitCode, null, "telemetry fields default null on the message-only ctor");
+	assert.equal(e.turns, null);
+	assert.equal(e.budgetReserved, null);
+});
+
+test("a completed return carries exitCode/turns from the container and budgetReserved true", async () => {
+	const { deps: d } = deps({ runContainer: async () => ({ code: 0, aborted: false, turns: 7 }) });
+	const r = await runJob(ghJob, d);
+	assert.equal(r.outcome, "completed");
+	assert.equal(r.exitCode, 0);
+	assert.equal(r.turns, 7);
+	assert.equal(r.budgetReserved, true);
+});
+
+test("an over-budget return carries null exit/turns but budgetReserved true (slot kept)", async () => {
+	const { deps: d } = deps({ redis: fakeRedis(10), cap: 10 });
+	const r = await runJob(ghJob, d);
+	assert.equal(r.reason, "over-budget");
+	assert.equal(r.exitCode, null);
+	assert.equal(r.turns, null);
+	assert.equal(r.budgetReserved, true);
+});
+
+test("an unprotected-branch return carries null exit/turns and budgetReserved false (pre-reserve)", async () => {
+	const { deps: d } = deps({ isDefaultBranchProtected: async () => false });
+	const r = await runJob(ghJob, d);
+	assert.equal(r.reason, "unprotected-branch");
+	assert.equal(r.exitCode, null);
+	assert.equal(r.turns, null);
+	assert.equal(r.budgetReserved, false);
+});
+
+test("an exit-1 infra throw stamps exitCode/turns and budgetReserved true (container ran and spent)", async () => {
+	const { deps: d } = deps({ runContainer: async () => ({ code: 1, aborted: false, turns: 4 }) });
+	await assert.rejects(
+		() => runJob(ghJob, d),
+		(e) => e instanceof InfraRetry && e.exitCode === 1 && e.turns === 4 && e.budgetReserved === true,
+	);
+});
+
+test("a container-never-started throw stamps budgetReserved false (its slot is refunded)", async () => {
+	const { deps: d } = deps({
+		runContainer: async () => {
+			throw new InfraRetry("container-never-started", { reason: "container-never-started" });
+		},
+	});
+	await assert.rejects(
+		() => runJob(ghJob, d),
+		(e) => e instanceof InfraRetry && e.reason === "container-never-started" && e.budgetReserved === false,
+	);
 });

--- a/worker/test/run-container.test.mjs
+++ b/worker/test/run-container.test.mjs
@@ -47,13 +47,66 @@ function fakeSpawnAbortedThenClose(ac, exitCode) {
 	};
 }
 
+/** A `docker` child that streams stdout `data` chunks BEFORE the `close`, so a test can exercise the
+ *  tee (onOutput + sink.write) and then observe the resolved result. Chunks arrive in array order. */
+function fakeSpawnWithData(recorder, { chunks = [], exitCode = 0 } = {}) {
+	return (cmd, args) => {
+		recorder.cmd = cmd;
+		recorder.args = args;
+		const child = new EventEmitter();
+		child.stdout = new EventEmitter();
+		child.stderr = new EventEmitter();
+		queueMicrotask(() => {
+			for (const chunk of chunks) child.stdout.emit("data", chunk);
+			child.emit("close", exitCode);
+		});
+		return child;
+	};
+}
+
+/** A `docker` child that fails to launch: it emits `error` and NEVER `close`, modelling docker-not-found
+ *  / daemon-down. Drives the `container-never-started` InfraRetry path and its best-effort sink teardown. */
+function fakeSpawnError(recorder, err = new Error("spawn docker ENOENT")) {
+	return (cmd, args) => {
+		recorder.cmd = cmd;
+		recorder.args = args;
+		const child = new EventEmitter();
+		child.stdout = new EventEmitter();
+		child.stderr = new EventEmitter();
+		queueMicrotask(() => child.emit("error", err));
+		return child;
+	};
+}
+
+/** A recording fake for `openJobLog`: captures every `write` chunk and counts `close` calls, and its
+ *  `close` resolves `{ turns }`. `closeDelay` defers the resolve past a `setImmediate`, so a test can
+ *  prove `resolve` awaits `close` -- a non-awaited close would leave `turns` at its null default. */
+function makeRecordingSink({ turns = null, closeDelay = false } = {}) {
+	const writes = [];
+	let closeCalls = 0;
+	return {
+		writes,
+		get closeCalls() {
+			return closeCalls;
+		},
+		write(chunk) {
+			writes.push(chunk);
+		},
+		close: async () => {
+			closeCalls += 1;
+			if (closeDelay) await new Promise((resolve) => setImmediate(resolve));
+			return { turns };
+		},
+	};
+}
+
 test("an already-aborted signal returns {code:137, aborted:true} and NEVER spawns docker", { skip }, async () => {
 	const rec = {};
 	const runContainer = mod.makeRunContainer({ image: "pi-job:x", hostEnv: HOST, spawnFn: fakeSpawn(rec) });
 	const ac = new AbortController();
 	ac.abort();
 	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: ac.signal });
-	assert.deepEqual(result, { code: 137, aborted: true });
+	assert.deepEqual(result, { code: 137, aborted: true, turns: null });
 	assert.equal(rec.cmd, undefined, "no container may start once the timeout has fired");
 });
 
@@ -73,20 +126,20 @@ test("launches docker with the isolation argv and returns the container's exit c
 test("exit 1 (infra) is returned, not thrown -- it is retryable, not a spawn error", { skip }, async () => {
 	const runContainer = mod.makeRunContainer({ image: "pi-job:x", hostEnv: HOST, spawnFn: fakeSpawn({}, 1) });
 	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: new AbortController().signal });
-	assert.deepEqual(result, { code: 1, aborted: false });
+	assert.deepEqual(result, { code: 1, aborted: false, turns: null });
 });
 
 test("close 137 while the worker aborted => {code:137, aborted:true} (our docker stop is POLICY)", { skip }, async () => {
 	const ac = new AbortController();
 	const runContainer = mod.makeRunContainer({ image: "pi-job:x", hostEnv: HOST, spawnFn: fakeSpawnAbortedThenClose(ac, 137) });
 	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: ac.signal });
-	assert.deepEqual(result, { code: 137, aborted: true });
+	assert.deepEqual(result, { code: 137, aborted: true, turns: null });
 });
 
 test("close 137 with a signal that never aborted => {code:137, aborted:false} (kernel OOM stays infra)", { skip }, async () => {
 	const runContainer = mod.makeRunContainer({ image: "pi-job:x", hostEnv: HOST, spawnFn: fakeSpawn({}, 137) });
 	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: new AbortController().signal });
-	assert.deepEqual(result, { code: 137, aborted: false });
+	assert.deepEqual(result, { code: 137, aborted: false, turns: null });
 });
 
 test("refuses before spawning if the provider is unconfigured (pre-spend guard)", { skip }, async () => {
@@ -97,4 +150,70 @@ test("refuses before spawning if the provider is unconfigured (pre-spend guard)"
 		(e) => e.piDispatchConfig === true,
 	);
 	assert.equal(rec.cmd, undefined, "no container for an unconfigured provider");
+});
+
+test("tee: every chunk reaches BOTH onOutput and the sink, in order", { skip }, async () => {
+	const outputs = [];
+	const sink = makeRecordingSink();
+	const runContainer = mod.makeRunContainer({
+		image: "pi-job:x",
+		hostEnv: HOST,
+		onOutput: (c) => outputs.push(c),
+		openJobLog: () => sink,
+		spawnFn: fakeSpawnWithData({}, { chunks: ["one", "two"], exitCode: 0 }),
+	});
+	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: new AbortController().signal });
+	assert.deepEqual(outputs, ["one", "two"], "onOutput sees both chunks in order");
+	assert.deepEqual(sink.writes, ["one", "two"], "the sink tee sees both chunks in order");
+	assert.equal(result.code, 0);
+});
+
+test("flush-before-resolve: resolve awaits a delayed sink.close and carries its turns", { skip }, async () => {
+	const sink = makeRecordingSink({ turns: 7, closeDelay: true });
+	const runContainer = mod.makeRunContainer({
+		image: "pi-job:x",
+		hostEnv: HOST,
+		onOutput: () => {},
+		openJobLog: () => sink,
+		spawnFn: fakeSpawn({}, 0),
+	});
+	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: new AbortController().signal });
+	assert.equal(result.turns, 7, "turns from a close that resolves only after setImmediate proves resolve awaited it");
+	assert.equal(result.code, 0);
+	assert.equal(sink.closeCalls, 1, "close is invoked exactly once");
+});
+
+test("hostile sink: a throwing write and a rejecting close neither hang nor crash the run", { skip, timeout: 5000 }, async () => {
+	const runContainer = mod.makeRunContainer({
+		image: "pi-job:x",
+		hostEnv: HOST,
+		onOutput: () => {},
+		openJobLog: () => ({
+			write: () => {
+				throw new Error("boom");
+			},
+			close: async () => {
+				throw new Error("boom2");
+			},
+		}),
+		spawnFn: fakeSpawnWithData({}, { chunks: ["x"], exitCode: 0 }),
+	});
+	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: new AbortController().signal });
+	assert.deepEqual(result, { code: 0, aborted: false, turns: null }, "the swallowed sink faults leave code/aborted intact and turns null");
+});
+
+test("never-started: the sink is still closed (best-effort teardown) and the reject reason is unchanged", { skip }, async () => {
+	const sink = makeRecordingSink();
+	const runContainer = mod.makeRunContainer({
+		image: "pi-job:x",
+		hostEnv: HOST,
+		onOutput: () => {},
+		openJobLog: () => sink,
+		spawnFn: fakeSpawnError({}),
+	});
+	await assert.rejects(
+		() => runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: new AbortController().signal }),
+		(e) => e.reason === "container-never-started",
+	);
+	assert.equal(sink.closeCalls, 1, "the never-started path still closes the sink");
 });

--- a/worker/test/run-history.test.mjs
+++ b/worker/test/run-history.test.mjs
@@ -1,0 +1,560 @@
+import assert from "node:assert/strict";
+import { basename, join } from "node:path";
+import { test } from "node:test";
+import { buildRecord, makeLogReaper, makeLogSink, makeRecordWriter, parseExitTurns, sanitizeJobId } from "../src/run-history.mjs";
+
+/**
+ * A fake writable that records chunks and lets a test drive `finish`/`error` timing.
+ * `emitOn` controls what `end()` emits: "finish" (normal flush), "error" (broken flush), or "none"
+ * (never settles -- exercises the bounded close timeout). `writeThrows` makes `write` throw
+ * synchronously; `emitError` makes `write` also schedule an async 'error' event.
+ */
+function makeFakeStream({ emitOn = "finish", writeThrows = false, emitError = false } = {}) {
+	const listeners = new Map();
+	const chunks = [];
+	const stream = {
+		chunks,
+		writeCalls: 0,
+		on(event, cb) {
+			if (!listeners.has(event)) listeners.set(event, []);
+			listeners.get(event).push(cb);
+			return stream;
+		},
+		once(event, cb) {
+			return stream.on(event, cb);
+		},
+		emit(event, ...args) {
+			for (const cb of [...(listeners.get(event) ?? [])]) cb(...args);
+		},
+		write(chunk) {
+			stream.writeCalls++;
+			chunks.push(chunk);
+			if (emitError) queueMicrotask(() => stream.emit("error", new Error("write error")));
+			if (writeThrows) throw new Error("write threw");
+		},
+		end() {
+			if (emitOn === "finish") queueMicrotask(() => stream.emit("finish"));
+			else if (emitOn === "error") queueMicrotask(() => stream.emit("error", new Error("end error")));
+			// emitOn === "none": never settles -- close must fall back to its timeout.
+		},
+	};
+	return stream;
+}
+
+/**
+ * A fake fs exposing only what the sink, the record writer, and the log reaper touch, with call
+ * counters for the assertions. `writes` records every `writeFileSync({path, data})`; `writeThrows`
+ * makes it throw so the writer's never-throw posture can be exercised.
+ *
+ * Reaper surface: `readdirNames` is the directory listing `readdirSync` returns; `readdirThrows` makes
+ * it throw (first-boot ENOENT). `stats` maps a filename to `{ isFile, mtimeMs }` -- `statSync` looks the
+ * entry up by `basename(path)` and returns a real `{ isFile: () => bool, mtimeMs }`. `statThrowsFor` and
+ * `unlinkThrowsFor` are name lists that make `statSync`/`unlinkSync` throw for those specific entries.
+ * `calls.readdir` counts listings and `unlinked` records every unlinked path.
+ */
+function makeFakeFs({
+	stream,
+	mkdirThrows = false,
+	writeThrows = false,
+	readdirNames = [],
+	readdirThrows = false,
+	stats = {},
+	statThrowsFor = [],
+	unlinkThrowsFor = [],
+} = {}) {
+	const calls = { mkdir: 0, createWriteStream: 0, paths: [], readdir: 0, stat: [] };
+	const writes = [];
+	const unlinked = [];
+	return {
+		calls,
+		writes,
+		unlinked,
+		mkdirSync() {
+			calls.mkdir++;
+			if (mkdirThrows) throw new Error("mkdir failed");
+		},
+		createWriteStream(path) {
+			calls.createWriteStream++;
+			calls.paths.push(path);
+			return stream;
+		},
+		writeFileSync(path, data) {
+			if (writeThrows) throw new Error("writeFileSync failed");
+			writes.push({ path, data });
+		},
+		readdirSync() {
+			calls.readdir++;
+			if (readdirThrows) throw new Error("ENOENT: no such file or directory");
+			return readdirNames;
+		},
+		statSync(path) {
+			calls.stat.push(path);
+			const name = basename(path);
+			if (statThrowsFor.includes(name)) throw new Error(`stat failed: ${name}`);
+			const entry = stats[name] ?? { isFile: true, mtimeMs: 0 };
+			return { isFile: () => entry.isFile, mtimeMs: entry.mtimeMs };
+		},
+		unlinkSync(path) {
+			const name = basename(path);
+			if (unlinkThrowsFor.includes(name)) throw new Error(`unlink failed: ${name}`);
+			unlinked.push(path);
+		},
+	};
+}
+
+test("sanitizeJobId strips colons from BullMQ scheduled ids", () => {
+	assert.equal(sanitizeJobId("repeat:a:1"), "repeat_a_1");
+});
+
+test("sanitizeJobId leaves an already-legal id unchanged", () => {
+	assert.equal(sanitizeJobId("gh-abc-123"), "gh-abc-123");
+});
+
+test("sanitizeJobId maps empty/nullish to a fixed sentinel", () => {
+	assert.equal(sanitizeJobId(""), "unknown-job");
+	assert.equal(sanitizeJobId(undefined), "unknown-job");
+	assert.equal(sanitizeJobId(null), "unknown-job");
+});
+
+test("sanitizeJobId collapses path separators to underscore", () => {
+	assert.equal(sanitizeJobId("a/b"), "a_b");
+	assert.equal(sanitizeJobId("a\\b"), "a_b");
+});
+
+test("parseExitTurns reads turns off the success exit line", () => {
+	assert.equal(parseExitTurns('{"event":"exit","code":0,"turns":7}\n'), 7);
+});
+
+test("parseExitTurns ignores pi_auto_retry noise before the exit line", () => {
+	const text = [
+		'{"event":"pi_auto_retry","attempt":1,"maxAttempts":3}',
+		'{"event":"pi_auto_retry","attempt":2,"maxAttempts":3}',
+		'{"event":"exit","code":0,"turns":12}',
+	].join("\n");
+	assert.equal(parseExitTurns(text), 12);
+});
+
+test("parseExitTurns returns null for the catch-path exit line that omits turns", () => {
+	assert.equal(parseExitTurns('{"event":"exit","code":2,"reason":"config"}'), null);
+});
+
+test("parseExitTurns skips non-JSON noise and finds the exit line", () => {
+	assert.equal(parseExitTurns('garbage not json\n{"event":"exit","turns":3}'), 3);
+});
+
+test("parseExitTurns returns null on a partial/truncated final line", () => {
+	assert.equal(parseExitTurns('{"event":"exi'), null);
+});
+
+test("parseExitTurns returns the LAST exit line's turns when two are present", () => {
+	assert.equal(parseExitTurns('{"event":"exit","turns":2}\n{"event":"exit","turns":9}'), 9);
+});
+
+test("parseExitTurns returns null for empty input", () => {
+	assert.equal(parseExitTurns(""), null);
+});
+
+test("parseExitTurns never throws across the full corpus", () => {
+	const inputs = [
+		'{"event":"exit","code":0,"turns":7}\n',
+		'{"event":"exit","code":2,"reason":"config"}',
+		'garbage not json\n{"event":"exit","turns":3}',
+		'{"event":"exi',
+		'{"event":"exit","turns":2}\n{"event":"exit","turns":9}',
+		"",
+		undefined,
+		null,
+		42,
+		"null",
+		"123",
+	];
+	for (const input of inputs) {
+		assert.doesNotThrow(() => parseExitTurns(input), `input=${JSON.stringify(input)}`);
+	}
+});
+
+test("buildRecord for a github job keeps id-only fields and admits no PII", () => {
+	const job = {
+		id: "gh-x",
+		attemptsMade: 0,
+		name: "github",
+		data: { kind: "github", repo: "o/r", issueNumber: 5, flow: "fix", title: "SECRET_T", body: "SECRET_B" },
+	};
+	const record = buildRecord({
+		job,
+		result: { outcome: "completed" },
+		startedAt: "2026-07-18T00:00:00.000Z",
+		endedAt: "2026-07-18T00:01:00.000Z",
+	});
+	assert.equal(record.target, "o/r#5");
+	assert.equal(record.outcome, "completed");
+	assert.equal(record.attempt, 0);
+	assert.equal(record.kind, "github");
+	assert.equal(record.flow, "fix");
+	assert.equal(record.turns, null);
+	assert.equal(record.exitCode, null);
+	assert.equal(record.budgetReserved, null);
+	assert.equal(record.reason, null);
+
+	const json = JSON.stringify(record);
+	assert.ok(!json.includes("SECRET_T"), "title must not leak");
+	assert.ok(!json.includes("SECRET_B"), "body must not leak");
+});
+
+test("buildRecord for a local job keeps only the folder basename and no task text", () => {
+	const job = {
+		id: "local-abc",
+		name: "local",
+		data: { kind: "local", folder: "C:/Users/rob/proj", flow: "x", task: "SECRET_TASK" },
+	};
+	const record = buildRecord({
+		job,
+		result: { outcome: "completed" },
+		startedAt: "2026-07-18T00:00:00.000Z",
+		endedAt: "2026-07-18T00:01:00.000Z",
+	});
+	assert.equal(record.target, "local:proj");
+	assert.equal(record.attempt, 0); // attemptsMade absent -> 0
+
+	const json = JSON.stringify(record);
+	assert.ok(!json.includes("SECRET_TASK"), "task must not leak");
+	assert.ok(!json.includes("C:/Users/rob/proj"), "full folder path must not leak");
+	assert.ok(!json.includes("/Users/rob/"), "OS account path must not leak");
+});
+
+test("buildRecord throw-path maps a present error and no result to a failed outcome", () => {
+	const job = { id: "gh-y", attemptsMade: 1, name: "github", data: { kind: "github", repo: "o/r", issueNumber: 9 } };
+	const record = buildRecord({
+		job,
+		error: { reason: "error" },
+		startedAt: "2026-07-18T00:00:00.000Z",
+		endedAt: "2026-07-18T00:00:30.000Z",
+	});
+	assert.equal(record.outcome, "failed");
+	assert.equal(record.reason, "error");
+	assert.equal(record.attempt, 1);
+	assert.equal(record.turns, null);
+});
+
+test("buildRecord throw-path admits no PII for either job kind", () => {
+	const startedAt = "2026-07-18T00:00:00.000Z";
+	const endedAt = "2026-07-18T00:00:30.000Z";
+
+	const githubRecord = buildRecord({
+		job: {
+			id: "gh-err",
+			attemptsMade: 1,
+			name: "github",
+			data: { kind: "github", repo: "o/r", issueNumber: 9, flow: "fix", title: "SECRET_T", body: "SECRET_B" },
+		},
+		error: { reason: "error" },
+		startedAt,
+		endedAt,
+	});
+	assert.equal(githubRecord.outcome, "failed");
+	const githubJson = JSON.stringify(githubRecord);
+	assert.ok(!githubJson.includes("SECRET_T"), "github title must not leak on the error branch");
+	assert.ok(!githubJson.includes("SECRET_B"), "github body must not leak on the error branch");
+
+	const localRecord = buildRecord({
+		job: {
+			id: "local-err",
+			attemptsMade: 1,
+			name: "local",
+			data: { kind: "local", folder: "C:/Users/rob/proj", flow: "x", task: "SECRET_TASK" },
+		},
+		error: { reason: "error" },
+		startedAt,
+		endedAt,
+	});
+	assert.equal(localRecord.outcome, "failed");
+	const localJson = JSON.stringify(localRecord);
+	assert.ok(!localJson.includes("SECRET_TASK"), "local task must not leak on the error branch");
+	assert.ok(!localJson.includes("C:/Users/rob/proj"), "full folder path must not leak on the error branch");
+	assert.ok(!localJson.includes("/Users/rob/"), "OS account path must not leak on the error branch");
+});
+
+test("makeLogSink enabled appends chunks in order and returns turns from the exit line", async () => {
+	const stream = makeFakeStream({ emitOn: "finish" });
+	const fs = makeFakeFs({ stream });
+	const openJobLog = makeLogSink({ logsDir: "/logs", enabled: true, fs });
+	const jobLog = openJobLog("gh-1");
+
+	const c1 = Buffer.from('{"event":"start"}\n');
+	const c2 = Buffer.from('{"event":"exit","turns":5}\n');
+	jobLog.write(c1);
+	jobLog.write(c2);
+	const { turns } = await jobLog.close();
+
+	assert.equal(turns, 5);
+	assert.equal(stream.chunks.length, 2);
+	assert.equal(stream.chunks[0].toString(), c1.toString());
+	assert.equal(stream.chunks[1].toString(), c2.toString());
+	assert.equal(fs.calls.createWriteStream, 1); // opened lazily, once per job
+	assert.equal(fs.calls.paths[0], join("/logs", "gh-1.log"));
+});
+
+test("makeLogSink disabled never opens a stream but still returns turns", async () => {
+	const fs = makeFakeFs({ stream: makeFakeStream() });
+	const openJobLog = makeLogSink({ logsDir: "/logs", enabled: false, fs });
+	const jobLog = openJobLog("gh-2");
+
+	jobLog.write(Buffer.from('{"event":"exit","turns":8}\n'));
+	const { turns } = await jobLog.close();
+
+	assert.equal(turns, 8);
+	assert.equal(fs.calls.createWriteStream, 0); // the raw .log is opt-in; nothing opened
+});
+
+test("makeLogSink swallows a stream that throws on write and emits error, still returning turns", async () => {
+	const stream = makeFakeStream({ emitOn: "finish", writeThrows: true, emitError: true });
+	const logs = [];
+	const fs = makeFakeFs({ stream });
+	const openJobLog = makeLogSink({ logsDir: "/logs", enabled: true, fs, log: (event, fields) => logs.push({ event, fields }) });
+	const jobLog = openJobLog("gh-3");
+
+	assert.doesNotThrow(() => jobLog.write(Buffer.from('{"event":"exit","turns":4}\n')));
+	const res = await jobLog.close();
+
+	assert.equal(res.turns, 4);
+	assert.ok(logs.some((l) => l.event === "log_sink_error"), "a swallowed error is reported, not thrown");
+});
+
+test("makeLogSink close resolves within the timeout when finish never fires", async () => {
+	const stream = makeFakeStream({ emitOn: "none" });
+	const fs = makeFakeFs({ stream });
+	const openJobLog = makeLogSink({ logsDir: "/logs", enabled: true, fs });
+	const jobLog = openJobLog("gh-4");
+
+	jobLog.write(Buffer.from('{"event":"exit","turns":2}\n'));
+	const start = Date.now();
+	const { turns } = await jobLog.close({ timeoutMs: 50 });
+	const elapsed = Date.now() - start;
+
+	assert.equal(turns, 2);
+	assert.ok(elapsed < 2000, `close must not hang, resolved in ${elapsed}ms`);
+});
+
+test("makeLogSink bounds the tail: an exit line older than the cap is evicted", async () => {
+	const fs = makeFakeFs({ stream: makeFakeStream() });
+	const openJobLog = makeLogSink({ logsDir: "/logs", enabled: false, fs });
+	const jobLog = openJobLog("gh-5");
+
+	jobLog.write(Buffer.from('{"event":"exit","turns":9}\n')); // early -- must fall out of the tail window
+	const noise = `${"x".repeat(1000)}\n`;
+	for (let i = 0; i < 20; i++) jobLog.write(Buffer.from(noise)); // ~20KB > 8KB cap
+	const { turns } = await jobLog.close();
+
+	assert.equal(turns, null); // the old exit line was dropped -> buffer is bounded
+});
+
+test("makeLogSink bounded tail retains the most recent exit line", async () => {
+	const fs = makeFakeFs({ stream: makeFakeStream() });
+	const openJobLog = makeLogSink({ logsDir: "/logs", enabled: false, fs });
+	const jobLog = openJobLog("gh-6");
+
+	const noise = `${"x".repeat(1000)}\n`;
+	for (let i = 0; i < 20; i++) jobLog.write(Buffer.from(noise));
+	jobLog.write(Buffer.from('{"event":"exit","turns":11}\n')); // last -- stays in the window
+	const { turns } = await jobLog.close();
+
+	assert.equal(turns, 11);
+});
+
+test("makeLogSink never throws from the factory when mkdirSync fails", () => {
+	const logs = [];
+	const fs = makeFakeFs({ stream: makeFakeStream(), mkdirThrows: true });
+	assert.doesNotThrow(() => makeLogSink({ logsDir: "/logs", enabled: true, fs, log: (event, fields) => logs.push({ event, fields }) }));
+	assert.ok(logs.some((l) => l.event === "logs_dir_error"), "a logs-dir failure is reported, not thrown");
+});
+
+test("makeRecordWriter writes one truncating JSON sidecar whose content round-trips the record", () => {
+	const fs = makeFakeFs({ stream: makeFakeStream() });
+	const writeRecord = makeRecordWriter({ logsDir: "/logs", fs });
+	const record = { jobId: "gh-x", target: "o/r#5", outcome: "completed" };
+
+	writeRecord(record);
+
+	assert.equal(fs.writes.length, 1);
+	assert.equal(fs.writes[0].path, join("/logs", "gh-x.json"));
+	assert.deepEqual(JSON.parse(fs.writes[0].data), record);
+});
+
+test("makeRecordWriter sanitizes the job id at the filename boundary only", () => {
+	const fs = makeFakeFs({ stream: makeFakeStream() });
+	const writeRecord = makeRecordWriter({ logsDir: "/logs", fs });
+
+	writeRecord({ jobId: "repeat:a:1", target: "o/r#5", outcome: "completed" });
+
+	assert.equal(basename(fs.writes[0].path), "repeat_a_1.json");
+	// The record body keeps the raw id; only the filename is sanitized.
+	assert.equal(JSON.parse(fs.writes[0].data).jobId, "repeat:a:1");
+});
+
+test("makeRecordWriter swallows an fs failure and logs jobId + reason with no record content", () => {
+	const logs = [];
+	const fs = makeFakeFs({ stream: makeFakeStream(), writeThrows: true });
+	const writeRecord = makeRecordWriter({ logsDir: "/logs", fs, log: (event, fields) => logs.push({ event, fields }) });
+
+	assert.doesNotThrow(() => writeRecord({ jobId: "gh-x", target: "o/r#5", outcome: "completed" }));
+
+	const failed = logs.find((l) => l.event === "run_record_failed");
+	assert.ok(failed, "an fs failure is reported, not thrown");
+	assert.equal(failed.fields.jobId, "gh-x");
+	assert.equal(typeof failed.fields.reason, "string");
+	const loggedKeys = Object.keys(failed.fields).sort();
+	assert.deepEqual(loggedKeys, ["jobId", "reason"]);
+	const loggedJson = JSON.stringify(failed.fields);
+	assert.ok(!loggedJson.includes("o/r#5"), "target must not leak into the failure log");
+	assert.ok(!loggedJson.includes("completed"), "outcome must not leak into the failure log");
+});
+
+test("makeRecordWriter swallows a JSON.stringify failure and never touches the fs", () => {
+	const logs = [];
+	const fs = makeFakeFs({ stream: makeFakeStream() });
+	const writeRecord = makeRecordWriter({ logsDir: "/logs", fs, log: (event, fields) => logs.push({ event, fields }) });
+	const circular = { jobId: "gh-circ", target: "o/r#5" };
+	circular.self = circular; // JSON.stringify throws on a circular reference
+
+	assert.doesNotThrow(() => writeRecord(circular));
+
+	assert.ok(logs.some((l) => l.event === "run_record_failed"), "a serialize failure is reported, not thrown");
+	assert.equal(fs.writes.length, 0, "no partial write reaches the fs when serialization fails");
+});
+
+test("makeRecordWriter overwrites on a re-run: two same-id writes are truncating writeFileSync, not append", () => {
+	const fs = makeFakeFs({ stream: makeFakeStream() });
+	const writeRecord = makeRecordWriter({ logsDir: "/logs", fs });
+
+	writeRecord({ jobId: "gh-x", target: "o/r#5", outcome: "failed", attempt: 0 });
+	writeRecord({ jobId: "gh-x", target: "o/r#5", outcome: "completed", attempt: 1 });
+
+	assert.equal(fs.writes.length, 2);
+	assert.equal(fs.writes[0].path, fs.writes[1].path); // same job id -> same sidecar, last write wins
+	assert.equal(fs.calls.createWriteStream, 0); // truncating writeFileSync, never an append stream
+	assert.equal(JSON.parse(fs.writes[1].data).outcome, "completed");
+});
+
+// A fixed clock so the reaper's cutoff is deterministic: day 1000, in ms.
+const NOW = 1000 * 86400000;
+
+test("makeLogReaper unlinks files older than the window and keeps newer ones, logging one reaped_log per unlink", () => {
+	const logs = [];
+	const fs = makeFakeFs({
+		stream: makeFakeStream(),
+		readdirNames: ["old.log", "old.json", "new.log", "new.json"],
+		stats: {
+			"old.log": { isFile: true, mtimeMs: 990 * 86400000 }, // < cutoff (993d) -> reaped
+			"old.json": { isFile: true, mtimeMs: 990 * 86400000 },
+			"new.log": { isFile: true, mtimeMs: 999 * 86400000 }, // > cutoff -> kept
+			"new.json": { isFile: true, mtimeMs: 999 * 86400000 },
+		},
+	});
+	const reapLogs = makeLogReaper({
+		logsDir: "/logs",
+		retentionDays: 7,
+		fs,
+		now: () => NOW,
+		log: (event, fields) => logs.push({ event, fields }),
+	});
+
+	assert.doesNotThrow(reapLogs);
+
+	assert.deepEqual(fs.unlinked.sort(), [join("/logs", "old.json"), join("/logs", "old.log")]);
+	const reaped = logs.filter((l) => l.event === "reaped_log").map((l) => l.fields.file).sort();
+	assert.deepEqual(reaped, ["old.json", "old.log"]);
+});
+
+test("makeLogReaper with retentionDays 0 keeps forever: nothing is read or unlinked", () => {
+	const fs = makeFakeFs({
+		stream: makeFakeStream(),
+		readdirNames: ["old.log"],
+		stats: { "old.log": { isFile: true, mtimeMs: 0 } },
+	});
+	const reapLogs = makeLogReaper({ logsDir: "/logs", retentionDays: 0, fs, now: () => NOW });
+
+	reapLogs();
+
+	assert.equal(fs.calls.readdir, 0); // keep-forever sentinel: the directory is never listed
+	assert.equal(fs.unlinked.length, 0);
+});
+
+test("makeLogReaper isolates a per-file failure: one statSync throw does not abort the sweep", () => {
+	const logs = [];
+	const fs = makeFakeFs({
+		stream: makeFakeStream(),
+		readdirNames: ["bad.log", "good.log"],
+		stats: {
+			"good.log": { isFile: true, mtimeMs: 990 * 86400000 },
+		},
+		statThrowsFor: ["bad.log"],
+	});
+	const reapLogs = makeLogReaper({
+		logsDir: "/logs",
+		retentionDays: 7,
+		fs,
+		now: () => NOW,
+		log: (event, fields) => logs.push({ event, fields }),
+	});
+
+	assert.doesNotThrow(reapLogs);
+
+	assert.deepEqual(fs.unlinked, [join("/logs", "good.log")]); // the sweep continued past the bad entry
+	const skipped = logs.find((l) => l.event === "log_reaper_skipped");
+	assert.equal(skipped.fields.file, "bad.log");
+});
+
+test("makeLogReaper does not throw and logs log_reaper_skipped when the logs dir is missing", () => {
+	const logs = [];
+	const fs = makeFakeFs({ stream: makeFakeStream(), readdirThrows: true });
+	const reapLogs = makeLogReaper({
+		logsDir: "/logs",
+		retentionDays: 7,
+		fs,
+		now: () => NOW,
+		log: (event, fields) => logs.push({ event, fields }),
+	});
+
+	assert.doesNotThrow(reapLogs);
+
+	assert.equal(fs.unlinked.length, 0);
+	assert.ok(logs.some((l) => l.event === "log_reaper_skipped"), "a missing dir is reported, not thrown");
+});
+
+test("makeLogReaper considers only .log/.json: other extensions are never statted or unlinked", () => {
+	const fs = makeFakeFs({
+		stream: makeFakeStream(),
+		readdirNames: ["notes.txt", "worker.out", "keep.log"],
+		stats: { "keep.log": { isFile: true, mtimeMs: 990 * 86400000 } },
+	});
+	const reapLogs = makeLogReaper({ logsDir: "/logs", retentionDays: 7, fs, now: () => NOW });
+
+	reapLogs();
+
+	const statted = fs.calls.stat.map((p) => basename(p));
+	assert.ok(!statted.includes("notes.txt"), "a non-matching extension is never statted");
+	assert.ok(!statted.includes("worker.out"), "a non-matching extension is never statted");
+	assert.deepEqual(fs.unlinked, [join("/logs", "keep.log")]); // only the .log was swept
+});
+
+test("makeLogReaper skips a directory entry: an aged name whose isFile() is false is not unlinked", () => {
+	const logs = [];
+	const fs = makeFakeFs({
+		stream: makeFakeStream(),
+		readdirNames: ["dir.log"],
+		stats: { "dir.log": { isFile: false, mtimeMs: 990 * 86400000 } }, // aged, but a directory
+	});
+	const reapLogs = makeLogReaper({
+		logsDir: "/logs",
+		retentionDays: 7,
+		fs,
+		now: () => NOW,
+		log: (event, fields) => logs.push({ event, fields }),
+	});
+
+	reapLogs();
+
+	assert.equal(fs.calls.stat.length, 1); // it was statted...
+	assert.equal(fs.unlinked.length, 0); // ...but the isFile() guard skipped the unlink
+	assert.ok(!logs.some((l) => l.event === "reaped_log"), "a directory is never reaped");
+});

--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -28,7 +28,7 @@ function fakeHost(overrides = {}) {
 // Drive startWorker with injected fakes and capture the exact object handed to createWorker
 // (deps are nested under `deps`). No real Redis: createWorkerFn is faked. The real ioredis client
 // startWorker constructs via makeRedisClient is torn down so it leaves no dangling handle.
-async function runStart({ env = {}, makeAuth, makeHost, makeReaper, order } = {}) {
+async function runStart({ env = {}, makeAuth, makeHost, makeReaper, makeLogSink, makeRecordWriter, makeLogReaper, order } = {}) {
 	const calls = [];
 	const registered = {};
 	const createWorkerFn = (arg) => {
@@ -47,6 +47,33 @@ async function runStart({ env = {}, makeAuth, makeHost, makeReaper, order } = {}
 	// inject their own.
 	const reaper = makeReaper ?? (() => async () => {});
 
+	// Default the run-history factories to inert fakes so the wiring tests never touch disk (the real
+	// factories mkdirSync/readdirSync at construction). Each default records the args it was constructed
+	// with so a test can assert config threading without a fs. A `logsDir`-only sentinel is fine here:
+	// runContainer is never invoked, so the returned openJobLog is stored and never called.
+	const openJobLogSentinel = () => ({ write() {}, close: async () => ({ turns: null }) });
+	const logSinkCalls = [];
+	const recordWriterCalls = [];
+	const logReaperCalls = [];
+	const logSink =
+		makeLogSink ??
+		((args) => {
+			logSinkCalls.push(args);
+			return openJobLogSentinel;
+		});
+	const recordWriter =
+		makeRecordWriter ??
+		((args) => {
+			recordWriterCalls.push(args);
+			return () => {};
+		});
+	const logReaper =
+		makeLogReaper ??
+		((args) => {
+			logReaperCalls.push(args);
+			return () => {};
+		});
+
 	const lines = [];
 	const origWrite = process.stdout.write;
 	process.stdout.write = (chunk) => {
@@ -54,7 +81,15 @@ async function runStart({ env = {}, makeAuth, makeHost, makeReaper, order } = {}
 		return true;
 	};
 	try {
-		await mod.startWorker(env, { makeAuth, makeHost, createWorkerFn, makeReaper: reaper });
+		await mod.startWorker(env, {
+			makeAuth,
+			makeHost,
+			createWorkerFn,
+			makeReaper: reaper,
+			makeLogSink: logSink,
+			makeRecordWriter: recordWriter,
+			makeLogReaper: logReaper,
+		});
 	} finally {
 		process.stdout.write = origWrite;
 	}
@@ -73,7 +108,7 @@ async function runStart({ env = {}, makeAuth, makeHost, makeReaper, order } = {}
 	});
 	// Expose the registration map under both names: `handlers` for the completed/failed handler tests,
 	// `registered` for the scheduler stall-guard test. Same object, one capture path.
-	return { captured, deps: captured?.deps, logs, handlers: registered, registered };
+	return { captured, deps: captured?.deps, logs, handlers: registered, registered, logSinkCalls, recordWriterCalls, logReaperCalls };
 }
 
 // Capture the JSON log lines a synchronous fn emits via process.stdout.write, then restore it.
@@ -221,4 +256,64 @@ test("cron wiring: a stalled listener is registered and schedules_installed prec
 	const startedIdx = logs.findIndex((l) => l.event === "worker_started");
 	assert.ok(startedIdx !== -1, "a worker_started log must be emitted");
 	assert.ok(installedIdx < startedIdx, "schedules_installed must be logged before worker_started");
+});
+
+// Run-history wiring (REQ-LOCAL-JOB-VISIBILITY). DEFAULT env => no live Valkey / disk required: the
+// harness injects inert run-history factories, so these assert the wiring, not the I/O.
+test("run-history: makeLogSink receives config.logsDir and the captureJobLogs gate (both polarities)", { skip }, async () => {
+	const makeAuth = async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" });
+
+	const on = await runStart({ env: { PI_LOGS_DIR: "/tmp/pi-logs", PI_CAPTURE_JOB_LOGS: "1" }, makeAuth, makeHost: () => fakeHost() });
+	assert.equal(on.logSinkCalls.length, 1, "makeLogSink must be constructed exactly once");
+	assert.equal(on.logSinkCalls[0].logsDir, "/tmp/pi-logs", "makeLogSink must receive the host-side config.logsDir");
+	assert.equal(on.logSinkCalls[0].enabled, true, "enabled must mirror captureJobLogs when PI_CAPTURE_JOB_LOGS=1");
+
+	// The record writer is always constructed against the same logsDir; the id-only record is not gated.
+	assert.equal(on.recordWriterCalls[0]?.logsDir, "/tmp/pi-logs", "makeRecordWriter must receive config.logsDir");
+
+	const off = await runStart({ env: { PI_LOGS_DIR: "/tmp/pi-logs" }, makeAuth, makeHost: () => fakeHost() });
+	assert.equal(off.logSinkCalls[0].enabled, false, "enabled must be false when PI_CAPTURE_JOB_LOGS is unset");
+});
+
+test("run-history: recordRun is passed to createWorker as a TOP-LEVEL arg, not nested under deps", { skip }, async () => {
+	const makeAuth = async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" });
+	const { captured } = await runStart({ makeAuth, makeHost: () => fakeHost() });
+	assert.equal(typeof captured.recordRun, "function", "recordRun must be a top-level createWorker arg");
+	assert.equal(captured.deps.recordRun, undefined, "recordRun must NOT be nested under deps");
+});
+
+test("run-history: the log reaper sweeps aged history BEFORE the worker starts draining", { skip }, async () => {
+	const order = [];
+	let reaperArgs;
+	const makeAuth = async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" });
+	const makeLogReaper = (args) => {
+		reaperArgs = args;
+		return () => {
+			order.push("reapLogs");
+		};
+	};
+	await runStart({
+		env: { PI_LOGS_DIR: "/tmp/pi-logs", PI_LOG_RETENTION_DAYS: "7" },
+		makeAuth,
+		makeHost: () => fakeHost(),
+		makeLogReaper,
+		order,
+	});
+	assert.deepEqual(order, ["reapLogs", "createWorker"], "the log reaper must sweep before the worker is created");
+	assert.equal(reaperArgs.logsDir, "/tmp/pi-logs", "the log reaper must receive config.logsDir");
+	assert.equal(reaperArgs.retentionDays, 7, "the log reaper must receive config.logRetentionDays");
+});
+
+test("run-history: worker_started announces logsDir, captureJobLogs and logRetentionDays (a path is not PII)", { skip }, async () => {
+	const makeAuth = async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" });
+	const { logs } = await runStart({
+		env: { PI_LOGS_DIR: "/tmp/pi-logs", PI_CAPTURE_JOB_LOGS: "1", PI_LOG_RETENTION_DAYS: "7" },
+		makeAuth,
+		makeHost: () => fakeHost(),
+	});
+	const started = logs.find((l) => l.event === "worker_started");
+	assert.ok(started, "a worker_started log must be emitted");
+	assert.equal(started.logsDir, "/tmp/pi-logs", "worker_started must announce where records land");
+	assert.equal(started.captureJobLogs, true, "worker_started must announce the raw-log capture gate");
+	assert.equal(started.logRetentionDays, 7, "worker_started must announce the retention window");
 });

--- a/worker/test/wiring.test.mjs
+++ b/worker/test/wiring.test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { test } from "node:test";
+// processor.mjs pulls in no bullmq, so this import is safe below the node floor where index.mjs skips.
+import { InfraRetry } from "../src/processor.mjs";
+// run-history.mjs pulls in only node:fs/node:path -- safe below the node floor alongside processor.mjs.
+import { buildRecord, makeRecordWriter } from "../src/run-history.mjs";
 
 // index.mjs imports bullmq, so this skips below the node floor / without deps and runs in CI,
 // where PI_DISPATCH_REQUIRE_WORKER_TESTS=1 turns a skip into a hard failure.
@@ -44,6 +49,7 @@ test("the processor declares arity 3 -- the silent trap that would disable the t
 		redis: {},
 		cap: 10,
 		deps: {},
+		recordRun: () => {},
 	});
 	assert.equal(processor.length, 3, "processor must declare (job, token, signal) or the abort dies");
 });
@@ -136,4 +142,248 @@ test("shutdown closes each extraCloser after the worker drains", { skip }, async
 		for (const l of process.listeners("SIGINT")) if (!beforeInt.has(l)) process.removeListener("SIGINT", l);
 		await Promise.resolve(worker?.close()).catch(() => {});
 	}
+});
+
+// The full BullMQ job object the processor hands to recordRun -- id/attemptsMade/name/data are the
+// fields buildRecord (start.mjs) reads, so recordRun must receive `job`, not `job.data`.
+const fakeJob = () => ({ id: "j1", attemptsMade: 0, name: "github", data: { kind: "github", repo: "o/r", issueNumber: 1, flow: "fix" } });
+const isoRoundtrips = (s) => typeof s === "string" && new Date(s).toISOString() === s;
+
+test("recordRun fires once on the SUCCESS (return) path with { job, result, startedAt, endedAt }", { skip }, async () => {
+	const calls = [];
+	const job = fakeJob();
+	const processor = mod.makeProcessor({
+		cancelJob: () => {},
+		stopContainer: () => {},
+		redis: { async incr() { return 1; }, async expire() {} },
+		cap: 10,
+		timeoutMs: 100000,
+		recordRun: (rec) => calls.push(rec),
+		deps: {
+			mintToken: async () => "t",
+			isDefaultBranchProtected: async () => true,
+			prepareWorkspace: async () => ({}),
+			runContainer: async () => ({ code: 0, aborted: false, turns: 3 }),
+			cleanup: async () => {},
+			comment: async () => {},
+		},
+	});
+
+	const result = await processor(job, "tok", new AbortController().signal);
+
+	assert.equal(calls.length, 1, "recordRun must fire exactly once");
+	const rec = calls[0];
+	assert.equal(rec.job, job, "recordRun receives the FULL job object, not job.data");
+	assert.equal(rec.result, result, "recordRun.result is the runJob return value");
+	assert.equal(rec.result.outcome, "completed");
+	assert.equal(rec.error, undefined, "no error on the success path");
+	assert.ok(isoRoundtrips(rec.startedAt), "startedAt is an ISO string");
+	assert.ok(isoRoundtrips(rec.endedAt), "endedAt is an ISO string");
+});
+
+test("recordRun fires with { job, error } BEFORE an UnrecoverableError propagates (non-infra throw)", { skip }, async () => {
+	const calls = [];
+	const job = fakeJob();
+	const boom = new Error("container boom");
+	const processor = mod.makeProcessor({
+		cancelJob: () => {},
+		stopContainer: () => {},
+		redis: { async incr() { return 1; }, async expire() {} },
+		cap: 10,
+		timeoutMs: 100000,
+		recordRun: (rec) => calls.push(rec),
+		deps: {
+			mintToken: async () => "t",
+			isDefaultBranchProtected: async () => true,
+			prepareWorkspace: async () => ({}),
+			runContainer: async () => { throw boom; },
+			cleanup: async () => {},
+			comment: async () => {},
+		},
+	});
+
+	await assert.rejects(
+		() => processor(job, "tok", new AbortController().signal),
+		(e) => e.name === "UnrecoverableError",
+		"a non-infra throw must surface as UnrecoverableError (no retry)",
+	);
+	assert.equal(calls.length, 1, "recordRun must fire before the throw propagates");
+	const rec = calls[0];
+	assert.equal(rec.job, job);
+	assert.equal(rec.error, boom, "recordRun.error is the original thrown error, pre-wrap");
+	assert.equal(rec.result, undefined, "no result on the throw path");
+	assert.ok(isoRoundtrips(rec.startedAt) && isoRoundtrips(rec.endedAt), "both timestamps are ISO strings");
+});
+
+test("recordRun fires and the InfraRetry still propagates (retryable, not UnrecoverableError)", { skip }, async () => {
+	const calls = [];
+	const job = fakeJob();
+	const processor = mod.makeProcessor({
+		cancelJob: () => {},
+		stopContainer: () => {},
+		redis: { async incr() { return 1; }, async expire() {}, async decr() {} },
+		cap: 10,
+		timeoutMs: 100000,
+		recordRun: (rec) => calls.push(rec),
+		deps: {
+			mintToken: async () => "t",
+			isDefaultBranchProtected: async () => true,
+			prepareWorkspace: async () => ({}),
+			// exit 1 => runJob throws InfraRetry; the processor must rethrow it unwrapped so BullMQ retries.
+			runContainer: async () => ({ code: 1, aborted: false, turns: 2 }),
+			cleanup: async () => {},
+			comment: async () => {},
+		},
+	});
+
+	await assert.rejects(
+		() => processor(job, "tok", new AbortController().signal),
+		(e) => e instanceof InfraRetry,
+		"an InfraRetry must propagate unwrapped (retryable), never become UnrecoverableError",
+	);
+	assert.equal(calls.length, 1, "recordRun must fire on the infra-retry path too");
+	assert.equal(calls[0].job, job);
+	assert.ok(calls[0].error instanceof InfraRetry, "recordRun.error is the InfraRetry");
+});
+
+// End-to-end money-path acceptance: compose the REAL recordRun = writeRecord(buildRecord(...)) over a
+// fake fs and drive makeProcessor per outcome, asserting the SERIALIZED bytes. This is the only place
+// the whole record path (processor wrapper -> buildRecord -> writeRecord) is exercised end-to-end, so
+// it is where "the record path never breaks the retry contract" is actually proven, not asserted piece
+// by piece. writeThrows models a real ENOSPC/EACCES from writeFileSync so (c)/(c2) exercise the
+// never-throw writer THROUGH makeProcessor, not a stub of it.
+function makeRealRecordRun({ writeThrows = false } = {}) {
+	const writes = [];
+	const fakeFs = {
+		mkdirSync: () => {},
+		writeFileSync: (path, data) => {
+			if (writeThrows) throw new Error("ENOSPC");
+			writes.push({ path, data });
+		},
+	};
+	const writeRecord = makeRecordWriter({ logsDir: "/logs", fs: fakeFs, log: () => {} });
+	const recordRun = (a) => writeRecord(buildRecord(a));
+	return { recordRun, writes };
+}
+
+// The full BullMQ job wrapper carrying user-authored PII (title/body) the record must never serialise.
+const secretJob = (id = "j1") => ({
+	id,
+	attemptsMade: 0,
+	name: "github",
+	data: { kind: "github", repo: "o/r", issueNumber: 1, flow: "fix", title: "SECRET_T", body: "SECRET_B" },
+});
+
+// A processor wired to the real recordRun. `runContainer`/`redis` are overridable so the infra-exit
+// paths (b)/(c2) reuse the same construction with a different container exit.
+function realRecordProcessor(recordRun, { runContainer, redis } = {}) {
+	return mod.makeProcessor({
+		cancelJob: () => {},
+		stopContainer: () => {},
+		redis: redis ?? { async incr() { return 1; }, async expire() {}, async decr() {} },
+		cap: 10,
+		timeoutMs: 100000,
+		recordRun,
+		deps: {
+			mintToken: async () => "t",
+			isDefaultBranchProtected: async () => true,
+			prepareWorkspace: async () => ({}),
+			runContainer: runContainer ?? (async () => ({ code: 0, aborted: false, turns: 3 })),
+			cleanup: async () => {},
+			comment: async () => {},
+			log: () => {},
+		},
+	});
+}
+
+test("(a) completed run: real writer serialises a PII-free record to <jobId>.json", { skip }, async () => {
+	const { recordRun, writes } = makeRealRecordRun();
+	const job = secretJob("j1");
+	const processor = realRecordProcessor(recordRun);
+
+	await processor(job, "tok", new AbortController().signal);
+
+	assert.equal(writes.length, 1, "exactly one record is written on the success path");
+	assert.equal(writes[0].path, join("/logs", "j1.json"), "path is the sanitized <jobId>.json under logsDir");
+	const rec = JSON.parse(writes[0].data);
+	assert.equal(rec.outcome, "completed");
+	assert.equal(rec.target, "o/r#1", "GitHub target is repo#issue, never the payload text");
+	assert.equal(rec.exitCode, 0);
+	assert.equal(rec.turns, 3);
+	assert.equal(rec.budgetReserved, true);
+	// buildRecord reads only stable non-PII fields, so the serialized bytes carry neither title nor body.
+	assert.equal(writes[0].data.includes("SECRET_T"), false, "issue title must not leak into the record bytes");
+	assert.equal(writes[0].data.includes("SECRET_B"), false, "issue body must not leak into the record bytes");
+});
+
+test("(b) infra exit 1: a failed record is written on the catch path BEFORE InfraRetry rethrows", { skip }, async () => {
+	const { recordRun, writes } = makeRealRecordRun();
+	const job = secretJob("j1");
+	const processor = realRecordProcessor(recordRun, { runContainer: async () => ({ code: 1, aborted: false, turns: 2 }) });
+
+	await assert.rejects(
+		() => processor(job, "tok", new AbortController().signal),
+		(e) => e.name === "InfraRetry",
+		"exit 1 must surface as the retryable InfraRetry",
+	);
+	assert.equal(writes.length, 1, "the record is written before the rethrow");
+	const rec = JSON.parse(writes[0].data);
+	assert.equal(rec.outcome, "failed", "the error path records outcome=failed");
+	assert.equal(rec.exitCode, 1);
+});
+
+test("(c) try-path writer failure NEVER converts a completed run into a failure/retry", { skip }, async () => {
+	const { recordRun, writes } = makeRealRecordRun({ writeThrows: true });
+	const job = secretJob("j1");
+	const processor = realRecordProcessor(recordRun);
+
+	// A throwing writer on the success path must be swallowed by writeRecord: no throw, no
+	// UnrecoverableError, and the processor resolves to the same completed result a healthy run yields.
+	const result = await processor(job, "tok", new AbortController().signal);
+
+	assert.equal(result.outcome, "completed");
+	assert.equal(result.exitCode, 0);
+	assert.equal(result.turns, 3);
+	assert.equal(result.budgetReserved, true);
+	assert.equal(writes.length, 0, "the throwing writer recorded nothing");
+});
+
+test("(c2) catch-path writer failure still propagates the retryable InfraRetry unswallowed", { skip }, async () => {
+	const { recordRun, writes } = makeRealRecordRun({ writeThrows: true });
+	const job = secretJob("j1");
+	const processor = realRecordProcessor(recordRun, { runContainer: async () => ({ code: 1, aborted: false, turns: 2 }) });
+
+	await assert.rejects(
+		() => processor(job, "tok", new AbortController().signal),
+		(e) => e.name === "InfraRetry",
+		"a writer failure on the catch path must not swallow the retryable error",
+	);
+	assert.equal(writes.length, 0, "the throwing writer recorded nothing");
+});
+
+test("(d) a colon-bearing scheduled id sanitizes in the filename but stays raw in the body", { skip }, async () => {
+	const { recordRun, writes } = makeRealRecordRun();
+	const job = secretJob("repeat:sched:123");
+	const processor = realRecordProcessor(recordRun);
+
+	await processor(job, "tok", new AbortController().signal);
+
+	assert.equal(writes[0].path, join("/logs", "repeat_sched_123.json"), "colon (illegal on NTFS) collapses to _ in the filename");
+	assert.equal(JSON.parse(writes[0].data).jobId, "repeat:sched:123", "the record body keeps the raw id");
+});
+
+test("(e) a burst of distinct ids writes one distinct file each through the same writer", { skip }, async () => {
+	const { recordRun, writes } = makeRealRecordRun();
+	const processor = realRecordProcessor(recordRun);
+
+	for (const id of ["j1", "j2", "j3"]) {
+		await processor(secretJob(id), "tok", new AbortController().signal);
+	}
+
+	assert.equal(writes.length, 3, "one record per job, none dropped or collided");
+	const paths = writes.map((w) => w.path);
+	assert.equal(new Set(paths).size, 3, "the three paths are distinct");
+	assert.ok(paths.includes(join("/logs", "j1.json")));
+	assert.ok(paths.includes(join("/logs", "j2.json")));
+	assert.ok(paths.includes(join("/logs", "j3.json")));
 });


### PR DESCRIPTION
Durable per-job **run history + logs** — the read-model layer a future admin panel reads (issue #4). Each job reaching a terminal state now persists a PII-free, id-keyed status record (`logs/<jobId>.json`) via a synchronous write that beats the shutdown race; when `PI_CAPTURE_JOB_LOGS=1` (opt-in, off by default) the container's raw output is also tee'd to `logs/<jobId>.log`. No new database — a flat `node:fs` sidecar keyed by job id, with a boot-time age sweep (`PI_LOG_RETENTION_DAYS`) for retention. All host-side, never mounted into the container; the raw log is gitignored.

The record captures what BullMQ's retained job cannot: `exitCode`, `turns` (parsed from the runner's `exit` stdout line), and `budgetReserved` — for every terminal outcome (completed / policy / infra-failure). The log/record path is money-path-adjacent, so it is fault-isolated end-to-end: a throwing or rejecting sink/writer can neither hang nor crash the run and **never** changes the throw-vs-return retry classification (proven by the load-bearing acceptance tests) — no double-spend, no lost retry. `{code, aborted}` and the reserve-before-container order are byte-identical.

New specs: `REQ-DURABLE-RUN-HISTORY`, `INT-RUN-HISTORY-FILE-CONTRACT`, `DES-RUN-HISTORY-FLAT-FILES-NO-DB`, and `OQ-007` (periodic-sweep retention, left OPEN).

## Verification
| Check | Baseline | Final |
|-------|----------|-------|
| test (node --test, whole workspace) | 311 pass / 0 fail / 15 skipped | **375 pass / 0 fail / 15 skipped** (+64 tests) |
| lint / typecheck | none configured (0) | none configured (0) |
| Legacy/dead-code sweep | — | PASS (no add-alongside; every export consumed) |
| Container Smoke (image) | — | **PASS** — image built (multi-arch); pi pinned exact `0.80.7`; runner tests 58/58 incl. new `turns` contract test |
| Webhook (receiver) | — | N/A (receiver untouched) |
| Queue Verification (worker) | — | **PASS** — offline deterministic matrix (drain path untouched); 93/93; money-path invariants confirmed |
| Spec drift | exit 0 | exit 0 (no new drift) |

Container one-job E2E was skipped (no provider key in the runner environment — optional per the plan).

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
