### PR TITLE
docs(readme): admin extension screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ session — no daemon, no web app, **no network port at all**. Load it with `pi 
 this checkout, add that path to the `"extensions"` array in `~/.pi/agent/settings.json`, or just run pi
 inside this checkout: the in-repo `.pi/extensions` shim auto-loads once you've trusted the project.
 
+Bare `/dispatch` opens a live dashboard overlay — one snapshot per second, `p`/`r` to pause/resume the
+queue in place:
+
+![The /dispatch dashboard overlay: queue state, budget, recent runs, schedulers with next-fire drift, and the settings overlay in one live TUI panel](docs/images/dispatch-dashboard.svg)
+
 It adds `/dispatch` commands that run **locally, with no model involvement**:
 
 - `status` — queue counts, paused state, budget; `budget` — today's spend against the daily cap
@@ -166,6 +171,8 @@ It adds `/dispatch` commands that run **locally, with no model involvement**:
 - `runs` / `logs` — recent run records, and one run's raw log
 - `triggers` — the configured triggers (display only)
 - `settings` / `set <key> <value>` / `unset <key>` — the runtime overlay
+
+![Transcript of /dispatch status, /dispatch runs and /dispatch triggers output in a pi session](docs/images/dispatch-commands.svg)
 
 `/dispatch pause|resume|status` are a second interface over the **same durable switch** as
 `pi-dispatch pause|resume|status` (see **Steer the running worker** above), not a new mechanism; `runs`

--- a/docs/images/dispatch-commands.svg
+++ b/docs/images/dispatch-commands.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1057 461" width="1057" height="461" role="img" aria-label="pi — /dispatch commands">
+  <rect width="1057" height="461" rx="10" fill="#0d1117" stroke="#30363d"/>
+  <rect width="1057" height="34" rx="10" fill="#161b22"/>
+  <rect y="24" width="1057" height="10" fill="#161b22"/>
+  <circle cx="20" cy="17" r="6" fill="#ff5f57"/>
+  <circle cx="42" cy="17" r="6" fill="#febc2e"/>
+  <circle cx="64" cy="17" r="6" fill="#28c840"/>
+  <text x="528.5" y="21" text-anchor="middle" fill="#8b949e" font-size="12" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">pi — /dispatch commands</text>
+  <g font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">
+  <text x="18" y="62.3" fill="#7ee787" xml:space="preserve">&gt; /dispatch status</text>
+  <text x="18" y="81.3" fill="#7ee787" xml:space="preserve">Queue: running</text>
+  <text x="18" y="100.3" fill="#c9d1d9" xml:space="preserve">  waiting 2  active 1  paused 0  delayed 0  failed 1</text>
+  <text x="18" y="119.3" fill="#c9d1d9" xml:space="preserve">  workers: 1</text>
+  <text x="18" y="138.3" fill="#79c0ff" xml:space="preserve">Budget: reserved 7 / cap 25 (overlay)</text>
+  <text x="18" y="157.3" fill="#c9d1d9" xml:space="preserve"></text>
+  <text x="18" y="176.3" fill="#7ee787" xml:space="preserve">&gt; /dispatch runs 4</text>
+  <text x="18" y="195.3" fill="#79c0ff" xml:space="preserve">JOB ID                                   TARGET              FLOW          OUTCOME    REASON       TURNS  ENDED</text>
+  <text x="18" y="214.3" fill="#c9d1d9" xml:space="preserve">gh-8f2e41d0-6c9a-4b7e-9d3f-2a1b0c9d8e7f  edgehero/my-app#42  backend-fix   completed  -            14     2026-07-22T09:41:03.512Z</text>
+  <text x="18" y="233.3" fill="#c9d1d9" xml:space="preserve">repeat:nightly-tidy:1784972800000        local:my-app        tidy          completed  -            9      2026-07-22T03:00:41.007Z</text>
+  <text x="18" y="252.3" fill="#c9d1d9" xml:space="preserve">gh-1b7c9a52-40de-4f11-8f6a-c3d2e1f0a9b8  edgehero/my-app#41  frontend-fix  policy     over-budget  -      2026-07-21T22:18:59.310Z</text>
+  <text x="18" y="271.3" fill="#c9d1d9" xml:space="preserve">local-3f9d2c                             local:side-project  tidy          failed     -            27     2026-07-21T20:02:17.845Z</text>
+  <text x="18" y="290.3" fill="#c9d1d9" xml:space="preserve"></text>
+  <text x="18" y="309.3" fill="#7ee787" xml:space="preserve">&gt; /dispatch triggers</text>
+  <text x="18" y="328.3" fill="#79c0ff" xml:space="preserve">Schedulers:</text>
+  <text x="18" y="347.3" fill="#c9d1d9" xml:space="preserve">  repeat:nightly-tidy  next 2026-07-23T03:00:00.000Z</text>
+  <text x="18" y="366.3" fill="#f0b72f" xml:space="preserve">  repeat:weekly-deps  next 2026-07-22T09:58:25.000Z  overdue by 95s</text>
+  <text x="18" y="385.3" fill="#c9d1d9" xml:space="preserve"></text>
+  <text x="18" y="404.3" fill="#79c0ff" xml:space="preserve">Label -&gt; flow:</text>
+  <text x="18" y="423.3" fill="#c9d1d9" xml:space="preserve">  pi:frontend -&gt; frontend-fix</text>
+  <text x="18" y="442.3" fill="#c9d1d9" xml:space="preserve">  pi:backend -&gt; backend-fix</text>
+  </g>
+</svg>

--- a/docs/images/dispatch-dashboard.svg
+++ b/docs/images/dispatch-dashboard.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1057 556" width="1057" height="556" role="img" aria-label="pi — /dispatch dashboard (live overlay)">
+  <rect width="1057" height="556" rx="10" fill="#0d1117" stroke="#30363d"/>
+  <rect width="1057" height="34" rx="10" fill="#161b22"/>
+  <rect y="24" width="1057" height="10" fill="#161b22"/>
+  <circle cx="20" cy="17" r="6" fill="#ff5f57"/>
+  <circle cx="42" cy="17" r="6" fill="#febc2e"/>
+  <circle cx="64" cy="17" r="6" fill="#28c840"/>
+  <text x="528.5" y="21" text-anchor="middle" fill="#8b949e" font-size="12" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">pi — /dispatch dashboard (live overlay)</text>
+  <g font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">
+  <text x="18" y="62.3" fill="#79c0ff" xml:space="preserve">pi-dispatch dashboard</text>
+  <text x="18" y="81.3" fill="#c9d1d9" xml:space="preserve"></text>
+  <text x="18" y="100.3" fill="#7ee787" xml:space="preserve">Queue: running</text>
+  <text x="18" y="119.3" fill="#c9d1d9" xml:space="preserve">  waiting 2  active 1  paused 0  delayed 0  failed 1</text>
+  <text x="18" y="138.3" fill="#c9d1d9" xml:space="preserve">  workers: 1</text>
+  <text x="18" y="157.3" fill="#c9d1d9" xml:space="preserve"></text>
+  <text x="18" y="176.3" fill="#79c0ff" xml:space="preserve">Budget: reserved 7 / cap 25 (overlay)</text>
+  <text x="18" y="195.3" fill="#c9d1d9" xml:space="preserve"></text>
+  <text x="18" y="214.3" fill="#79c0ff" xml:space="preserve">JOB ID                                   TARGET              FLOW          OUTCOME    REASON       TURNS  ENDED</text>
+  <text x="18" y="233.3" fill="#c9d1d9" xml:space="preserve">gh-8f2e41d0-6c9a-4b7e-9d3f-2a1b0c9d8e7f  edgehero/my-app#42  backend-fix   completed  -            14     2026-07-22T09:41:03.512Z</text>
+  <text x="18" y="252.3" fill="#c9d1d9" xml:space="preserve">repeat:nightly-tidy:1784972800000        local:my-app        tidy          completed  -            9      2026-07-22T03:00:41.007Z</text>
+  <text x="18" y="271.3" fill="#c9d1d9" xml:space="preserve">gh-1b7c9a52-40de-4f11-8f6a-c3d2e1f0a9b8  edgehero/my-app#41  frontend-fix  policy     over-budget  -      2026-07-21T22:18:59.310Z</text>
+  <text x="18" y="290.3" fill="#c9d1d9" xml:space="preserve">local-3f9d2c                             local:side-project  tidy          failed     -            27     2026-07-21T20:02:17.845Z</text>
+  <text x="18" y="309.3" fill="#c9d1d9" xml:space="preserve"></text>
+  <text x="18" y="328.3" fill="#79c0ff" xml:space="preserve">Schedulers:</text>
+  <text x="18" y="347.3" fill="#c9d1d9" xml:space="preserve">  repeat:nightly-tidy  next 2026-07-23T03:00:00.000Z</text>
+  <text x="18" y="366.3" fill="#f0b72f" xml:space="preserve">  repeat:weekly-deps  next 2026-07-22T09:58:25.000Z  overdue by 95s</text>
+  <text x="18" y="385.3" fill="#c9d1d9" xml:space="preserve"></text>
+  <text x="18" y="404.3" fill="#79c0ff" xml:space="preserve">Settings (/tmp/pi-dispatch/settings.json):</text>
+  <text x="18" y="423.3" fill="#c9d1d9" xml:space="preserve">  model: claude-sonnet-4-5-20250929</text>
+  <text x="18" y="442.3" fill="#c9d1d9" xml:space="preserve">  provider: (unset)</text>
+  <text x="18" y="461.3" fill="#c9d1d9" xml:space="preserve">  maxTurns: (unset)</text>
+  <text x="18" y="480.3" fill="#c9d1d9" xml:space="preserve">  dailyCap: 25</text>
+  <text x="18" y="499.3" fill="#c9d1d9" xml:space="preserve">  concurrency: (unset)</text>
+  <text x="18" y="518.3" fill="#c9d1d9" xml:space="preserve"></text>
+  <text x="18" y="537.3" fill="#8b949e" xml:space="preserve">[p]ause  [r]esume  [q]uit</text>
+  </g>
+</svg>


### PR DESCRIPTION
Adds two images to the README's Admin section: the live `/dispatch` dashboard overlay and a transcript of `/dispatch status` / `runs` / `triggers`.

These are SVG terminal renders whose text is generated by the **real** admin renderers — the dashboard image is the actual `makeDashboard` component's `render()` output against fixture data (loaded through pi's own jiti, same as the tests), and the transcript is `renderStatus`/`renderRuns`/`renderTriggers` verbatim. Only the terminal chrome is drawn; the content cannot drift from what the extension shows without the generator being re-run.

Docs-only: README.md + 2 new files under `docs/images/`. Suite untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3npQvQXLWsW6qsrRMAmNL