### PR TITLE
Admin dashboard redesign: framed panel, unified TRIGGERS pane, run drill-ins + live-tail

### DIFF
--- a/admin/src/dashboard.ts
+++ b/admin/src/dashboard.ts
@@ -8,9 +8,15 @@
  * renders the last one, so a slow or unreachable queue degrades the panel rather than freezing it. A
  * fetch already in flight suppresses the next tick's fetch, so a stall cannot stack overlapping reads.
  *
- * PII discipline (no-pii-in-logs, INT-RUN-HISTORY-FILE-CONTRACT): the panel shows PII-free run records,
- * counts, budget, schedulers and the settings overlay only. Raw `.log` bytes are never read here -- that
- * surface belongs to the logs overlay viewer in index.ts alone.
+ * Three in-component views share this one overlay: LIST -- a framed monochrome panel of status, spend,
+ * the unified TRIGGERS pane and an interactive runs list; RUN_DETAIL -- a drill-in of one run's PII-free
+ * `.json` fields; and LIVE_TAIL -- a tail of a running job's `.log`.
+ *
+ * PII discipline (no-pii-in-logs, INT-RUN-HISTORY-FILE-CONTRACT): LIST and RUN_DETAIL surface only
+ * PII-free run records, counts, budget, schedulers and the settings overlay. LIVE_TAIL renders tail bytes
+ * obtained through the injected `tailLog` seam whose `fs` access lives in index.ts, so this module never
+ * touches the filesystem -- the bytes reach the overlay alone, never `snapshot`, never a shared renderer,
+ * never a message.
  */
 import { dayKey } from "@pi-dispatch/worker/budget";
 import { parseConnection, makeRedisClient } from "@pi-dispatch/worker/connection";

--- a/admin/src/dashboard.ts
+++ b/admin/src/dashboard.ts
@@ -23,6 +23,9 @@ import { box, meter, clip } from "./panel.mjs";
 const KEY_HINTS = "[p]ause  [r]esume  [q]uit";
 const RUNS_ON_DASHBOARD = 10;
 const REFRESH_MS = 1000;
+// Lines requested per tail fetch, and the on-screen window of them the LIVE_TAIL view scrolls through.
+const TAIL_LINES = 200;
+const TAIL_VIEWPORT = 20;
 // panel.mjs floors a box to this width; below it (or a missing/non-finite width) the panel degrades to
 // unframed plain lines rather than a ragged or over-width frame.
 const MIN_WIDTH = 8;
@@ -99,16 +102,28 @@ export function makeDashboard({
   let disposed = false;
   let interval: any = null;
   // In-component view machine: LIST is the framed panel with the interactive run list; RUN_DETAIL is the
-  // single-record dump. `selected` is the list cursor; `detailRun` is the record captured on Enter.
+  // single-record dump; LIVE_TAIL tails a running job's `.log` inside the overlay. `selected` is the list
+  // cursor; `detailRun` is the record captured on Enter.
   let view = "LIST";
   let selected = 0;
   let detailRun: any = null;
+  // LIVE_TAIL state, held here in dedicated component fields keyed only by the id-only `activeJobId`. The
+  // raw `.log` bytes in `tail` are PII-bearing and untrusted: they live here and reach the TUI overlay via
+  // render() alone -- never `snapshot`, never a shared renderer, never `sendMessage` (INT-RUN-HISTORY-FILE-CONTRACT).
+  let tailJobId: any = null;
+  let tail: any = null;
+  let tailTop = 0;
 
   const refresh = async () => {
     if (fetching || disposed) return;
     fetching = true;
     try {
       snapshot = await deps.fetchSnapshot();
+      // Only while the tail view is open, and only through the injected capability, re-read the tail keyed
+      // by the id-only `tailJobId`. `await` unwraps a synchronous return too. The bytes stay in `tail`.
+      if (view === "LIVE_TAIL" && tailJobId && deps.tailLog) {
+        tail = await deps.tailLog({ jobId: tailJobId, lines: TAIL_LINES });
+      }
     } catch (err: any) {
       snapshot = { unreachable: err?.message ?? String(err) };
     } finally {
@@ -145,11 +160,25 @@ export function makeDashboard({
 
   const component = {
     render(width: number): string[] {
-      // Clamp the cursor here so a snapshot whose runs list shrank between ticks can never leave `selected`
-      // pointing past the end.
-      const runsLen = snapshot?.runs?.length ?? 0;
-      if (selected > runsLen - 1) selected = Math.max(0, runsLen - 1);
-      return renderPanel(snapshot, width, view, selected, detailRun);
+      // Clamp the cursor here so a rows list that shrank between ticks can never leave `selected` pointing
+      // past the end. `rows` spans the optional ACTIVE row plus the run records.
+      const rows = buildRows(snapshot);
+      if (selected > rows.length - 1) selected = Math.max(0, rows.length - 1);
+      // Clamp the tail scroll so a shrinking log can never scroll past the end.
+      if (view === "LIVE_TAIL") {
+        const len = Array.isArray(tail?.lines) ? tail.lines.length : 0;
+        const maxTop = Math.max(0, len - TAIL_VIEWPORT);
+        tailTop = Math.min(Math.max(0, tailTop), maxTop);
+      }
+      return renderPanel(snapshot, width, {
+        view,
+        selected,
+        detailRun,
+        tailJobId,
+        tail,
+        tailTop,
+        tailAvailable: typeof deps?.tailLog === "function",
+      });
     },
     invalidate(): void {
       // No cached render state to clear; the TUI redraws from render().
@@ -164,13 +193,50 @@ export function makeDashboard({
         }
         return;
       }
+      if (view === "LIVE_TAIL") {
+        // Escape backs out to the list and drops the held tail bytes; scroll keys move the window. Every
+        // other key is inert. This view never closes the overlay or disposes the held clients.
+        if (matchesKey(data, "escape")) {
+          view = "LIST";
+          tailJobId = null;
+          tail = null;
+          tailTop = 0;
+          tui?.requestRender?.();
+          return;
+        }
+        const len = Array.isArray(tail?.lines) ? tail.lines.length : 0;
+        const maxTop = Math.max(0, len - TAIL_VIEWPORT);
+        if (matchesKey(data, "up")) {
+          tailTop = Math.max(0, tailTop - 1);
+          tui?.requestRender?.();
+        } else if (matchesKey(data, "down")) {
+          tailTop = Math.min(maxTop, tailTop + 1);
+          tui?.requestRender?.();
+        } else if (matchesKey(data, "pageUp")) {
+          tailTop = Math.max(0, tailTop - TAIL_VIEWPORT);
+          tui?.requestRender?.();
+        } else if (matchesKey(data, "pageDown")) {
+          tailTop = Math.min(maxTop, tailTop + TAIL_VIEWPORT);
+          tui?.requestRender?.();
+        }
+        return;
+      }
       if (matchesKey(data, "escape") || data === "q" || data === "Q") {
         void dispose().finally(() => done(undefined));
         return;
       }
       if (data === "\r" || data === "\n") {
-        if (snapshot?.runs?.length) {
-          detailRun = snapshot.runs[selected];
+        const rows = buildRows(snapshot);
+        const row = rows[selected];
+        if (!row) return;
+        if (row.kind === "active") {
+          // Opening the tail: fire an immediate fetch so the first frame carries the tail, not the next tick.
+          tailJobId = row.jobId;
+          tailTop = 0;
+          view = "LIVE_TAIL";
+          void refresh();
+        } else {
+          detailRun = row.record;
           view = "RUN_DETAIL";
           tui?.requestRender?.();
         }
@@ -182,7 +248,7 @@ export function makeDashboard({
         return;
       }
       if (matchesKey(data, "down")) {
-        selected = Math.min((snapshot?.runs?.length ?? 1) - 1, selected + 1);
+        selected = Math.min(Math.max(0, buildRows(snapshot).length - 1), selected + 1);
         tui?.requestRender?.();
         return;
       }
@@ -211,7 +277,8 @@ function toLines(text: string): string[] {
  * that is missing, non-finite, or below `MIN_WIDTH` degrades to unframed plain lines; a sane width frames
  * the same content with `box`, its inner column count driving every meter and clip.
  */
-function renderPanel(snapshot: any, width: number, view: string, selected: number, detailRun: any): string[] {
+function renderPanel(snapshot: any, width: number, state: any): string[] {
+  const { view, selected, detailRun, tailJobId, tail, tailTop, tailAvailable } = state;
   const framed = Number.isFinite(width) && Math.trunc(width) >= MIN_WIDTH;
   const inner = Math.trunc(width) - 4;
   const title = "pi-dispatch";
@@ -221,6 +288,10 @@ function renderPanel(snapshot: any, width: number, view: string, selected: numbe
     const detailLines = renderRunDetail(detailRun);
     if (!framed) return [detailTitle, "", ...detailLines, "", "Esc back"];
     return box({ title: detailTitle, footer: "Esc back", width, sections: [{ lines: detailLines }] });
+  }
+
+  if (view === "LIVE_TAIL") {
+    return renderLiveTail({ snapshot, framed, width, tailJobId, tail, tailTop, tailAvailable });
   }
 
   if (snapshot === null) {
@@ -243,7 +314,7 @@ function renderPanel(snapshot: any, width: number, view: string, selected: numbe
       ],
     },
     { title: "TRIGGERS", lines: toLines(renderTriggers({ schedulers: snapshot.schedulers, flows: snapshot.flows })) },
-    { title: "RUNS", lines: renderRunList(snapshot.runs, selected, framed ? inner : 24) },
+    { title: "RUNS", lines: renderRunList(buildRows(snapshot), selected, framed ? inner : 24) },
     { title: "SETTINGS", lines: toLines(renderSettingsView(snapshot.settings)) },
   ];
 
@@ -256,20 +327,65 @@ function renderPanel(snapshot: any, width: number, view: string, selected: numbe
 }
 
 /**
- * The interactive RUNS list: one compact row per record, cursor-prefixed (`›` on the selected row, space
- * otherwise) with `jobId` leading so a jobId match still hits. Each row is `clip`ped to the inner column
- * count so a long target can neither overflow the frame nor mis-size a row. Operates only on the passed
- * records -- no read, no `.log`, no `.data`.
+ * The selectable LIST rows: the optional ACTIVE row first (present only when the snapshot carries an
+ * id-only `activeJobId`), then one row per run record. `selected` and up/down span this array; Enter
+ * dispatches on `kind`. A null or malformed snapshot yields an empty list. No `.log`, no `.data` -- the
+ * ACTIVE row carries only the id-only job id.
  */
-function renderRunList(runs: any[], selected: number, w: number): string[] {
-  if (!Array.isArray(runs) || runs.length === 0) return [clip("(no runs)", w)];
-  return runs.map((run, i) => {
+function buildRows(snapshot: any): any[] {
+  const runs = Array.isArray(snapshot?.runs) ? snapshot.runs : [];
+  const active = snapshot?.activeJobId ? [{ kind: "active", jobId: snapshot.activeJobId }] : [];
+  return [...active, ...runs.map((record: any) => ({ kind: "run", record }))];
+}
+
+/**
+ * The interactive RUNS list over the rows model: one compact row per entry, cursor-prefixed (`›` on the
+ * selected row, space otherwise). The ACTIVE row leads with its id-only job id; run rows lead with `jobId`
+ * so a jobId match still hits. Each row is `clip`ped to the inner column count so a long target can neither
+ * overflow the frame nor mis-size a row. Operates only on the passed rows -- no read, no `.log`, no `.data`.
+ */
+function renderRunList(rows: any[], selected: number, w: number): string[] {
+  if (!Array.isArray(rows) || rows.length === 0) return [clip("(no runs)", w)];
+  return rows.map((row, i) => {
     const cursor = i === selected ? "›" : " ";
+    if (row.kind === "active") return clip(`${cursor} * ACTIVE ${row.jobId} running`, w);
+    const run = row.record;
     const cells = [run?.jobId, run?.target, run?.flow, run?.outcome, run?.turns]
       .map((f) => (f === null || f === undefined ? "-" : String(f)))
       .join(" · ");
     return clip(`${cursor} ${cells}`, w);
   });
+}
+
+/**
+ * The LIVE_TAIL view: a bounded, scrollable window of a running job's captured `.log`, framed in the
+ * overlay. The tail bytes arrive here only through render() -> this pure function and are returned as
+ * overlay lines; they never enter `snapshot`, a shared renderer, or `sendMessage` (INT-RUN-HISTORY-FILE-CONTRACT).
+ * Four states: capability absent, no captured log, the windowed tail, and the tail after the job left the
+ * active slot. `tailTop` is clamped to `[0, maxTop]` so a shrunk log cannot scroll past the end.
+ */
+function renderLiveTail({ snapshot, framed, width, tailJobId, tail, tailTop, tailAvailable }: any): string[] {
+  const boxTitle = `live ${tailJobId}`;
+  let lines: string[];
+  let footer: string;
+  if (tail === null && !tailAvailable) {
+    lines = ["live tail unavailable in this build"];
+    footer = "Esc back";
+  } else if (tail?.missing) {
+    lines = [`live ${tailJobId} -- no captured log (PI_CAPTURE_JOB_LOGS off or not found)`];
+    footer = "Esc back";
+  } else {
+    const all = Array.isArray(tail?.lines) ? tail.lines : [];
+    const len = all.length;
+    const maxTop = Math.max(0, len - TAIL_VIEWPORT);
+    const top = Math.min(Math.max(0, tailTop), maxTop);
+    lines = [`live ${tailJobId} -- ${len} line(s)`, ...all.slice(top, top + TAIL_VIEWPORT)];
+    // The job left the active slot (ended, or a different job now runs): keep showing the last tail.
+    if (snapshot?.activeJobId !== tailJobId) lines.push("(run ended -- Esc to go back)");
+    footer = `[${Math.min(top + TAIL_VIEWPORT, len)}/${len}]  Up/Down PgUp/PgDn scroll, Esc back`;
+  }
+  if (!framed) return [boxTitle, "", ...lines, "", footer];
+  return box({ title: boxTitle, footer, width, sections: [{ lines }] });
 }
 
 /**

--- a/admin/src/dashboard.ts
+++ b/admin/src/dashboard.ts
@@ -16,9 +16,9 @@ import { dayKey } from "@pi-dispatch/worker/budget";
 import { parseConnection, makeRedisClient } from "@pi-dispatch/worker/connection";
 import { makeQueue } from "@pi-dispatch/worker/queue";
 import { listRuns, readSettingsView, mapSchedulers, readFlows } from "./read-model.mjs";
-import { renderStatus, renderBudget, renderRuns, renderTriggers, renderSettingsView } from "./render.mjs";
+import { renderStatus, renderBudget, renderTriggers, renderSettingsView } from "./render.mjs";
 import { matchesKey } from "./keys.mjs";
-import { box, meter } from "./panel.mjs";
+import { box, meter, clip } from "./panel.mjs";
 
 const KEY_HINTS = "[p]ause  [r]esume  [q]uit";
 const RUNS_ON_DASHBOARD = 10;
@@ -98,6 +98,11 @@ export function makeDashboard({
   let fetching = false;
   let disposed = false;
   let interval: any = null;
+  // In-component view machine: LIST is the framed panel with the interactive run list; RUN_DETAIL is the
+  // single-record dump. `selected` is the list cursor; `detailRun` is the record captured on Enter.
+  let view = "LIST";
+  let selected = 0;
+  let detailRun: any = null;
 
   const refresh = async () => {
     if (fetching || disposed) return;
@@ -140,14 +145,45 @@ export function makeDashboard({
 
   const component = {
     render(width: number): string[] {
-      return renderPanel(snapshot, width);
+      // Clamp the cursor here so a snapshot whose runs list shrank between ticks can never leave `selected`
+      // pointing past the end.
+      const runsLen = snapshot?.runs?.length ?? 0;
+      if (selected > runsLen - 1) selected = Math.max(0, runsLen - 1);
+      return renderPanel(snapshot, width, view, selected, detailRun);
     },
     invalidate(): void {
       // No cached render state to clear; the TUI redraws from render().
     },
     handleInput(data: string): void {
+      if (view === "RUN_DETAIL") {
+        // Escape backs out to the list only; it never closes the overlay or disposes the held clients.
+        // Every other key (including q/p/r) is inert in the detail view.
+        if (matchesKey(data, "escape")) {
+          view = "LIST";
+          tui?.requestRender?.();
+        }
+        return;
+      }
       if (matchesKey(data, "escape") || data === "q" || data === "Q") {
         void dispose().finally(() => done(undefined));
+        return;
+      }
+      if (data === "\r" || data === "\n") {
+        if (snapshot?.runs?.length) {
+          detailRun = snapshot.runs[selected];
+          view = "RUN_DETAIL";
+          tui?.requestRender?.();
+        }
+        return;
+      }
+      if (matchesKey(data, "up")) {
+        selected = Math.max(0, selected - 1);
+        tui?.requestRender?.();
+        return;
+      }
+      if (matchesKey(data, "down")) {
+        selected = Math.min((snapshot?.runs?.length ?? 1) - 1, selected + 1);
+        tui?.requestRender?.();
         return;
       }
       if (data === "p" || data === "P") {
@@ -175,10 +211,17 @@ function toLines(text: string): string[] {
  * that is missing, non-finite, or below `MIN_WIDTH` degrades to unframed plain lines; a sane width frames
  * the same content with `box`, its inner column count driving every meter and clip.
  */
-function renderPanel(snapshot: any, width: number): string[] {
+function renderPanel(snapshot: any, width: number, view: string, selected: number, detailRun: any): string[] {
   const framed = Number.isFinite(width) && Math.trunc(width) >= MIN_WIDTH;
   const inner = Math.trunc(width) - 4;
   const title = "pi-dispatch";
+
+  if (view === "RUN_DETAIL") {
+    const detailTitle = `run ${detailRun?.jobId ?? "-"}`;
+    const detailLines = renderRunDetail(detailRun);
+    if (!framed) return [detailTitle, "", ...detailLines, "", "Esc back"];
+    return box({ title: detailTitle, footer: "Esc back", width, sections: [{ lines: detailLines }] });
+  }
 
   if (snapshot === null) {
     if (!framed) return [`${title} -- loading`, "", KEY_HINTS];
@@ -200,7 +243,7 @@ function renderPanel(snapshot: any, width: number): string[] {
       ],
     },
     { title: "TRIGGERS", lines: toLines(renderTriggers({ schedulers: snapshot.schedulers, flows: snapshot.flows })) },
-    { title: "RUNS", lines: toLines(renderRuns(snapshot.runs)) },
+    { title: "RUNS", lines: renderRunList(snapshot.runs, selected, framed ? inner : 24) },
     { title: "SETTINGS", lines: toLines(renderSettingsView(snapshot.settings)) },
   ];
 
@@ -210,4 +253,49 @@ function renderPanel(snapshot: any, width: number): string[] {
   for (const section of sections) plain.push(section.title, ...section.lines);
   plain.push(KEY_HINTS);
   return plain.join("\n\n").split("\n");
+}
+
+/**
+ * The interactive RUNS list: one compact row per record, cursor-prefixed (`›` on the selected row, space
+ * otherwise) with `jobId` leading so a jobId match still hits. Each row is `clip`ped to the inner column
+ * count so a long target can neither overflow the frame nor mis-size a row. Operates only on the passed
+ * records -- no read, no `.log`, no `.data`.
+ */
+function renderRunList(runs: any[], selected: number, w: number): string[] {
+  if (!Array.isArray(runs) || runs.length === 0) return [clip("(no runs)", w)];
+  return runs.map((run, i) => {
+    const cursor = i === selected ? "›" : " ";
+    const cells = [run?.jobId, run?.target, run?.flow, run?.outcome, run?.turns]
+      .map((f) => (f === null || f === undefined ? "-" : String(f)))
+      .join(" · ");
+    return clip(`${cursor} ${cells}`, w);
+  });
+}
+
+/**
+ * A monochrome key/value dump of one run record, every value nullable-safe (`-` when null or undefined) so
+ * the fixture's missing fields render rather than throw. Operates only on the passed record: no read, no
+ * `.log`, no `.data` -- exactly the PII-free run-history fields (INT-RUN-HISTORY-FILE-CONTRACT).
+ */
+function renderRunDetail(record: any): string[] {
+  const r = record ?? {};
+  const show = (v: any): string => (v === null || v === undefined ? "-" : String(v));
+  const fields: [string, any][] = [
+    ["jobId", r.jobId],
+    ["kind", r.kind],
+    ["target", r.target],
+    ["flow", r.flow],
+    ["outcome", r.outcome],
+    ["reason", r.reason],
+    ["turns", r.turns],
+    ["exitCode", r.exitCode],
+    ["budgetReserved", r.budgetReserved],
+    ["attempt", r.attempt],
+    ["chainDepth", r.chainDepth],
+    ["parentJobId", r.parentJobId],
+    ["chainRefused", r.chainRefused],
+    ["startedAt", r.startedAt],
+    ["endedAt", r.endedAt],
+  ];
+  return fields.map(([k, v]) => `${k}: ${show(v)}`);
 }

--- a/admin/src/dashboard.ts
+++ b/admin/src/dashboard.ts
@@ -15,13 +15,17 @@
 import { dayKey } from "@pi-dispatch/worker/budget";
 import { parseConnection, makeRedisClient } from "@pi-dispatch/worker/connection";
 import { makeQueue } from "@pi-dispatch/worker/queue";
-import { listRuns, readSettingsView, mapSchedulers } from "./read-model.mjs";
-import { renderStatus, renderBudget, renderRuns, renderSchedulers, renderSettingsView } from "./render.mjs";
+import { listRuns, readSettingsView, mapSchedulers, readFlows } from "./read-model.mjs";
+import { renderStatus, renderBudget, renderRuns, renderTriggers, renderSettingsView } from "./render.mjs";
 import { matchesKey } from "./keys.mjs";
+import { box, meter } from "./panel.mjs";
 
 const KEY_HINTS = "[p]ause  [r]esume  [q]uit";
 const RUNS_ON_DASHBOARD = 10;
 const REFRESH_MS = 1000;
+// panel.mjs floors a box to this width; below it (or a missing/non-finite width) the panel degrades to
+// unframed plain lines rather than a ragged or over-width frame.
+const MIN_WIDTH = 8;
 
 /**
  * Build the read/act/close deps for a live dashboard from resolved paths: ONE failFast queue and ONE
@@ -35,12 +39,13 @@ export function createDashboardDeps(paths: any) {
   const redis = makeRedisClient(paths.valkeyUrl);
   return {
     async fetchSnapshot() {
-      const [pausedState, counts, workerList, reservedRaw, schedulerList] = await Promise.all([
+      const [pausedState, counts, workerList, reservedRaw, schedulerList, activeList] = await Promise.all([
         queue.isPaused(),
         queue.getJobCounts("waiting", "active", "paused", "delayed", "failed"),
         queue.getWorkers().catch(() => []),
         redis.get(dayKey()),
         queue.getJobSchedulers(0, -1, true),
+        queue.getActive(0, 0).catch(() => []),
       ]);
       const workers = Array.isArray(workerList) && workerList.length > 0 ? workerList.length : "unknown";
       return {
@@ -49,6 +54,10 @@ export function createDashboardDeps(paths: any) {
         schedulers: mapSchedulers(schedulerList, Date.now()),
         runs: listRuns({ logsDir: paths.logsDir, limit: RUNS_ON_DASHBOARD }),
         settings: readSettingsView({ settingsFile: paths.settingsFile }),
+        flows: readFlows({ flowsPath: paths.flowsPath }),
+        // ONLY the id off the active Job -- a Job's `.data` holds issue title/body/username (PII), so it
+        // never enters the snapshot (no-pii-in-logs, INT-RUN-HISTORY-FILE-CONTRACT).
+        activeJobId: activeList?.[0]?.id ?? null,
       };
     },
     async pause() {
@@ -130,8 +139,8 @@ export function makeDashboard({
   void refresh();
 
   const component = {
-    render(_width: number): string[] {
-      return renderDashboard(snapshot);
+    render(width: number): string[] {
+      return renderPanel(snapshot, width);
     },
     invalidate(): void {
       // No cached render state to clear; the TUI redraws from render().
@@ -154,26 +163,51 @@ export function makeDashboard({
   return component;
 }
 
+/** Split a renderer's multi-line string into the per-line array a `box` section expects. */
+function toLines(text: string): string[] {
+  return String(text).split("\n");
+}
+
 /**
- * Compose the panel text from the last snapshot alone, reusing the slash-command renderers so the panel
- * and the commands cannot drift. A null snapshot is the pre-first-fetch state; a snapshot carrying
- * `unreachable` degrades the whole panel to one line rather than a wall of empty sections.
+ * Compose the monochrome framed panel from the last snapshot alone, reusing the slash-command renderers so
+ * the panel and the commands cannot drift. A null snapshot is the pre-first-fetch loading state; a snapshot
+ * carrying `unreachable` degrades the whole panel to one line rather than a wall of empty sections. A width
+ * that is missing, non-finite, or below `MIN_WIDTH` degrades to unframed plain lines; a sane width frames
+ * the same content with `box`, its inner column count driving every meter and clip.
  */
-function renderDashboard(snapshot: any): string[] {
+function renderPanel(snapshot: any, width: number): string[] {
+  const framed = Number.isFinite(width) && Math.trunc(width) >= MIN_WIDTH;
+  const inner = Math.trunc(width) - 4;
+  const title = "pi-dispatch";
+
   if (snapshot === null) {
-    return ["pi-dispatch dashboard -- loading...", "", KEY_HINTS];
+    if (!framed) return [`${title} -- loading`, "", KEY_HINTS];
+    return box({ title, sections: [{ lines: ["loading"] }], footer: KEY_HINTS, width });
   }
   if (snapshot.unreachable) {
-    return [`pi-dispatch dashboard -- unreachable (${snapshot.unreachable})`, "", KEY_HINTS];
+    const msg = `unreachable (${snapshot.unreachable})`;
+    if (!framed) return [`${title} -- ${msg}`, "", KEY_HINTS];
+    return box({ title, sections: [{ lines: [msg] }], footer: KEY_HINTS, width });
   }
-  const blocks = [
-    "pi-dispatch dashboard",
-    renderStatus(snapshot.queue),
-    renderBudget({ budget: snapshot.budget, settings: snapshot.settings }),
-    renderRuns(snapshot.runs),
-    renderSchedulers(snapshot.schedulers),
-    renderSettingsView(snapshot.settings),
-    KEY_HINTS,
+
+  const sections = [
+    { title: "STATUS", lines: toLines(renderStatus(snapshot.queue)) },
+    {
+      title: "SPEND",
+      lines: [
+        renderBudget({ budget: snapshot.budget, settings: snapshot.settings }),
+        meter(snapshot.budget?.reserved, snapshot.settings?.overlay?.dailyCap, framed ? inner : 24),
+      ],
+    },
+    { title: "TRIGGERS", lines: toLines(renderTriggers({ schedulers: snapshot.schedulers, flows: snapshot.flows })) },
+    { title: "RUNS", lines: toLines(renderRuns(snapshot.runs)) },
+    { title: "SETTINGS", lines: toLines(renderSettingsView(snapshot.settings)) },
   ];
-  return blocks.join("\n\n").split("\n");
+
+  if (framed) return box({ title, sections, footer: KEY_HINTS, width });
+
+  const plain = [title];
+  for (const section of sections) plain.push(section.title, ...section.lines);
+  plain.push(KEY_HINTS);
+  return plain.join("\n\n").split("\n");
 }

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -48,7 +48,7 @@ import {
   KNOWN_KEYS,
 } from "./read-model.mjs";
 import { renderStatus, renderRuns, renderBudget, renderTriggers, renderSettingsView } from "./render.mjs";
-import { makeDashboard } from "./dashboard.ts";
+import { makeDashboard, createDashboardDeps } from "./dashboard.ts";
 import { matchesKey } from "./keys.mjs";
 
 // The single source of truth for the ExtensionAPI surface this extension
@@ -322,7 +322,18 @@ async function openDashboard(paths: any, ctx: any, notify: Notify): Promise<void
   }
   await custom.call(
     ctx.ui,
-    (tui: any, _theme: any, _keybindings: any, done: (value: void) => void) => makeDashboard({ paths, done, tui }),
+    (tui: any, _theme: any, _keybindings: any, done: (value: void) => void) =>
+      makeDashboard({
+        paths,
+        done,
+        tui,
+        deps: {
+          ...createDashboardDeps(paths),
+          // log read stays here; overlay-only, returns readLogTail's result verbatim
+          tailLog: ({ jobId, lines }: { jobId: string; lines: number }) =>
+            readLogTail({ logsDir: paths.logsDir, jobId, lines }),
+        },
+      }),
     { overlay: true, overlayOptions: { width: "75%", maxHeight: "90%", anchor: "center" } },
   );
 }

--- a/admin/src/panel.mjs
+++ b/admin/src/panel.mjs
@@ -1,0 +1,115 @@
+/**
+ * Pure text primitives for the admin dashboard: box-drawing frames, meters, and width-safe clipping.
+ * No I/O, no clock, no process.env, no console, no pi API -- every input is a value the caller already
+ * has, so these are testable with plain fixtures (asserted pure by panel.test.mjs).
+ *
+ * PII discipline (no-pii-in-logs, INT-RUN-HISTORY-FILE-CONTRACT): `clip` is the width gate through which
+ * dashboard.ts funnels untrusted, PII-bearing `.log` bytes before framing. It strips control characters
+ * so an escape sequence or a stray byte can neither crash the layout nor mis-size a row.
+ */
+
+// Custom: no box-drawing/meter primitive exists in deps -- ink/blessed/boxen are full TUI frameworks and
+// this dashboard is a handful of monochrome frames, so a thin pure module is the right size (library-first).
+
+/** Box-drawing + block glyphs. Swap to ASCII by aliasing this to `ASCII` for glyph-width-hostile terminals. */
+export const GLYPHS = {
+  tl: "┌", // top-left corner
+  tr: "┐", // top-right corner
+  bl: "└", // bottom-left corner
+  br: "┘", // bottom-right corner
+  h: "─", //  horizontal rule
+  v: "│", //  vertical edge
+  ml: "├", // left tee (section separator start)
+  mr: "┤", // right tee (section separator end)
+  full: "█", // filled meter cell
+  empty: "░", // empty meter cell
+  ellipsis: "…", // truncation marker
+};
+
+/** Parallel ASCII fallback: same keys, no glyph-width risk. Single point of substitution for `GLYPHS`. */
+export const ASCII = {
+  tl: "+",
+  tr: "+",
+  bl: "+",
+  br: "+",
+  h: "-",
+  v: "|",
+  ml: "+",
+  mr: "+",
+  full: "#",
+  empty: ".",
+  ellipsis: "...",
+};
+
+const MIN_WIDTH = 8;
+
+/**
+ * Truncate `line` to `w` display columns, appending an ellipsis glyph when content is cut. Control
+ * characters (including escape sequences) are stripped first so untrusted input cannot crash or mis-size:
+ * content is ASCII/box-drawing, so post-strip `String.length` is a safe column proxy.
+ */
+export function clip(line, w) {
+  const width = Math.max(0, Math.trunc(w) || 0);
+  // eslint-disable-next-line no-control-regex -- defensive strip of C0/C1 control chars from untrusted input
+  const clean = String(line ?? "").replace(/[\x00-\x1f\x7f-\x9f]/g, "");
+  if (clean.length <= width) return clean;
+  if (width <= 1) return GLYPHS.ellipsis.slice(0, width);
+  return clean.slice(0, width - 1) + GLYPHS.ellipsis;
+}
+
+/** `clip` to `w`, then right-pad with spaces to exactly `w` columns. */
+export function pad(line, w) {
+  const width = Math.max(0, Math.trunc(w) || 0);
+  return clip(line, width).padEnd(width);
+}
+
+/**
+ * Frame `sections` into a titled box, returning `string[]` where no line exceeds `width`. The inner
+ * content width (`width - 4`) is computed once and is the single source of alignment truth: every inner
+ * line is `pad`/`clip`ped to it. Below `MIN_WIDTH` the width is floored to `MIN_WIDTH` so a too-small
+ * request degrades to a minimal frame rather than emitting ragged or over-width rows.
+ */
+export function box({ title = "", sections = [], footer, width = 40 } = {}) {
+  const w = Math.max(MIN_WIDTH, Math.trunc(width) || MIN_WIDTH);
+  const inner = w - 4; // "| " + content + " |"
+  const lines = [];
+
+  // Top border: `+- title -...-+`, title clipped so the border never overflows `w`.
+  const titleText = title ? ` ${clip(title, Math.max(0, inner - 2))} ` : "";
+  const topFill = Math.max(0, w - 2 - 1 - titleText.length); // corners + one leading `h`
+  lines.push(GLYPHS.tl + GLYPHS.h + titleText + GLYPHS.h.repeat(topFill) + GLYPHS.tr);
+
+  const framed = (text) => `${GLYPHS.v} ${pad(text, inner)} ${GLYPHS.v}`;
+  const rule = () => GLYPHS.ml + GLYPHS.h.repeat(w - 2) + GLYPHS.mr;
+
+  sections.forEach((section, i) => {
+    if (i > 0) lines.push(rule());
+    if (section?.title) lines.push(framed(section.title));
+    for (const line of section?.lines ?? []) lines.push(framed(line));
+  });
+
+  if (footer !== undefined && footer !== null) {
+    if (sections.length > 0) lines.push(rule());
+    lines.push(framed(footer));
+  }
+
+  lines.push(GLYPHS.bl + GLYPHS.h.repeat(w - 2) + GLYPHS.br);
+  return lines;
+}
+
+/**
+ * A block-char progress bar `[####....] reserved/cap` fitted to `width`. When `cap` is not a positive
+ * integer the true cap is unknown to this process, so it renders `reserved / ? (cap unknown)` with no bar
+ * rather than a bar against a guessed denominator.
+ */
+export function meter(reserved, cap, width = 24) {
+  const r = Number.isFinite(reserved) ? Math.max(0, Math.trunc(reserved)) : 0;
+  if (!Number.isInteger(cap) || cap <= 0) {
+    return clip(`${r} / ? (cap unknown)`, width);
+  }
+  const label = ` ${r}/${cap}`;
+  const barCells = Math.max(0, Math.trunc(width) - label.length - 2); // "[" + cells + "]" + label
+  const filled = Math.min(barCells, Math.round((Math.min(r, cap) / cap) * barCells));
+  const bar = `[${GLYPHS.full.repeat(filled)}${GLYPHS.empty.repeat(barCells - filled)}]`;
+  return clip(bar + label, width);
+}

--- a/admin/test/dashboard.test.mjs
+++ b/admin/test/dashboard.test.mjs
@@ -199,3 +199,181 @@ test("dashboard.ts has no path to raw .log content", () => {
     "the dashboard renders records/counts/settings only -- raw .log bytes belong to the logs viewer alone",
   );
 });
+
+test("frames to a sane width and degrades to unframed plain lines at a tiny width", async () => {
+  const comp = makeDashboard({ paths: {}, done() {}, tui: fakeTui(), intervalMs: 100000, deps: cannedDeps() });
+  await flush();
+  const framed = comp.render(80);
+  const tiny = comp.render(4).join("\n");
+  await comp.dispose();
+
+  assert.match(framed.join("\n"), /[┌┐└┘│─]/, "a sane width draws a box frame");
+  assert.ok(framed.every((l) => l.length <= 80), "no framed line exceeds the requested width");
+  assert.doesNotMatch(tiny, /[┌┐└┘│─]/, "below MIN_WIDTH the panel drops the frame rather than emitting a ragged box");
+});
+
+test("the spend meter shows a filled bar against a known cap, and (cap unknown) with no bar otherwise", async () => {
+  const known = makeDashboard({ paths: {}, done() {}, tui: fakeTui(), intervalMs: 100000, deps: cannedDeps() });
+  await flush();
+  const knownOut = known.render(80).join("\n");
+  await known.dispose();
+
+  const unknown = makeDashboard({
+    paths: {},
+    done() {},
+    tui: fakeTui(),
+    intervalMs: 100000,
+    // Overlay carries no dailyCap, so the true cap is unknown to this process: no bar, no denominator.
+    deps: cannedDeps({ fetchSnapshot: async () => ({ ...SNAPSHOT, settings: { path: "/s", overlay: { model: "m" } } }) }),
+  });
+  await flush();
+  const unknownOut = unknown.render(80).join("\n");
+  await unknown.dispose();
+
+  assert.match(knownOut, /5\/25/, "reserved/cap label against the overlay cap");
+  assert.match(knownOut, /[█]/, "a filled block glyph fills the bar");
+  assert.match(unknownOut, /cap unknown/, "an unknown cap renders as text");
+  assert.doesNotMatch(unknownOut, /[█]/, "no bar is drawn against an unknown denominator");
+});
+
+test("the TRIGGERS section unifies the label allowlist with the schedulers block", async () => {
+  const comp = makeDashboard({
+    paths: {},
+    done() {},
+    tui: fakeTui(),
+    intervalMs: 100000,
+    deps: cannedDeps({ fetchSnapshot: async () => ({ ...SNAPSHOT, flows: { mappings: { bug: "fix" } } }) }),
+  });
+  await flush();
+  const out = comp.render(80).join("\n");
+  await comp.dispose();
+
+  assert.match(out, /Label -> flow:/, "the committed label allowlist header");
+  assert.match(out, /bug -> fix/, "the label->flow mapping row");
+  assert.match(out, /Schedulers:/, "the schedulers block shares the section");
+});
+
+test("Enter on a run opens its detail dump, and Esc backs out to the list without quitting", async () => {
+  let closed = 0;
+  const comp = makeDashboard({
+    paths: {},
+    done: () => {
+      closed++;
+    },
+    tui: fakeTui(),
+    intervalMs: 100000,
+    deps: cannedDeps(),
+  });
+  await flush();
+
+  comp.handleInput("\x1b[B");
+  comp.handleInput("\r");
+  await flush();
+  const detail = comp.render(80).join("\n");
+  assert.match(detail, /run j1/, "the detail view titles on the selected run");
+  assert.match(detail, /attempt: -/, "a detail-only field renders, absent as '-'");
+
+  comp.handleInput("\x1b");
+  await flush();
+  const back = comp.render(80).join("\n");
+  await comp.dispose();
+  assert.match(back, /\[p\]ause/, "Esc returns to the interactive list");
+  assert.equal(closed, 0, "Esc from a sub-view never closes the overlay");
+});
+
+test("Enter on the ACTIVE row tails its live log inside the overlay", async () => {
+  const calls = [];
+  const comp = makeDashboard({
+    paths: {},
+    done() {},
+    tui: fakeTui(),
+    intervalMs: 100000,
+    deps: cannedDeps({
+      fetchSnapshot: async () => ({ ...SNAPSHOT, activeJobId: "jA" }),
+      tailLog: (args) => {
+        calls.push(args);
+        return { lines: ["HELLO_TAIL"] };
+      },
+    }),
+  });
+  await flush();
+
+  comp.handleInput("\r");
+  await flush();
+  await flush();
+  const out = comp.render(80).join("\n");
+  await comp.dispose();
+
+  assert.match(out, /HELLO_TAIL/, "the captured tail line renders in the overlay");
+  assert.match(out, /live jA/, "the tail view titles on the id-only active job");
+  assert.match(out, /\[\d+\/\d+\]/, "a windowed footer counts the tail");
+  assert.equal(calls[0].jobId, "jA", "the tail is keyed by the id-only active job id");
+});
+
+test("the live tail reports a missing captured log by job id", async () => {
+  const comp = makeDashboard({
+    paths: {},
+    done() {},
+    tui: fakeTui(),
+    intervalMs: 100000,
+    deps: cannedDeps({
+      fetchSnapshot: async () => ({ ...SNAPSHOT, activeJobId: "jA" }),
+      tailLog: () => ({ missing: true }),
+    }),
+  });
+  await flush();
+
+  comp.handleInput("\r");
+  await flush();
+  await flush();
+  const out = comp.render(80).join("\n");
+  await comp.dispose();
+
+  assert.match(out, /no captured log \(PI_CAPTURE_JOB_LOGS/, "a missing log degrades to a captured-off notice");
+});
+
+test("the live tail reports unavailable when no tail capability is injected", async () => {
+  const comp = makeDashboard({
+    paths: {},
+    done() {},
+    tui: fakeTui(),
+    intervalMs: 100000,
+    // No tailLog capability in deps: the view degrades rather than reaching for a .log surface.
+    deps: cannedDeps({ fetchSnapshot: async () => ({ ...SNAPSHOT, activeJobId: "jA" }) }),
+  });
+  await flush();
+
+  comp.handleInput("\r");
+  await flush();
+  await flush();
+  const out = comp.render(80).join("\n");
+  await comp.dispose();
+
+  assert.match(out, /unavailable/, "an absent tail capability renders as unavailable in this build");
+});
+
+test("PageDown scrolls the live tail window past the first viewport", async () => {
+  const comp = makeDashboard({
+    paths: {},
+    done() {},
+    tui: fakeTui(),
+    intervalMs: 100000,
+    deps: cannedDeps({
+      fetchSnapshot: async () => ({ ...SNAPSHOT, activeJobId: "jA" }),
+      tailLog: () => ({ lines: Array.from({ length: 50 }, (_, i) => "L" + i) }),
+    }),
+  });
+  await flush();
+
+  comp.handleInput("\r");
+  await flush();
+  await flush();
+  const before = comp.render(80).join("\n");
+  assert.match(before, /\[20\/50\]/, "the first frame windows the first viewport of 50 lines");
+
+  comp.handleInput("\x1b[6~");
+  await flush();
+  const after = comp.render(80).join("\n");
+  await comp.dispose();
+  assert.match(after, /\[40\/50\]/, "PageDown advances the window a full viewport past line 20");
+});

--- a/admin/test/panel.test.mjs
+++ b/admin/test/panel.test.mjs
@@ -7,8 +7,8 @@ import { GLYPHS, clip, pad, box, meter } from "../src/panel.mjs";
 test("panel.mjs is pure: no fs, no require, no node:fs import", () => {
   const src = readFileSync(fileURLToPath(new URL("../src/panel.mjs", import.meta.url)), "utf8");
   assert.ok(
-    !/readFileSync|\breadFile\b|require\(|import\s+.*node:fs/.test(src),
-    "panel primitives must have no I/O -- they take values in and return strings",
+    !/readFileSync|\breadFile\b|require\(|import\s+.*node:fs|console\.|process\.env[.[]|@earendil-works/.test(src),
+    "panel primitives must have no I/O, no console, no env, no pi API -- values in, strings out",
   );
 });
 

--- a/admin/test/panel.test.mjs
+++ b/admin/test/panel.test.mjs
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { GLYPHS, clip, pad, box, meter } from "../src/panel.mjs";
+
+test("panel.mjs is pure: no fs, no require, no node:fs import", () => {
+  const src = readFileSync(fileURLToPath(new URL("../src/panel.mjs", import.meta.url)), "utf8");
+  assert.ok(
+    !/readFileSync|\breadFile\b|require\(|import\s+.*node:fs/.test(src),
+    "panel primitives must have no I/O -- they take values in and return strings",
+  );
+});
+
+test("box frames a title, sections, and footer within width", () => {
+  const width = 30;
+  const out = box({
+    title: "STATUS",
+    sections: [
+      { title: "Queue", lines: ["waiting 2", "active 1"] },
+      { lines: ["workers: 1"] },
+    ],
+    footer: "updated 00:00",
+    width,
+  });
+  assert.ok(Array.isArray(out));
+  const joined = out.join("\n");
+  assert.match(joined, new RegExp(GLYPHS.tl));
+  assert.match(joined, new RegExp(GLYPHS.br));
+  assert.match(joined, new RegExp(GLYPHS.ml), "a section separator rule is present");
+  assert.match(joined, /STATUS/);
+  assert.match(joined, /Queue/);
+  assert.match(joined, /waiting 2/);
+  assert.match(joined, /workers: 1/);
+  assert.match(joined, /updated 00:00/);
+  for (const line of out) {
+    assert.ok(line.length <= width, `line "${line}" (${line.length}) exceeds width ${width}`);
+  }
+});
+
+test("box degrades on a tiny width without emitting over-width lines", () => {
+  const out = box({ title: "way-too-long-title", sections: [{ lines: ["content"] }], footer: "f", width: 3 });
+  assert.ok(out.length >= 2, "still produces a top and bottom border");
+  const maxLen = Math.max(...out.map((l) => l.length));
+  for (const line of out) {
+    assert.equal(line.length, maxLen, "degraded frame stays rectangular, never ragged or over-width");
+  }
+});
+
+test("meter renders a bar glyph and reserved/cap", () => {
+  const out = meter(3, 10, 24);
+  assert.match(out, new RegExp(GLYPHS.full), "a filled block glyph appears");
+  assert.match(out, /3\/10/);
+});
+
+test("meter renders (cap unknown) with no bar glyph when cap is not a positive integer", () => {
+  const out = meter(5, null, 24);
+  assert.match(out, /\(cap unknown\)/);
+  assert.doesNotMatch(out, new RegExp(GLYPHS.full), "no bar when the cap is unknown");
+  assert.doesNotMatch(out, new RegExp(GLYPHS.empty), "no bar when the cap is unknown");
+  assert.doesNotMatch(meter(5, 0, 24), /\[/, "cap of 0 is not a positive integer");
+});
+
+test("clip truncates long input to width and ends with the ellipsis glyph", () => {
+  const out = clip("abcdefghij", 5);
+  assert.equal(out.length, 5);
+  assert.ok(out.endsWith(GLYPHS.ellipsis));
+});
+
+test("clip leaves short input unchanged", () => {
+  assert.equal(clip("abc", 10), "abc");
+});
+
+test("clip survives control characters and stays within width", () => {
+  const evil = `a\x1b[31mb\x00c\x07d\x7f`;
+  const out = clip(evil, 6);
+  assert.ok(out.length <= 6, "width is respected after control chars are stripped");
+  assert.doesNotMatch(out, /[\x00-\x1f\x7f-\x9f]/, "control characters are removed"); // eslint-disable-line no-control-regex
+});
+
+test("pad right-pads short input to exactly width", () => {
+  const out = pad("hi", 6);
+  assert.equal(out.length, 6);
+  assert.equal(out, "hi    ");
+});
+
+test("pad clips long input to width", () => {
+  const out = pad("abcdefghij", 4);
+  assert.equal(out.length, 4);
+  assert.ok(out.endsWith(GLYPHS.ellipsis));
+});

--- a/specs/design.md
+++ b/specs/design.md
@@ -442,8 +442,14 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
 - **Decision**: The admin surface is a **pi extension** shipped in an `admin/` workspace, loaded into the
   operator's own interactive pi session (via `-e`, `~/.pi/agent/extensions`, or a trust-gated
   `.pi/extensions`). It provides operator-only slash commands
-  (`/dispatch status|pause|resume|runs|logs|budget|triggers|settings|set|unset`) and a TUI overlay
-  dashboard. The LLM-callable tools are reads, `pause`/`resume`, and the gated `dispatch_run` enqueue;
+  (`/dispatch status|pause|resume|runs|logs|budget|triggers|settings|set|unset`) and one
+  self-refreshing TUI overlay component with **three in-component views**: **LIST** — a framed
+  monochrome panel carrying a status bar, a SPEND meter, a unified **TRIGGERS** pane that shows
+  schedulers plus `label -> flow` mappings **display-only**, and an interactive runs list with `↑↓`
+  selection; **RUN_DETAIL** — a drill-in dump of the selected run's PII-free `.json` run-record fields;
+  and **LIVE_TAIL** — a view that tails a running job's `.log` **inside the overlay** through an
+  injected `deps.tailLog` seam whose `fs` read lives in `index.ts`. The LLM-callable tools are reads,
+  `pause`/`resume`, and the gated `dispatch_run` enqueue;
   every settings write is an operator-typed command, never a model-invocable tool. The extension talks to the same Valkey
   (`VALKEY_URL`) and reads the run-history sidecar files; it **binds no network port at all**. Bull Board
   is dropped.
@@ -464,9 +470,12 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
     for it and disqualifying for a trigger. Reachability, and now lifetime, are per-surface decisions.
   - **The injection boundary holds by placement, not by filtering.** Raw container `.log` output is
     untrusted agent-adjacent text and **never enters LLM context** — only the fixed-enum, PII-free `.json`
-    run records may; the `.log` is overlay-viewer-only. This is the same structural defence as
-    `CONST-ISSUE-TEXT-IS-DATA`, one layer down: the boundary is where the data is placed, not a filter
-    over its content. One residual is named and accepted: a prompt injection in the operator's session
+    run records may; the `.log` is overlay-viewer-only. The LIVE_TAIL view **preserves** exactly this
+    boundary: the injected `deps.tailLog` seam renders `.log` bytes in-overlay only — never a tool result,
+    never model context — and the USED_API surface stays the three pi members, because `tailLog` is an
+    internal overlay dependency injected through the existing `custom` seam, not a pi member. This is the
+    same structural defence as `CONST-ISSUE-TEXT-IS-DATA`, one layer down: the boundary is where the data
+    is placed, not a filter over its content. One residual is named and accepted: a prompt injection in the operator's session
     can invoke `dispatch_pause`/`dispatch_resume`, accepted because the outcome is durable-but-reversible
     and money-safe — neither tool spends tokens nor raises the cap (`CONST-BUDGET-BEFORE-TOKENS`), so the
     worst case is a queue stall the operator observes and undoes.
@@ -802,3 +811,4 @@ a tunnel.
 | 2026-07-22 | **AI-triggered flows.** Two new entries: `DES-AI-TRIGGER-FLOW-GATE` (a flow is AI-triggerable only if its `.pi/skills/<flow>/SKILL.md` frontmatter carries `ai-trigger: allow`, read from the git object store at the pre-agent SHA, default deny — an agent cannot self-authorize by committing its own `SKILL.md`) and `DES-JOB-OUTBOX-CHAINING` (an in-container agent writes `request-<n>.json` to a rw `/outbox` mount outside `/workspace`; the worker is the only enqueuer, collecting completed-only and forcing same-folder local jobs, `VALKEY_URL` never crossing the container boundary; GitHub-parent outboxes dropped). Two amendments: `DES-CLI-TRIGGER-FOR-LOCAL` now names **three** producers of local jobs (CLI, `dispatch_run`, outbox collector), retargets its superseded `DES-PANEL-SEPARATE-FROM-RECEIVER` trace to `DES-ADMIN-VIA-PI-EXTENSION`, and states the dirty-guard's same-folder-chain exception; `DES-ADMIN-VIA-PI-EXTENSION` adds a second named injection residual for the paid, not-money-safe `dispatch_run` tool (bounded by folder allowlist, per-flow opt-in, no-force, no spend-knob params, per-hour rate limit, daily cap), superseding the "reads plus pause/resume only" categorical. Reason: local jobs gain two prompt-injection-reachable producers, which need a WHAT-axis opt-in distinct from `CONST-TRIGGER-AUTHOR-GATE`'s WHO-axis webhook gate. Companion `requirements.md`/`interfaces.md`/`open-questions.md` amendments land in sibling tasks. |
 | 2026-07-22 | `DES-JOB-OUTBOX-CHAINING` records how the agent learns the outbox protocol: a **separate baked persona file** (`guardrails/OUTBOX_PROTOCOL.md`, immutable `chmod a-w`), composed into `appendSystemPromptOverride` **only when `/outbox` is mounted** (a github job is never billed for it) and evaluated once at loader build per `CONST-PERSONA-IN-CACHED-PREFIX`; kept out of `HARD_RULES.md` (the always-billed safety floor) and framed as documentation — the caps and `ai-trigger` gate are host-enforced, the persona controls nothing. |
 | 2026-07-22 | Coherence fix: reworded the `DES-ADMIN-VIA-PI-EXTENSION` `Decision` line — "reads plus `pause`/`resume` only" now reads "reads, `pause`/`resume`, and the gated `dispatch_run` enqueue", resolving the self-contradiction with the same entry's second injection residual (every settings write stays operator-typed). |
+| 2026-07-22 | `DES-ADMIN-VIA-PI-EXTENSION` dashboard amended to three in-component views — LIST (framed monochrome panel with unified TRIGGERS pane + `↑↓` runs selection), RUN_DETAIL (PII-free `.json` fields), and LIVE_TAIL — in one self-refreshing overlay. LIVE_TAIL renders raw `.log` bytes through an injected `deps.tailLog` seam whose `fs` read lives in `index.ts`, preserving the overlay-only `.log` boundary (never a tool result, never model context); USED_API stays the three pi members, `tailLog` being an internal `custom`-seam dependency, not a pi member. |


### PR DESCRIPTION
Redesigns the admin `/dispatch` dashboard (a pi CLI TUI overlay) around a single organizing idea — **one queue, one job contract, many heterogeneous producers** — rendered as a framed **monochrome** panel. The old flat stack of renderer blocks becomes an in-component state machine with three views: **LIST** (status bar + daily-spend meter + a unified **TRIGGERS** pane showing cron schedulers *and* `label -> flow` filters, display-only + an interactive runs list), **RUN_DETAIL** (a drill-in of the selected run's PII-free record fields), and **LIVE_TAIL** (tails a running job's `.log` inside the overlay). Monochrome-only by design: the overlay renders plain `string[]` with no verified ANSI support, so box-drawing + glyphs + layout carry every state (color is a separate, unverified spike).

New pure `admin/src/panel.mjs` (frame/meter/clip/pad, ASCII-fallback-ready) holds all drawing; `render.mjs` is byte-identical (it also feeds `sendMessage`, so it stays plain). The LIVE_TAIL log read is injected as `deps.tailLog` from `index.ts` (which already owns `readLogTail` for `/dispatch logs`), so `dashboard.ts` never touches the filesystem and the static-source guard holds.

**Load-bearing invariants verified:** raw `.log` bytes stay overlay-only, never model context — the tail is held in dedicated component state, never in `snapshot`, never `sendMessage`'d; `activeJobId` is the job **id only**, never `job.data` (which carries PII); `USED_API` stays exactly `{registerCommand, registerTool, sendMessage}` (proxy-locked); `render.mjs` unchanged; TRIGGERS is display-only (OQ-008 stays open).

## Verification
| Check | Baseline | Final |
|-------|----------|-------|
| typecheck/lint/test (whole workspace, `node --test`) | 572 total / 557 pass / 0 fail / 15 skip | **590 total / 575 pass / 0 fail / 15 skip** (+18 net-new, 0 regressions) |
| Legacy sweep | — | PASS (no add-alongside, no introduced dead code) |
| E2E — Container Smoke | — | N/A (`image/` untouched) |
| E2E — Webhook | — | N/A (`receiver/` untouched) |
| E2E — Queue | — | N/A (`worker/` untouched) |
| Admin EVP (applicable) | — | PASS — jiti-load **wiring test** (real extension vs recording proxy of pinned pi API: `USED_API` == the three, one overlay, dashboard/logs never `sendMessage`) + `load`/`pinned-extension-api` + grep gates (no ANSI in admin render paths; `render.mjs` byte-identical; no `readLogTail`/`readFileSync`/`readFile` literal in `dashboard.ts`) |

**E2E scope note:** the Phase-4 Container/Webhook/Queue trio covers the core pipeline (`image/`/`receiver/`/`worker/`). This change touches only `admin/` (the operator-side pi extension — a fourth surface) + `specs/`, so all three self-skip by scope; the applicable admin EVP above ran green. The only non-automatable step is the live pi TUI render (inherently manual for any terminal UI).

Spec: `DES-ADMIN-VIA-PI-EXTENSION` amended to record the three views + the `tailLog` seam (framed as *preserving* the `.log`-overlay-only boundary); one Revision History row. No new spec drift (detector exit 0, unchanged from baseline).

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
