### PR TITLE
Require/exclude label filters (any/all/none per flow) — #18

### DIFF
--- a/.plan-artifacts/2026-07-22-label-filters-any-all-none-plan/drift-snapshot.json
+++ b/.plan-artifacts/2026-07-22-label-filters-any-all-none-plan/drift-snapshot.json
@@ -1,0 +1,6 @@
+{
+  "generated": "2026-07-22T00:00:00Z",
+  "planSlug": "2026-07-22-label-filters-any-all-none-plan",
+  "exitCode": 0,
+  "reqStates": {}
+}

--- a/admin/src/read-model.mjs
+++ b/admin/src/read-model.mjs
@@ -414,9 +414,11 @@ export function readSettingsView({ settingsFile, fs = nodeFs }) {
 }
 
 /**
- * Read the receiver's committed label->flow allowlist for display. Unlike the receiver's fail-loud loader
- * (boot semantics), a viewer degrades: an absent file is `{ missing: true }`, malformed content is
- * `{ invalid }`, and only string flows survive into `{ mappings }`.
+ * Read the receiver's committed per-flow `{any, all, none}` trigger rules for display. Unlike the
+ * receiver's fail-loud loader (boot semantics), a viewer degrades: an absent file is `{ missing: true }`,
+ * malformed content is `{ invalid }`, and each rule normalizes into `{ rules: { <flow>: {any, all, none} } }`
+ * with missing selectors defaulting to `[]` and non-string members dropped. A value that is not an object
+ * is skipped, not fatal.
  */
 export function readFlows({ flowsPath, fs = nodeFs }) {
   let text;
@@ -432,13 +434,24 @@ export function readFlows({ flowsPath, fs = nodeFs }) {
     return { invalid: "flows file is not valid JSON" };
   }
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return { invalid: "flows file must be a label -> flow object" };
+    return { invalid: "flows file must be a flow -> rule object" };
   }
-  const mappings = {};
-  for (const [label, flow] of Object.entries(parsed)) {
-    if (typeof flow === "string" && flow.trim() !== "") mappings[label] = flow;
+  const rules = {};
+  for (const [flowName, rule] of Object.entries(parsed)) {
+    if (rule === null || typeof rule !== "object" || Array.isArray(rule)) continue;
+    rules[flowName] = {
+      any: normalizeSelector(rule.any),
+      all: normalizeSelector(rule.all),
+      none: normalizeSelector(rule.none),
+    };
   }
-  return { mappings };
+  return { rules };
+}
+
+// Custom: fail-soft display normalizer, not the receiver's fail-loud validator; a viewer degrades, never throws.
+function normalizeSelector(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((member) => typeof member === "string");
 }
 
 /** The sanitized ids present in the logs dir (from `*.json` filenames), for `logs <id>` autocomplete. */

--- a/admin/src/render.mjs
+++ b/admin/src/render.mjs
@@ -93,21 +93,31 @@ export function renderSchedulers(schedulers) {
 }
 
 /**
- * Render triggers display-only (OQ-008): the schedulers block, then the committed label->flow allowlist.
+ * Render triggers display-only (OQ-008): the schedulers block, then the committed per-flow
+ * `{any, all, none}` trigger rules.
  */
 export function renderTriggers({ schedulers, flows } = {}) {
-  const out = [renderSchedulers(schedulers), "", "Label -> flow:"];
+  const out = [renderSchedulers(schedulers), "", "Triggers:"];
   if (flows && flows.missing) {
     out.push("  (flows file not found)");
   } else if (flows && flows.invalid) {
     out.push(`  (flows file invalid: ${flows.invalid})`);
   } else {
-    const mappings = (flows && flows.mappings) ?? {};
-    const labels = Object.keys(mappings);
-    if (labels.length === 0) out.push("  (no mappings)");
-    else for (const label of labels) out.push(`  ${label} -> ${mappings[label]}`);
+    const rules = (flows && flows.rules) ?? {};
+    const flowNames = Object.keys(rules);
+    if (flowNames.length === 0) out.push("  (no rules)");
+    else for (const flowName of flowNames) out.push(`  ${flowName}: ${ruleClauses(rules[flowName])}`);
   }
   return out.join("\n");
+}
+
+function ruleClauses(rule) {
+  const clauses = [];
+  for (const key of ["any", "all", "none"]) {
+    const members = rule?.[key] ?? [];
+    if (members.length > 0) clauses.push(`${key}[${members.join(",")}]`);
+  }
+  return clauses.join(" ");
 }
 
 function schedulerLine(s) {

--- a/admin/test/dashboard.test.mjs
+++ b/admin/test/dashboard.test.mjs
@@ -242,14 +242,14 @@ test("the TRIGGERS section unifies the label allowlist with the schedulers block
     done() {},
     tui: fakeTui(),
     intervalMs: 100000,
-    deps: cannedDeps({ fetchSnapshot: async () => ({ ...SNAPSHOT, flows: { mappings: { bug: "fix" } } }) }),
+    deps: cannedDeps({ fetchSnapshot: async () => ({ ...SNAPSHOT, flows: { rules: { fix: { any: ["bug"] } } } }) }),
   });
   await flush();
   const out = comp.render(80).join("\n");
   await comp.dispose();
 
-  assert.match(out, /Label -> flow:/, "the committed label allowlist header");
-  assert.match(out, /bug -> fix/, "the label->flow mapping row");
+  assert.match(out, /Triggers:/, "the committed trigger-rules header");
+  assert.match(out, /fix: any\[bug\]/, "the per-flow rule row");
   assert.match(out, /Schedulers:/, "the schedulers block shares the section");
 });
 

--- a/admin/test/read-model.test.mjs
+++ b/admin/test/read-model.test.mjs
@@ -265,10 +265,32 @@ test("readSchedulers returns { unreachable } on a connection error", async () =>
   assert.match(res.unreachable, /down/);
 });
 
-test("readFlows returns the label->flow mappings", () => {
-  const files = { "receiver.flows.json": JSON.stringify({ "pi:frontend": "frontend-fix", "pi:backend": "backend-fix" }) };
+test("readFlows returns the normalized per-flow rules", () => {
+  const files = {
+    "receiver.flows.json": JSON.stringify({
+      "frontend-fix": { any: ["pi:frontend"] },
+      "backend-fix": { any: ["pi:backend"], none: ["wontfix"] },
+    }),
+  };
   const res = readFlows({ flowsPath: "/x/receiver.flows.json", fs: fakeFs(files) });
-  assert.deepEqual(res.mappings, { "pi:frontend": "frontend-fix", "pi:backend": "backend-fix" });
+  assert.deepEqual(res.rules, {
+    "frontend-fix": { any: ["pi:frontend"], all: [], none: [] },
+    "backend-fix": { any: ["pi:backend"], all: [], none: ["wontfix"] },
+  });
+});
+
+test("readFlows skips a rule whose value is not an object (viewer degrades)", () => {
+  const files = {
+    "receiver.flows.json": JSON.stringify({ "frontend-fix": { any: ["pi:frontend"] }, "backend-fix": "backend-fix" }),
+  };
+  const res = readFlows({ flowsPath: "/x/receiver.flows.json", fs: fakeFs(files) });
+  assert.deepEqual(res.rules, { "frontend-fix": { any: ["pi:frontend"], all: [], none: [] } });
+});
+
+test("readFlows returns { invalid } when the file is a JSON array", () => {
+  const files = { "receiver.flows.json": JSON.stringify(["frontend-fix"]) };
+  const res = readFlows({ flowsPath: "/x/receiver.flows.json", fs: fakeFs(files) });
+  assert.ok(res.invalid, "a top-level array is invalid, not a rule object");
 });
 
 test("readFlows returns { missing:true } when the file is absent (viewer degrades)", () => {

--- a/admin/test/render.test.mjs
+++ b/admin/test/render.test.mjs
@@ -79,15 +79,15 @@ test("renderBudget reports unreachable", () => {
   assert.match(renderBudget({ budget: { unreachable: "down" }, settings: {} }), /unreachable/);
 });
 
-test("renderTriggers lists schedulers with next + overdue drift and the label map", () => {
+test("renderTriggers lists schedulers with next + overdue drift and the per-flow rules", () => {
   const out = renderTriggers({
     schedulers: [{ key: "s1", next: Date.UTC(2026, 6, 21, 0, 0, 0), overdueMs: 5000 }],
-    flows: { mappings: { "pi:frontend": "frontend-fix" } },
+    flows: { rules: { "frontend-fix": { any: ["pi:frontend"], all: [], none: ["wontfix"] } } },
   });
   assert.match(out, /s1/);
   assert.match(out, /next 2026-07-21T00:00:00.000Z/);
   assert.match(out, /overdue by 5s/);
-  assert.match(out, /pi:frontend -> frontend-fix/);
+  assert.match(out, /frontend-fix: any\[pi:frontend\] none\[wontfix\]/);
 });
 
 test("renderTriggers degrades on no schedulers and missing flows", () => {
@@ -97,7 +97,7 @@ test("renderTriggers degrades on no schedulers and missing flows", () => {
 });
 
 test("renderTriggers reports an unreachable scheduler read", () => {
-  assert.match(renderTriggers({ schedulers: { unreachable: "down" }, flows: { mappings: {} } }), /unreachable \(down\)/);
+  assert.match(renderTriggers({ schedulers: { unreachable: "down" }, flows: { rules: {} } }), /unreachable \(down\)/);
 });
 
 test("renderSettingsView lists all five keys, unset ones marked", () => {

--- a/deploy/receiver.flows.json
+++ b/deploy/receiver.flows.json
@@ -1,4 +1,4 @@
 {
-  "pi:frontend": "frontend-fix",
-  "pi:backend": "backend-fix"
+  "frontend-fix": { "any": ["pi:frontend"] },
+  "backend-fix": { "any": ["pi:backend"] }
 }

--- a/receiver/src/config.mjs
+++ b/receiver/src/config.mjs
@@ -8,8 +8,8 @@
  *
  * - `webhookSecret` is REQUIRED: without it the receiver cannot verify `X-Hub-Signature-256` over the
  *   raw body, and an unverified webhook is a forgeable paid-agent trigger (CONST-HMAC-OVER-RAW-BODY).
- * - `labelFlows` IS the label allowlist: only labels present here map to a flow, and only collaborators
- *   can apply labels, so the map is the human approval gate (CONST-TRIGGER-AUTHOR-GATE).
+ * - `labelFlows` IS the label allowlist: each flow declares an `{any, all, none}` label rule, and only
+ *   collaborators can apply labels, so the allowlist is the human approval gate (CONST-TRIGGER-AUTHOR-GATE).
  * - `bind` defaults to `0.0.0.0` (public): the receiver is the trigger surface that lives outside pi
  *   (DES-TRIGGER-OUTSIDE-PI). It carries no admin/dashboard config -- the admin surface is a pi extension
  *   in the operator's session and binds no port (DES-ADMIN-VIA-PI-EXTENSION), so there is none here.
@@ -48,9 +48,15 @@ export function loadReceiverConfig(env = process.env, { readFile = readFileSync,
 }
 
 /**
- * Load and validate the label->flow allowlist from the flows file. The file is the reviewed, committed
- * source of truth for which labels trigger which flow; a missing, unparseable, or malformed file fails
- * loud rather than degrading to an empty (silently trigger-nothing) allowlist.
+ * Load and validate the flow -> `{any, all, none}` rule allowlist from the flows file. The file is the
+ * reviewed, committed source of truth for which label sets trigger which flow; a missing, unparseable, or
+ * malformed file fails loud rather than degrading to an empty (silently trigger-nothing) allowlist.
+ *
+ * Each rule needs at least one positive selector (`any` or `all`): a `none`-only rule matches every
+ * labeled event lacking the excluded labels, which is wider than today's single-label allowlist and would
+ * weaken CONST-TRIGGER-AUTHOR-GATE. Selectors are validated as arrays of non-empty strings BEFORE the
+ * positive-selector count, because `.length` is truthy on a string too -- a string selector that reached
+ * the pure `matchesRule` would throw there, breaking the gate's never-throw invariant.
  */
 function loadLabelFlows(env, readFile, fileExists) {
 	const path = env.RECEIVER_FLOWS_PATH ?? DEFAULT_FLOWS_PATH;
@@ -67,11 +73,24 @@ function loadLabelFlows(env, readFile, fileExists) {
 	}
 
 	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-		throw configError(`receiver flows file must be a JSON object of label -> flow strings: ${path}`);
+		throw configError(`receiver flows file must be a JSON object of flow -> {any, all, none} rules: ${path}`);
 	}
-	for (const [label, flow] of Object.entries(parsed)) {
-		if (typeof flow !== "string" || flow.trim() === "") {
-			throw configError(`receiver flows file has a non-string or empty flow for label ${JSON.stringify(label)}: ${path}`);
+	for (const [flowName, rule] of Object.entries(parsed)) {
+		if (flowName.trim() === "" || /^\d+$/.test(flowName)) {
+			throw configError(`receiver flows file has an empty or integer-like flow name ${JSON.stringify(flowName)}: ${path}`);
+		}
+		if (typeof rule !== "object" || rule === null || Array.isArray(rule)) {
+			throw configError(`receiver flows file flow ${JSON.stringify(flowName)} must map to an {any, all, none} rule object: ${path}`);
+		}
+		for (const key of ["any", "all", "none"]) {
+			const selector = rule[key];
+			if (selector === undefined) continue;
+			if (!Array.isArray(selector) || selector.some((s) => typeof s !== "string" || s.trim() === "")) {
+				throw configError(`receiver flows file flow ${JSON.stringify(flowName)} has a ${key} that is not an array of non-empty strings: ${path}`);
+			}
+		}
+		if ((rule.any?.length ?? 0) + (rule.all?.length ?? 0) === 0) {
+			throw configError(`receiver flows file flow ${JSON.stringify(flowName)} needs at least one positive selector (any or all): ${path}`);
 		}
 	}
 

--- a/receiver/src/filter.mjs
+++ b/receiver/src/filter.mjs
@@ -44,11 +44,12 @@ export function filter(eventName, subset, cfg, selfId, deliveryId) {
 	if (eventName === "issues" && LABEL_ACTIONS.has(action)) {
 		// Label path: the label allowlist IS the human approval gate -- only collaborators can label.
 		const labels = Array.isArray(subset.issue?.labels) ? subset.issue.labels : [];
+		const L = new Set(labels.map((l) => l?.name).filter((n) => typeof n === "string"));
 		const labelFlows = cfg?.labelFlows ?? {};
-		for (const label of labels) {
-			const name = label?.name;
-			if (typeof name === "string" && Object.prototype.hasOwnProperty.call(labelFlows, name)) {
-				flow = labelFlows[name];
+		// Flow-keyed predicate: iterate flows in file (insertion) order; the first whose rule matches wins.
+		for (const [flowName, rule] of Object.entries(labelFlows)) {
+			if (matchesRule(L, rule)) {
+				flow = flowName;
 				break;
 			}
 		}
@@ -66,9 +67,9 @@ export function filter(eventName, subset, cfg, selfId, deliveryId) {
 			return { enqueue: false, reason: "no-trigger-phrase" };
 		}
 		// Default to the configured flow; an explicit `<phrase> <flow>` overrides only when `<flow>` is
-		// a known flow value, so a comment cannot summon an unlisted flow.
+		// a known flow name, so a comment cannot summon an unlisted flow.
 		flow = cfg?.commentTrigger?.defaultFlow;
-		const knownFlows = new Set(Object.values(cfg?.labelFlows ?? {}));
+		const knownFlows = new Set(Object.keys(cfg?.labelFlows ?? {}));
 		const match = body.match(new RegExp(escapeRegExp(phrase) + "\\s+(\\S+)"));
 		if (match && knownFlows.has(match[1])) {
 			flow = match[1];
@@ -91,6 +92,24 @@ export function filter(eventName, subset, cfg, selfId, deliveryId) {
 		trigger: { event: eventName, action, deliveryId, sender: { id: subset.sender.id } },
 	};
 	return { enqueue: true, job };
+}
+
+/**
+ * Per-flow label predicate over the issue's label set `L`:
+ *   (any empty OR L∩any ≠ ∅) AND (all ⊆ L) AND (L∩none = ∅).
+ * An empty `any` is vacuously true, so the `all`/`none` clauses carry the requirement; the loader
+ * guarantees at least one positive selector (`config.mjs` loadLabelFlows), so a validated rule can never
+ * match every event. Reads only its arguments and never throws -- the gate's purity extends here, and
+ * the defensive `?? []` covers a rule the loader has already validated.
+ */
+function matchesRule(L, rule) {
+	const any = rule?.any ?? [];
+	const all = rule?.all ?? [];
+	const none = rule?.none ?? [];
+	if (any.length > 0 && !any.some((x) => L.has(x))) return false;
+	if (!all.every((x) => L.has(x))) return false;
+	if (none.some((x) => L.has(x))) return false;
+	return true;
 }
 
 /** Escape a literal string for safe embedding in a RegExp -- the trigger phrase is config, not a pattern. */

--- a/receiver/test/config.test.mjs
+++ b/receiver/test/config.test.mjs
@@ -2,11 +2,16 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { loadReceiverConfig } from "../src/config.mjs";
 
-// A valid flows file, injected: exists and parses to a well-formed label -> flow map.
+// A valid flows file, injected: exists and parses to a well-formed flow -> {any, all, none} rule map.
 const validFlows = {
 	fileExists: () => true,
-	readFile: () => '{"pi:frontend":"frontend-fix"}',
+	readFile: () => '{"frontend-fix":{"any":["pi:frontend"]}}',
 };
+
+/** Inject a flows file whose raw JSON is `json`, with WEBHOOK_SECRET present. */
+function withFlows(json) {
+	return () => loadReceiverConfig({ WEBHOOK_SECRET: "shh" }, { fileExists: () => true, readFile: () => json });
+}
 
 test("missing WEBHOOK_SECRET is a config error -- never boot unable to verify signatures", () => {
 	assert.throws(() => loadReceiverConfig({}, validFlows), (e) => e.piDispatchConfig === true);
@@ -22,7 +27,7 @@ test("a valid secret + injected flows yields conservative defaults and the parse
 	assert.equal(c.webhookSecret, "shh");
 	assert.equal(c.bind, "0.0.0.0");
 	assert.equal(c.port, 3000);
-	assert.equal(c.labelFlows["pi:frontend"], "frontend-fix");
+	assert.deepEqual(c.labelFlows["frontend-fix"], { any: ["pi:frontend"] });
 });
 
 test("RECEIVER_PORT and RECEIVER_BIND overrides are honored", () => {
@@ -62,11 +67,44 @@ test("malformed flows JSON is a config error", () => {
 	);
 });
 
-test("a non-string flow value is a config error", () => {
-	assert.throws(
-		() => loadReceiverConfig({ WEBHOOK_SECRET: "shh" }, { fileExists: () => true, readFile: () => '{"pi:x": 5}' }),
-		(e) => e.piDispatchConfig === true,
-	);
+test("a none-only rule is a config error -- no positive selector would widen the trigger surface", () => {
+	assert.throws(withFlows('{"fix":{"none":["blocked"]}}'), (e) => e.piDispatchConfig === true);
+});
+
+test("an empty rule {} is a config error (no positive selector)", () => {
+	assert.throws(withFlows('{"fix":{}}'), (e) => e.piDispatchConfig === true);
+});
+
+test('a string selector (any:"foo") is rejected as non-array BEFORE the positive-selector count', () => {
+	// The ordering guard: .length is truthy on a string, so a count-first check would accept this and let
+	// the pure matchesRule throw on "foo".some(...). Array-ness is checked first, so this is a load error.
+	assert.throws(withFlows('{"fix":{"any":"foo"}}'), (e) => e.piDispatchConfig === true);
+});
+
+test("a non-array selector (all:{}) is a config error", () => {
+	assert.throws(withFlows('{"fix":{"all":{}}}'), (e) => e.piDispatchConfig === true);
+});
+
+test("an empty-string selector member is a config error", () => {
+	assert.throws(withFlows('{"fix":{"any":["",""]}}'), (e) => e.piDispatchConfig === true);
+});
+
+test("a rule value that is not an object is a config error", () => {
+	assert.throws(withFlows('{"fix":5}'), (e) => e.piDispatchConfig === true);
+});
+
+test("an integer-like flow key is a config error -- V8 reorders integer keys, breaking file order", () => {
+	assert.throws(withFlows('{"1":{"any":["pi:x"]}}'), (e) => e.piDispatchConfig === true);
+});
+
+test("an all-only rule is accepted (all carries the requirement)", () => {
+	const c = loadReceiverConfig({ WEBHOOK_SECRET: "shh" }, { fileExists: () => true, readFile: () => '{"fix":{"all":["a","b"]}}' });
+	assert.deepEqual(c.labelFlows["fix"], { all: ["a", "b"] });
+});
+
+test("an explicit empty `any` alongside a non-empty `all` is accepted", () => {
+	const c = loadReceiverConfig({ WEBHOOK_SECRET: "shh" }, { fileExists: () => true, readFile: () => '{"fix":{"any":[],"all":["a"]}}' });
+	assert.deepEqual(c.labelFlows["fix"], { any: [], all: ["a"] });
 });
 
 test("a non-object flows file (JSON array) is a config error", () => {

--- a/receiver/test/enqueue.integration.test.mjs
+++ b/receiver/test/enqueue.integration.test.mjs
@@ -23,7 +23,7 @@ const SECRET = "test-webhook-secret";
 const SELF_ID = 999;
 const cfg = {
 	webhookSecret: SECRET,
-	labelFlows: { "pi:frontend": "frontend-fix" },
+	labelFlows: { "frontend-fix": { any: ["pi:frontend"] } },
 	commentTrigger: { phrase: "@pi", defaultFlow: null },
 };
 

--- a/receiver/test/filter.test.mjs
+++ b/receiver/test/filter.test.mjs
@@ -4,7 +4,16 @@ import { filter } from "../src/filter.mjs";
 
 // The reviewed allowlist + comment trigger, mirroring loadReceiverConfig's shape.
 const cfg = {
-	labelFlows: { "pi:frontend": "frontend-fix" },
+	labelFlows: { "frontend-fix": { any: ["pi:frontend"] } },
+	commentTrigger: { phrase: "@pi", defaultFlow: "triage" },
+};
+// A richer allowlist exercising every predicate clause: any-of-many, a required `all`, exclusion `none`,
+// and a second flow to prove first-match-in-file-order and single-clause routing.
+const matrixCfg = {
+	labelFlows: {
+		fix: { any: ["ai-fix", "urgent-fix"], all: ["triaged"], none: ["blocked", "wontfix"] },
+		review: { any: ["ai-review"] },
+	},
 	commentTrigger: { phrase: "@pi", defaultFlow: "triage" },
 };
 const SELF_ID = 999;
@@ -30,6 +39,11 @@ function issuesSubset(over = {}) {
 		issue: { number: 42, title: "T", body: "B", labels: [{ name: "pi:frontend" }] },
 		...over,
 	};
+}
+
+/** An `issues.labeled` subset carrying exactly the named labels -- for the predicate matrix. */
+function labeledSubset(labelNames) {
+	return issuesSubset({ issue: { number: 42, title: "T", body: "B", labels: labelNames.map((name) => ({ name })) } });
 }
 
 test("self-comment is dropped even though it would clear the author gate + phrase (PAT owner mode)", () => {
@@ -124,6 +138,42 @@ test("issues.opened and issues.reopened also route the label path", () => {
 		assert.equal(r.enqueue, true);
 		assert.equal(r.job.trigger.action, action);
 	}
+});
+
+test("predicate: an `any` hit with all required labels and no exclusion enqueues the flow", () => {
+	const r = filter("issues", labeledSubset(["ai-fix", "triaged"]), matrixCfg, SELF_ID, "d-m1");
+	assert.equal(r.enqueue, true);
+	assert.equal(r.job.flow, "fix");
+});
+
+test("predicate: an `any` hit missing a required `all` label is dropped (all makes it stricter)", () => {
+	const r = filter("issues", labeledSubset(["ai-fix"]), matrixCfg, SELF_ID, "d-m2");
+	assert.equal(r.enqueue, false);
+	assert.equal(r.reason, "no-allowlisted-label");
+});
+
+test("predicate: a `none` label suppresses the flow (exclusion brake); no other flow matches", () => {
+	const r = filter("issues", labeledSubset(["ai-fix", "triaged", "blocked"]), matrixCfg, SELF_ID, "d-m3");
+	assert.equal(r.enqueue, false);
+	assert.equal(r.reason, "no-allowlisted-label");
+});
+
+test("predicate: no positive (`any`) label present is dropped", () => {
+	const r = filter("issues", labeledSubset(["triaged"]), matrixCfg, SELF_ID, "d-m4");
+	assert.equal(r.enqueue, false);
+	assert.equal(r.reason, "no-allowlisted-label");
+});
+
+test("predicate: the first flow in file order wins when several rules could match", () => {
+	const r = filter("issues", labeledSubset(["ai-fix", "triaged", "ai-review"]), matrixCfg, SELF_ID, "d-m5");
+	assert.equal(r.enqueue, true);
+	assert.equal(r.job.flow, "fix");
+});
+
+test("predicate: a label matching only the second flow routes to it (single-clause any)", () => {
+	const r = filter("issues", labeledSubset(["ai-review"]), matrixCfg, SELF_ID, "d-m6");
+	assert.equal(r.enqueue, true);
+	assert.equal(r.job.flow, "review");
 });
 
 test("comment with the phrase but no defaultFlow and no @pi <flow> is dropped as no-flow", () => {

--- a/receiver/test/receiver.test.mjs
+++ b/receiver/test/receiver.test.mjs
@@ -8,7 +8,7 @@ const SECRET = "test-webhook-secret";
 const SELF_ID = 999;
 const cfg = {
 	webhookSecret: SECRET,
-	labelFlows: { "pi:frontend": "frontend-fix" },
+	labelFlows: { "frontend-fix": { any: ["pi:frontend"] } },
 	commentTrigger: { phrase: "@pi", defaultFlow: null },
 };
 

--- a/specs/design.md
+++ b/specs/design.md
@@ -445,7 +445,7 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   (`/dispatch status|pause|resume|runs|logs|budget|triggers|settings|set|unset`) and one
   self-refreshing TUI overlay component with **three in-component views**: **LIST** — a framed
   monochrome panel carrying a status bar, a SPEND meter, a unified **TRIGGERS** pane that shows
-  schedulers plus `label -> flow` mappings **display-only**, and an interactive runs list with `↑↓`
+  schedulers plus the per-flow `{any, all, none}` trigger rules **display-only**, and an interactive runs list with `↑↓`
   selection; **RUN_DETAIL** — a drill-in dump of the selected run's PII-free `.json` run-record fields;
   and **LIVE_TAIL** — a view that tails a running job's `.log` **inside the overlay** through an
   injected `deps.tailLog` seam whose `fs` read lives in `index.ts`. The LLM-callable tools are reads,

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -463,6 +463,9 @@ Evidence convention as in `constitution.md`.
   - Headers consumed: `X-Hub-Signature-256`, `X-GitHub-Event`, `X-GitHub-Delivery`
   - Body fields consumed: `action`, `issue.number`, `issue.title`, `issue.body`, `issue.labels[].name`,
     `comment.body`, `comment.author_association`, `sender.id`, `repository.full_name`
+  - `issue.labels[].name` is consumed as a **set**, evaluated by the per-flow `{any, all, none}` trigger
+    predicate (`REQ-TRIGGER-AUTHOR-GATE`) — this changes *how* the field is used, not which fields are
+    read; it is no new field.
   - **Everything else is ignored.**
 - **Why**: Naming the subset **is** the contract. Because everything else is ignored by construction, an
   upstream schema addition cannot change our behaviour — and a reviewer can see the entire attack

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -144,13 +144,20 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
 
 - **Statement**: The receiver shall enqueue only for allowlisted labels, or comments whose
   `author_association ∈ {OWNER, MEMBER, COLLABORATOR}` matching the trigger phrase. Events sent by our
-  own App identity shall be ignored.
+  own App identity shall be ignored. The label allowlist is a per-flow `{any, all, none}` predicate over
+  the issue's label set: `any` is an OR requirement, `all` a stricter AND requirement, and `none` is
+  **suppress-only** — it can never cause a trigger, only prevent one. A rule shall carry at least one
+  positive selector (a non-empty `any` or `all`); the whole predicate stays equal-or-stricter than a
+  single-label OR and collaborator-gated, since only collaborators can apply labels.
 - **Why**: The enforcement of `CONST-TRIGGER-AUTHOR-GATE`. The bot-loop guard matters independently: our
   own job comments on the issue, which is an `issue_comment.created` event, which without the guard
-  triggers another job — an unbounded paid recursion.
+  triggers another job — an unbounded paid recursion. The positive-selector requirement is what keeps a
+  `none`-only rule — which would match every labeled event lacking the excluded labels, wider than
+  today — from ever loading.
 - **Traces to**: `CONST-TRIGGER-AUTHOR-GATE`, `CONST-HMAC-OVER-RAW-BODY`
 - **Acceptance**: Given `@pi fix this` with `author_association: NONE`, 204 and zero jobs. Given a
-  comment from our own App id, 204 and zero jobs.
+  comment from our own App id, 204 and zero jobs. Given a flow rule with no positive selector (`none`
+  only, or empty), config load fails and the receiver does not boot.
 
 ## REQ-JOB-TIMEOUT-30M
 


### PR DESCRIPTION
Replace the receiver's flat `{label → flow}` trigger allowlist with a per-flow `{any, all, none}` predicate, so a flow can **require** several labels (`all`) and be **suppressed** by exclusion labels (`none`). The change is strictly **equal-or-stricter** than today's single-label OR and stays collaborator-gated: the loader rejects any rule with no positive selector (`any`/`all` both empty), which is the invariant that makes `none` provably suppress-only and keeps `CONST-TRIGGER-AUTHOR-GATE` intact. The admin extension — a second, display-only reader of the same file (not in the original issue scope; found by a scope-completeness sweep) — is migrated to render the new rule shape, fail-soft and read-only (`OQ-008` stays open).

## Verification
| Check | Baseline | Final |
|-------|----------|-------|
| test (node --test, all workspaces) | 590 tests, 575 pass, 0 fail, 15 skip | 606 tests, 591 pass, 0 fail, 15 skip (+16 coverage, 0 regressions) |
| Webhook (trust boundary) | — | PASS — signed→1 job; wrong-sig→401 before parse (`CONST-HMAC-OVER-RAW-BODY`); exclusion brake proven; author-gate/self-id/dedup unchanged & green |
| Container Smoke | — | N/A (touches neither `image/` nor `image/runner/`) |
| Queue | — | N/A (does not touch `worker/`) |
| Legacy sweep | — | PASS (flat shape fully removed; no dead code, no compat-union) |

Loader validation order is load-bearing: the array-type check runs **before** the positive-selector count, so a string selector (`{any:"foo"}`) is rejected at load and never reaches the pure never-throw predicate. Specs `REQ-TRIGGER-AUTHOR-GATE`, `INT-WEBHOOK-PAYLOAD-SUBSET`, and `design.md` record that `none` is suppress-only and that no new webhook field is consumed.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
