### PR TITLE
feat(budget): week/month spend caps + soft-hold band (#19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,11 @@ PI_MODEL=claude-sonnet-4-5-20250929
 
 # --- Spend + concurrency guards (money bounds; all have conservative defaults) ---
 PI_MAX_TURNS=30        # per-job turn cap -- pi has none of its own, so the harness imposes one
-PI_DAILY_CAP=25        # max job containers started per day
+PI_DAILY_CAP=25        # max job containers started per day (mandatory window)
+# PI_WEEKLY_CAP=100    # optional weekly ceiling on container starts; unset = weekly window disabled
+# PI_MONTHLY_CAP=400   # optional monthly ceiling on container starts; unset = monthly window disabled
+# PI_SOFT_HOLD_PCT=80  # optional soft-hold band (1-99): once any window hits this % of its cap, new starts
+                       # pause (in-flight jobs finish) and the panel meter turns amber; unset = disabled
 PI_CONCURRENCY=3       # how many jobs run in parallel
 
 # --- Infrastructure ---

--- a/admin/src/dashboard.ts
+++ b/admin/src/dashboard.ts
@@ -18,7 +18,7 @@
  * touches the filesystem -- the bytes reach the overlay alone, never `snapshot`, never a shared renderer,
  * never a message.
  */
-import { dayKey } from "@pi-dispatch/worker/budget";
+import { dayKey, weekKey, monthKey, windowState } from "@pi-dispatch/worker/budget";
 import { parseConnection, makeRedisClient } from "@pi-dispatch/worker/connection";
 import { makeQueue } from "@pi-dispatch/worker/queue";
 import { listRuns, readSettingsView, mapSchedulers, readFlows } from "./read-model.mjs";
@@ -48,18 +48,20 @@ export function createDashboardDeps(paths: any) {
   const redis = makeRedisClient(paths.valkeyUrl);
   return {
     async fetchSnapshot() {
-      const [pausedState, counts, workerList, reservedRaw, schedulerList, activeList] = await Promise.all([
+      const [pausedState, counts, workerList, dayRaw, weekRaw, monthRaw, schedulerList, activeList] = await Promise.all([
         queue.isPaused(),
         queue.getJobCounts("waiting", "active", "paused", "delayed", "failed"),
         queue.getWorkers().catch(() => []),
         redis.get(dayKey()),
+        redis.get(weekKey()),
+        redis.get(monthKey()),
         queue.getJobSchedulers(0, -1, true),
         queue.getActive(0, 0).catch(() => []),
       ]);
       const workers = Array.isArray(workerList) && workerList.length > 0 ? workerList.length : "unknown";
       return {
         queue: { pausedState, counts, workers },
-        budget: { reserved: Number(reservedRaw ?? 0) },
+        budget: { day: Number(dayRaw ?? 0), week: Number(weekRaw ?? 0), month: Number(monthRaw ?? 0) },
         schedulers: mapSchedulers(schedulerList, Date.now()),
         runs: listRuns({ logsDir: paths.logsDir, limit: RUNS_ON_DASHBOARD }),
         settings: readSettingsView({ settingsFile: paths.settingsFile }),
@@ -277,6 +279,31 @@ function toLines(text: string): string[] {
 }
 
 /**
+ * One meter per spend window whose cap the admin can read (the overlay sets it). The day meter always shows
+ * (parity with the single-window panel); week/month meters show only when their overlay cap is set. Each
+ * meter's state comes from the worker's own `windowState`, so the bar's amber/red marker cannot drift from
+ * what `reserveBudget` enforces. `meter` renders "cap unknown" for a window with no readable cap, so a
+ * missing overlay cap degrades in place rather than guessing a denominator.
+ */
+function budgetMeters(budget: any, settings: any, width: number): string[] {
+  const overlay = settings?.overlay ?? {};
+  const pct = Number.isInteger(overlay.softHoldPct) ? overlay.softHoldPct : null;
+  const specs = [
+    { key: "day", cap: overlay.dailyCap, always: true },
+    { key: "week", cap: overlay.weeklyCap, always: false },
+    { key: "month", cap: overlay.monthlyCap, always: false },
+  ];
+  const out: string[] = [];
+  for (const s of specs) {
+    if (!s.always && !Number.isInteger(s.cap)) continue;
+    const reserved = Number(budget?.[s.key] ?? 0);
+    const state = Number.isInteger(s.cap) ? windowState(reserved, s.cap, pct) : "ok";
+    out.push(meter(reserved, s.cap, width, state));
+  }
+  return out;
+}
+
+/**
  * Compose the monochrome framed panel from the last snapshot alone, reusing the slash-command renderers so
  * the panel and the commands cannot drift. A null snapshot is the pre-first-fetch loading state; a snapshot
  * carrying `unreachable` degrades the whole panel to one line rather than a wall of empty sections. A width
@@ -315,8 +342,8 @@ function renderPanel(snapshot: any, width: number, state: any): string[] {
     {
       title: "SPEND",
       lines: [
-        renderBudget({ budget: snapshot.budget, settings: snapshot.settings }),
-        meter(snapshot.budget?.reserved, snapshot.settings?.overlay?.dailyCap, framed ? inner : 24),
+        ...toLines(renderBudget({ budget: snapshot.budget, settings: snapshot.settings })),
+        ...budgetMeters(snapshot.budget, snapshot.settings, framed ? inner : 24),
       ],
     },
     { title: "TRIGGERS", lines: toLines(renderTriggers({ schedulers: snapshot.schedulers, flows: snapshot.flows })) },

--- a/admin/src/panel.mjs
+++ b/admin/src/panel.mjs
@@ -101,13 +101,18 @@ export function box({ title = "", sections = [], footer, width = 40 } = {}) {
  * A block-char progress bar `[####....] reserved/cap` fitted to `width`. When `cap` is not a positive
  * integer the true cap is unknown to this process, so it renders `reserved / ? (cap unknown)` with no bar
  * rather than a bar against a guessed denominator.
+ *
+ * `state` ("ok" | "soft-hold" | "over") appends a textual marker to the label: the panel is monochrome and
+ * `clip` strips ANSI, so the amber/red of a soft-hold or over-budget window is carried as a word, not a
+ * color. "ok" (the default) adds nothing, so a plain call renders exactly as before.
  */
-export function meter(reserved, cap, width = 24) {
+export function meter(reserved, cap, width = 24, state = "ok") {
   const r = Number.isFinite(reserved) ? Math.max(0, Math.trunc(reserved)) : 0;
   if (!Number.isInteger(cap) || cap <= 0) {
     return clip(`${r} / ? (cap unknown)`, width);
   }
-  const label = ` ${r}/${cap}`;
+  const tag = state === "soft-hold" ? " soft-hold" : state === "over" ? " over" : "";
+  const label = ` ${r}/${cap}${tag}`;
   const barCells = Math.max(0, Math.trunc(width) - label.length - 2); // "[" + cells + "]" + label
   const filled = Math.min(barCells, Math.round((Math.min(r, cap) / cap) * barCells));
   const bar = `[${GLYPHS.full.repeat(filled)}${GLYPHS.empty.repeat(barCells - filled)}]`;

--- a/admin/src/read-model.mjs
+++ b/admin/src/read-model.mjs
@@ -21,7 +21,7 @@ import { execFileSync } from "node:child_process";
 import { defaultLogsDir } from "@pi-dispatch/worker/config";
 import { settingsFilePath, readOverlay, writeOverlay, KNOWN_KEYS } from "@pi-dispatch/worker/runtime-settings";
 import { sanitizeJobId } from "@pi-dispatch/worker/run-history";
-import { dayKey } from "@pi-dispatch/worker/budget";
+import { dayKey, weekKey, monthKey } from "@pi-dispatch/worker/budget";
 import { parseConnection, makeRedisClient } from "@pi-dispatch/worker/connection";
 import { makeQueue, enqueueLocalJob } from "@pi-dispatch/worker/queue";
 import { readFlowGate } from "@pi-dispatch/worker/flow-gate";
@@ -321,17 +321,19 @@ export function mapSchedulers(list, nowMs) {
 }
 
 /**
- * Read today's reserved budget count with a plain, side-effect-free GET of the worker's own `dayKey()` --
- * NEVER an INCR/EXPIRE, so observing the budget cannot consume a slot. `makeRedisClient` has no failFast
- * option and would otherwise buffer the GET forever while disconnected, so the read is bounded by a
- * timeout that degrades to `{ unreachable }`; the client is force-disconnected in `finally`.
+ * Read the reserved counts for all three spend windows with plain, side-effect-free GETs of the worker's own
+ * `dayKey()` / `weekKey()` / `monthKey()` -- NEVER an INCR/EXPIRE, so observing the budget cannot consume a
+ * slot. Returns `{ day, week, month }` reserved counts (the caps live in the settings overlay, resolved by
+ * the renderer). `makeRedisClient` has no failFast option and would otherwise buffer the GETs forever while
+ * disconnected, so the read is bounded by a timeout that degrades to `{ unreachable }`; the client is
+ * force-disconnected in `finally`.
  */
 export async function readBudget({ url, redisFn = makeRedisClient, timeoutMs = 2500 } = {}) {
   let redis;
   try {
     redis = redisFn(url);
-    const settled = Promise.resolve(redis.get(dayKey())).then(
-      (value) => ({ reserved: Number(value ?? 0) }),
+    const settled = Promise.all([redis.get(dayKey()), redis.get(weekKey()), redis.get(monthKey())]).then(
+      ([day, week, month]) => ({ day: Number(day ?? 0), week: Number(week ?? 0), month: Number(month ?? 0) }),
       (err) => ({ unreachable: err?.message ?? String(err) }),
     );
     return await withTimeout(settled, timeoutMs, { unreachable: "timed out reaching the queue" });

--- a/admin/src/render.mjs
+++ b/admin/src/render.mjs
@@ -10,7 +10,16 @@
  * from here to a `.log` file (asserted by render.test.mjs).
  */
 
-const SETTINGS_KEYS = ["model", "provider", "maxTurns", "dailyCap", "concurrency"];
+import { windowState } from "@pi-dispatch/worker/budget";
+
+const SETTINGS_KEYS = ["model", "provider", "maxTurns", "dailyCap", "weeklyCap", "monthlyCap", "concurrency", "softHoldPct"];
+
+// The three spend windows and the overlay cap key each reads. Order is day -> week -> month.
+const BUDGET_WINDOWS = [
+  { key: "day", label: "day", capKey: "dailyCap" },
+  { key: "week", label: "week", capKey: "weeklyCap" },
+  { key: "month", label: "month", capKey: "monthlyCap" },
+];
 
 const RUN_COLUMNS = [
   { key: "jobId", header: "JOB ID" },
@@ -58,21 +67,39 @@ export function renderRuns(runs) {
 }
 
 /**
- * Render the budget: reserved count and the daily cap. The cap is only known to the admin when the
- * overlay sets `dailyCap`; otherwise the worker resolves it from its own env/default, which this process
- * cannot read authoritatively, so it renders as unknown rather than a guessed number.
+ * Render the budget across the day/week/month windows, each `reserved / cap [state]`. A cap is only known
+ * to the admin when the overlay sets it; otherwise the worker resolves it from its own env/default, which
+ * this process cannot read authoritatively, so it renders as unknown rather than a guessed number. The
+ * per-window state ("soft-hold" / "over") is computed via the worker's own `windowState` -- the same
+ * classifier `reserveBudget` uses -- so the panel and the enforcement cannot drift.
+ *
+ * The day line always shows (parity with the single-window view). Week/month lines show only when they are
+ * actually in play -- the overlay sets their cap, or the window has a non-zero reserved count (an
+ * env-configured window the admin can see reserving but whose cap it cannot read). The soft-hold line shows
+ * only when the overlay sets `softHoldPct`.
  */
 export function renderBudget({ budget, settings } = {}) {
   if (!budget || budget.unreachable) {
     return `Budget: unreachable (${budget?.unreachable ?? "unknown"})`;
   }
-  return `Budget: reserved ${budget.reserved ?? 0} / cap ${capLabel(settings)}`;
+  const overlay = (settings && settings.overlay) ?? {};
+  const pct = Number.isInteger(overlay.softHoldPct) ? overlay.softHoldPct : null;
+  const lines = ["Budget:"];
+  for (const w of BUDGET_WINDOWS) {
+    const reserved = Number(budget[w.key] ?? 0);
+    const cap = overlay[w.capKey];
+    if (w.key !== "day" && !Number.isInteger(cap) && reserved === 0) continue; // window not in play
+    lines.push(`  ${w.label}: reserved ${reserved} / cap ${capLabel(cap, reserved, pct)}`);
+  }
+  if (pct !== null) lines.push(`  soft-hold band: ${pct}%`);
+  return lines.join("\n");
 }
 
-function capLabel(settings) {
-  const overlay = settings && settings.overlay;
-  if (overlay && Number.isInteger(overlay.dailyCap)) return `${overlay.dailyCap} (overlay)`;
-  return "unknown (worker env/default)";
+/** One window's cap + state suffix: the overlay cap and its classified state, or the unknown-cap notice. */
+function capLabel(cap, reserved, pct) {
+  if (!Number.isInteger(cap)) return "unknown (worker env/default)";
+  const state = windowState(reserved, cap, pct);
+  return state === "ok" ? `${cap} (overlay)` : `${cap} (overlay) [${state}]`;
 }
 
 /**

--- a/admin/test/dashboard.test.mjs
+++ b/admin/test/dashboard.test.mjs
@@ -22,7 +22,7 @@ const fakeTui = () => ({ requestRender() {} });
 
 const SNAPSHOT = {
   queue: { pausedState: true, counts: { waiting: 2, active: 1, paused: 0, delayed: 0, failed: 3 }, workers: 1 },
-  budget: { reserved: 5 },
+  budget: { day: 5, week: 0, month: 0 },
   settings: { path: "/s", overlay: { model: "claude-x", dailyCap: 25 } },
   runs: [
     {
@@ -234,6 +234,31 @@ test("the spend meter shows a filled bar against a known cap, and (cap unknown) 
   assert.match(knownOut, /[█]/, "a filled block glyph fills the bar");
   assert.match(unknownOut, /cap unknown/, "an unknown cap renders as text");
   assert.doesNotMatch(unknownOut, /[█]/, "no bar is drawn against an unknown denominator");
+});
+
+test("the spend panel shows the soft-hold state (amber-as-text) when a window is in the band", async () => {
+  // day cap 10, softHoldPct 80 -> threshold 8; reserved 9 is in-band, week/month set so all three meter.
+  const comp = makeDashboard({
+    paths: {},
+    done() {},
+    tui: fakeTui(),
+    intervalMs: 100000,
+    deps: cannedDeps({
+      fetchSnapshot: async () => ({
+        ...SNAPSHOT,
+        budget: { day: 9, week: 1, month: 1 },
+        settings: { path: "/s", overlay: { dailyCap: 10, weeklyCap: 50, monthlyCap: 200, softHoldPct: 80 } },
+      }),
+    }),
+  });
+  await flush();
+  const out = comp.render(80).join("\n");
+  await comp.dispose();
+
+  assert.match(out, /day: reserved 9 \/ cap 10 \(overlay\) \[soft-hold\]/, "the day window text shows soft-hold");
+  assert.match(out, /soft-hold band: 80%/, "the configured band is shown");
+  assert.match(out, /9\/10 soft-hold/, "the day meter carries the soft-hold marker (monochrome, so text not colour)");
+  assert.match(out, /week: reserved 1 \/ cap 50/, "the week window is listed once its cap is set");
 });
 
 test("the TRIGGERS section unifies the label allowlist with the schedulers block", async () => {

--- a/admin/test/panel.test.mjs
+++ b/admin/test/panel.test.mjs
@@ -53,6 +53,14 @@ test("meter renders a bar glyph and reserved/cap", () => {
   assert.match(out, /3\/10/);
 });
 
+test("meter appends a textual state marker for soft-hold and over (no colour in a monochrome panel)", () => {
+  assert.match(meter(9, 10, 24, "soft-hold"), /9\/10 soft-hold/);
+  assert.match(meter(11, 10, 24, "over"), /11\/10 over/);
+  // "ok" (the default) adds nothing, so a plain call is unchanged.
+  assert.doesNotMatch(meter(3, 10, 24, "ok"), /soft-hold|over/);
+  assert.doesNotMatch(meter(3, 10, 24), /soft-hold|over/);
+});
+
 test("meter renders (cap unknown) with no bar glyph when cap is not a positive integer", () => {
   const out = meter(5, null, 24);
   assert.match(out, /\(cap unknown\)/);

--- a/admin/test/read-model.test.mjs
+++ b/admin/test/read-model.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { dayKey } from "@pi-dispatch/worker/budget";
+import { dayKey, weekKey, monthKey } from "@pi-dispatch/worker/budget";
 import {
   resolvePaths,
   readQueueState,
@@ -152,25 +152,27 @@ test("readLogTail returns the last N lines, dropping the trailing-newline segmen
   assert.deepEqual(rec.lines, ["l4", "l5"]);
 });
 
-test("readBudget issues only a GET of the day key and never mutates", async () => {
+test("readBudget GETs the day/week/month keys and never mutates", async () => {
   const commands = [];
+  const values = { [dayKey()]: "7", [weekKey()]: "20", [monthKey()]: "55" };
   const redis = {
     async get(key) {
       commands.push(["get", key]);
-      return "7";
+      return values[key] ?? null;
     },
     disconnect() {
       commands.push(["disconnect"]);
     },
   };
   const res = await readBudget({ url: "redis://x", redisFn: () => redis });
-  assert.deepEqual(res, { reserved: 7 });
+  assert.deepEqual(res, { day: 7, week: 20, month: 55 });
+  const ops = commands.filter((c) => c[0] !== "disconnect");
+  assert.deepEqual(new Set(ops.map((c) => c[0])), new Set(["get"]), "only GET -- never INCR/EXPIRE");
   assert.deepEqual(
-    commands.filter((c) => c[0] !== "disconnect").map((c) => c[0]),
-    ["get"],
-    "only GET -- never INCR/EXPIRE",
+    new Set(ops.map((c) => c[1])),
+    new Set([dayKey(), weekKey(), monthKey()]),
+    "GETs the worker's own day/week/month keys",
   );
-  assert.equal(commands[0][1], dayKey(), "GET is keyed on the worker's own dayKey()");
 });
 
 test("readBudget returns { unreachable } when the client errors", async () => {

--- a/admin/test/render.test.mjs
+++ b/admin/test/render.test.mjs
@@ -64,15 +64,42 @@ test("renderRuns degrades on empty and unreachable inputs", () => {
   assert.match(renderRuns({ unreachable: "x" }), /unreachable/);
 });
 
-test("renderBudget shows reserved and the overlay-derived cap", () => {
-  const out = renderBudget({ budget: { reserved: 5 }, settings: { path: "/s", overlay: { dailyCap: 25 } } });
-  assert.match(out, /reserved 5/);
-  assert.match(out, /cap 25 \(overlay\)/);
+test("renderBudget shows the day window's reserved count and the overlay-derived cap", () => {
+  const out = renderBudget({ budget: { day: 5, week: 0, month: 0 }, settings: { path: "/s", overlay: { dailyCap: 25 } } });
+  assert.match(out, /day: reserved 5 \/ cap 25 \(overlay\)/);
 });
 
-test("renderBudget marks the cap unknown when the overlay omits dailyCap", () => {
-  const out = renderBudget({ budget: { reserved: 0 }, settings: { path: "/s", overlay: {} } });
-  assert.match(out, /cap unknown/);
+test("renderBudget marks the day cap unknown when the overlay omits dailyCap", () => {
+  const out = renderBudget({ budget: { day: 0 }, settings: { path: "/s", overlay: {} } });
+  assert.match(out, /day: reserved 0 \/ cap unknown/);
+});
+
+test("renderBudget shows week/month windows only when the overlay sets their cap (or they are reserving)", () => {
+  const withCaps = renderBudget({
+    budget: { day: 1, week: 4, month: 9 },
+    settings: { path: "/s", overlay: { dailyCap: 25, weeklyCap: 100, monthlyCap: 400 } },
+  });
+  assert.match(withCaps, /week: reserved 4 \/ cap 100 \(overlay\)/);
+  assert.match(withCaps, /month: reserved 9 \/ cap 400 \(overlay\)/);
+
+  // No overlay week/month caps and zero reserved -> those lines are omitted (window not in play).
+  const dayOnly = renderBudget({ budget: { day: 1, week: 0, month: 0 }, settings: { path: "/s", overlay: { dailyCap: 25 } } });
+  assert.doesNotMatch(dayOnly, /week:/);
+  assert.doesNotMatch(dayOnly, /month:/);
+
+  // An env-configured window the admin cannot read the cap for still surfaces once it is reserving.
+  const envWeek = renderBudget({ budget: { day: 1, week: 3, month: 0 }, settings: { path: "/s", overlay: { dailyCap: 25 } } });
+  assert.match(envWeek, /week: reserved 3 \/ cap unknown/);
+});
+
+test("renderBudget marks a window soft-hold / over via the shared windowState, and shows the band", () => {
+  // day cap 10, softHoldPct 80 -> threshold 8; reserved 9 is inside the band.
+  const soft = renderBudget({ budget: { day: 9 }, settings: { path: "/s", overlay: { dailyCap: 10, softHoldPct: 80 } } });
+  assert.match(soft, /day: reserved 9 \/ cap 10 \(overlay\) \[soft-hold\]/);
+  assert.match(soft, /soft-hold band: 80%/);
+
+  const over = renderBudget({ budget: { day: 11 }, settings: { path: "/s", overlay: { dailyCap: 10 } } });
+  assert.match(over, /\[over\]/);
 });
 
 test("renderBudget reports unreachable", () => {
@@ -100,12 +127,15 @@ test("renderTriggers reports an unreachable scheduler read", () => {
   assert.match(renderTriggers({ schedulers: { unreachable: "down" }, flows: { mappings: {} } }), /unreachable \(down\)/);
 });
 
-test("renderSettingsView lists all five keys, unset ones marked", () => {
-  const out = renderSettingsView({ path: "/s", overlay: { model: "claude", dailyCap: 5 } });
+test("renderSettingsView lists all eight keys, unset ones marked", () => {
+  const out = renderSettingsView({ path: "/s", overlay: { model: "claude", dailyCap: 5, weeklyCap: 100, softHoldPct: 80 } });
   assert.match(out, /Settings \(\/s\)/);
   assert.match(out, /model: claude/);
   assert.match(out, /dailyCap: 5/);
+  assert.match(out, /weeklyCap: 100/);
+  assert.match(out, /softHoldPct: 80/);
   assert.match(out, /provider: \(unset\)/);
+  assert.match(out, /monthlyCap: \(unset\)/);
   assert.match(out, /concurrency: \(unset\)/);
 });
 

--- a/admin/test/wiring.test.mjs
+++ b/admin/test/wiring.test.mjs
@@ -147,7 +147,7 @@ test("dispatch_run advertises PAID/ai-trigger/no-force, is sequential, and takes
   assert.equal(run.executionMode, "sequential");
   const props = run.parameters.properties ?? {};
   assert.deepEqual(Object.keys(props).sort(), ["flow", "folder", "task"], "exactly the three job inputs");
-  for (const knob of ["model", "maxTurns", "dailyCap", "concurrency"]) {
+  for (const knob of ["model", "maxTurns", "dailyCap", "weeklyCap", "monthlyCap", "concurrency", "softHoldPct"]) {
     assert.ok(!(knob in props), `no spend-knob param: ${knob}`);
   }
 });

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -164,15 +164,18 @@ that always fires is one nobody reads.
 
 ## CONST-BUDGET-BEFORE-TOKENS
 
-- **Statement**: The daily cap shall be checked and incremented **before** an agent run begins — before
-  any provider call is made.
+- **Statement**: The spend cap shall be checked and incremented **before** an agent run begins — before
+  any provider call is made. The cap is a **job count** (container starts), not tokens. What is counted may
+  span several windows (day/week/month) and carry a soft-hold band (`REQ-SPEND-CAPS-MULTI-WINDOW`); this
+  constraint governs only the **ordering** — check-and-increment before the container — which is invariant
+  across however many windows exist.
 - **Why**: The ordering **is** the mechanism. Check-after-spend means fifty junk triggers cost fifty jobs
   of real money before the cap engages, which is the exact scenario the cap exists for. Adopted from
   pi-routines, the one idea worth taking from it, whose README states the principle exactly: the cap is
   *"applied BEFORE acquiring the guard so capped fires consume zero provider tokens."* Relaxed to
   check-after, the cap is decorative.
 - **Evidence (upstream)**: `Davidcreador/pi-routines @ 6d2aa64 (v0.5.1)` — `maxRunsPerDay`
-- **Traces to**: `REQ-RUNNER-TURN-BUDGET`, `CONST-RETRY-INFRA-ONLY`
+- **Traces to**: `REQ-RUNNER-TURN-BUDGET`, `CONST-RETRY-INFRA-ONLY`, `REQ-SPEND-CAPS-MULTI-WINDOW`
 - **Acceptance**: Given the cap is exhausted, a new trigger consumes zero provider tokens and comments
   on the issue.
 

--- a/specs/design.md
+++ b/specs/design.md
@@ -526,9 +526,12 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
 - **Decision**: Runtime-tunable settings are a flat `settings.json` **overlay** — path `PI_SETTINGS_FILE`,
   default `<OS temp>/pi-dispatch/settings.json` — written **atomically** (tmp + rename) by the admin
   extension and **re-read by the worker at each job start**. The keys are exactly `model`, `provider`
-  (non-empty strings), `maxTurns` (int ≥1), `dailyCap` (int ≥1), and `concurrency` (int 1–10). Resolution
-  precedence is **`job.data > overlay > env > default`**; producers stop baking env defaults into job
-  data, so an unset job field falls through to the overlay rather than to a value frozen at enqueue time.
+  (non-empty strings), `maxTurns`, `dailyCap`, `weeklyCap`, `monthlyCap` (int ≥1), `concurrency` (int 1–10),
+  and `softHoldPct` (int 1–99). `weeklyCap`/`monthlyCap`/`softHoldPct` are optional ceilings/band that
+  default to **disabled** when unset (the mandatory daily cap is always the primary bound —
+  `REQ-SPEND-CAPS-MULTI-WINDOW`). Resolution precedence is **`job.data > overlay > env > default`**;
+  producers stop baking env defaults into job data, so an unset job field falls through to the overlay
+  rather than to a value frozen at enqueue time.
 - **Why**:
   - **Per-job re-read needs no watcher and no IPC.** The worker already opens each job in its processor;
     reading one small file there costs a `stat` + parse and removes any need for `fs.watch`, a pub/sub

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -616,8 +616,11 @@ Evidence convention as in `constitution.md`.
     "model":       "<optional, non-empty string>",   // provider-native model id
     "provider":    "<optional, non-empty string>",   // pi provider id
     "maxTurns":    <optional, int >= 1>,             // runner turn budget
-    "dailyCap":    <optional, int >= 1>,             // jobs admitted per day
-    "concurrency": <optional, int 1-10>              // worker slot count
+    "dailyCap":    <optional, int >= 1>,             // jobs admitted per day (mandatory window; env default 25)
+    "weeklyCap":   <optional, int >= 1>,             // jobs admitted per ISO week; unset -> weekly window disabled
+    "monthlyCap":  <optional, int >= 1>,             // jobs admitted per calendar month; unset -> monthly window disabled
+    "concurrency": <optional, int 1-10>,             // worker slot count
+    "softHoldPct": <optional, int 1-99>              // soft-hold band as a % of each active cap; unset -> band disabled
   }
   ```
   All keys are optional; a missing file is an empty overlay. **Write protocol** (admin extension): validate
@@ -632,11 +635,13 @@ Evidence convention as in `constitution.md`.
 - **Why**: The worker resolves the effective job settings at job start — precedence
   `job.data > overlay > env > default` — so this file is the shared, durable truth between the admin
   extension and the worker: a write made while the worker is down is simply read at the next job start.
-  `dailyCap` is resolved at the existing pre-container cap check, so the overlay changes *which value* the
-  cap takes, never *when* it is checked (`CONST-BUDGET-BEFORE-TOKENS`). See `DES-RUNTIME-SETTINGS-FILE-OVERLAY`
-  for why a file, why atomic, and why a present-but-invalid file fails closed.
+  `dailyCap`/`weeklyCap`/`monthlyCap`/`softHoldPct` are resolved at the existing pre-container cap check, so
+  the overlay changes *which values* the caps and band take, never *when* they are checked
+  (`CONST-BUDGET-BEFORE-TOKENS`, `REQ-SPEND-CAPS-MULTI-WINDOW`). An unset `weeklyCap`/`monthlyCap` disables
+  that window; an unset `softHoldPct` disables the band. See `DES-RUNTIME-SETTINGS-FILE-OVERLAY` for why a
+  file, why atomic, and why a present-but-invalid file fails closed.
 - **Traces to**: `DES-RUNTIME-SETTINGS-FILE-OVERLAY`, `DES-ADMIN-VIA-PI-EXTENSION`,
-  `CONST-BUDGET-BEFORE-TOKENS`, `CONST-RETRY-INFRA-ONLY`
+  `CONST-BUDGET-BEFORE-TOKENS`, `CONST-RETRY-INFRA-ONLY`, `REQ-SPEND-CAPS-MULTI-WINDOW`
 - **Acceptance**: Given a present-but-invalid file, when a job starts, then the processor returns a policy
   refusal `settings-overlay-invalid` before `reserveBudget` — no budget slot consumed, no container
   started, not retried; given a job whose data omits `model`/`provider`/`maxTurns`, when it starts, then

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -357,8 +357,8 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
 ## REQ-RUNTIME-SETTINGS-PICKUP
 
 - **Statement**: The worker shall honour overlay changes without a restart: `model`, `provider`,
-  `maxTurns`, and `dailyCap` resolve per job at job start, and `concurrency` is applied at the worker's
-  next job pickup.
+  `maxTurns`, `dailyCap`, `weeklyCap`, `monthlyCap`, and `softHoldPct` resolve per job at job start, and
+  `concurrency` is applied at the worker's next job pickup.
 - **Why**: A settings edit at 11pm must not require a service restart. The worker re-reads the overlay in
   its processor at each job start — no watcher and no reload signal (see `DES-RUNTIME-SETTINGS-FILE-OVERLAY`).
 - **Traces to**: `DES-RUNTIME-SETTINGS-FILE-OVERLAY`, `INT-CONFIG-OVERLAY-CONTRACT`,
@@ -370,6 +370,34 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
   lowered below today's reserved count, when the next job starts, then it is refused over-budget before any
   container.
 
+## REQ-SPEND-CAPS-MULTI-WINDOW
+
+- **Statement**: The pre-container budget check shall bound container starts across **three windows** — a
+  **mandatory daily** cap plus **optional weekly and monthly** ceilings — and shall additionally refuse new
+  starts inside a single **soft-hold band** expressed as a percentage of each active window's cap. A job is
+  admitted only when **every** active window is within its cap **and** outside its soft-hold band; otherwise
+  it is refused pre-container with a window-named reason (`over-budget` at the hard cap, `soft-hold` in the
+  band). Week/month are disabled when their cap is unset; the soft-hold band is disabled when its percentage
+  is unset. All three windows and the band are overlay/env tunable (`weeklyCap`, `monthlyCap`, `softHoldPct`;
+  `PI_WEEKLY_CAP`, `PI_MONTHLY_CAP`, `PI_SOFT_HOLD_PCT`) and resolve `job.data > overlay > env` per job.
+- **Why**: A daily cap alone bounds a single day's blast radius but not a slow bleed — a flow that stays
+  under 25/day every day still spends unboundedly across a month. The weekly and monthly ceilings close that
+  gap on longer horizons. The soft-hold band is a distinct operator brake **before** the hard wall: crossing
+  it pauses new starts (in-flight containers finish, since the reservation is pre-container) and turns the
+  panel meter amber, so an operator is warned and can raise a cap or intervene rather than discovering the
+  ceiling only when jobs start refusing. These remain **job-count** caps (container starts), not tokens —
+  the thing knowable *before* a run — so `CONST-BUDGET-BEFORE-TOKENS` is unchanged; token caps are a
+  separate, structurally lagging problem tracked at `OQ-010`.
+- **Traces to**: `CONST-BUDGET-BEFORE-TOKENS`, `DES-RUNTIME-SETTINGS-FILE-OVERLAY`,
+  `INT-CONFIG-OVERLAY-CONTRACT`, `REQ-RUNTIME-SETTINGS-PICKUP`
+- **Acceptance**: Given any active window over its cap, when a job starts, then it is refused `over-budget`
+  before `reserveBudget` admits a container, and the refusal names the blocking window; given a reservation
+  that lands inside the soft-hold band of any active window but under every hard cap, when a job starts, then
+  it is refused `soft-hold` before any container while in-flight jobs continue; given an unset `weeklyCap`
+  (and no `PI_WEEKLY_CAP`), when a job starts, then the weekly window is neither counted nor evaluated; given
+  a `softHoldPct` set live in the overlay, when the next job starts, then the band takes effect with no
+  restart; given a refused reservation, when the window rolls over, then its counter is reclaimed by TTL.
+
 ---
 
 ## Notes (not requirements)
@@ -377,8 +405,9 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
 **Capacity and cost.** ~1.5–2.5 GB RAM per job (pi + dev server + headless Chromium) and roughly
 $0.5–$5 per job are **unmeasured estimates** — the design document says "measure!" and notes no
 published figures exist. A requirement needs a testable threshold; a guess is rationale at best. These
-inform `DES-CONCURRENCY-3` and are tracked at `OQ-002`. Only the daily budget cap graduates to a
-constraint (`CONST-BUDGET-BEFORE-TOKENS`).
+inform `DES-CONCURRENCY-3` and are tracked at `OQ-002`. Only the budget caps graduate to a constraint
+(`CONST-BUDGET-BEFORE-TOKENS`), now spanning day/week/month windows plus a soft-hold band
+(`REQ-SPEND-CAPS-MULTI-WINDOW`).
 
 **Burst math.** 50 triggers at concurrency 3 and ~10 min/job drains in ≈2.8 hours. That is the
 wait-list working as designed, not a failure — see `README.md`.
@@ -395,5 +424,6 @@ wait-list working as designed, not a failure — see `README.md`.
 | 2026-07-21 | Added REQ-DURABLE-RUN-HISTORY (durable per-job run record + opt-in raw log; read model for the panel). |
 | 2026-07-16 | **Scope de-GitHub-ified.** It said "triggers on GitHub issue activity" and never mentioned local folders, the CLI/panel, or cron -- stale, since local is now first-class and built. Rewritten as trigger × target. `REQ-JOB-STATUS-COMMENTS` scoped to GitHub jobs explicitly (a local job has no issue). New `REQ-LOCAL-JOB-VISIBILITY`: local jobs surface their outcome on the worker console (and later the panel) -- the local counterpart of the issue comment and the same signal for `CONST-PI-VERSION-PINNED`'s silent-no-op mode. Code updated to match: startWorker now logs one terminal line per job. |
 | 2026-07-21 | Added REQ-ADMIN-VIA-PI-EXTENSION (admin surface as a pi extension in `admin/`: operator observability/pause-resume/settings commands, reads-plus-pause/resume-only model tools, overlay-only raw logs) and REQ-RUNTIME-SETTINGS-PICKUP (per-job overlay re-read for model/provider/maxTurns/dailyCap; concurrency at next pickup). Rescoped panel references to the admin extension in Scope, `REQ-JOB-STATUS-COMMENTS`, `REQ-LOCAL-JOB-VISIBILITY`, and `REQ-DURABLE-RUN-HISTORY`. |
+| 2026-07-22 | Added REQ-SPEND-CAPS-MULTI-WINDOW: the pre-container budget check now spans a mandatory daily cap plus optional weekly/monthly ceilings and a soft-hold percentage band (enforcing — refuses new starts in-band with a distinct `soft-hold` reason). Extended REQ-RUNTIME-SETTINGS-PICKUP's key list to include `weeklyCap`/`monthlyCap`/`softHoldPct`. `CONST-BUDGET-BEFORE-TOKENS` unchanged (still job-count, still check-before-start). |
 | 2026-07-22 | Amended REQ-ADMIN-VIA-PI-EXTENSION to the three-tool framing — `dispatch_run` is a third, spend-knobless model-callable enqueue gated by `DES-AI-TRIGGER-FLOW-GATE`; the `Statement` and `Why` both drop the superseded reads-plus-pause/resume-only categorical, keeping the cap-integrity rationale on the new premise that no model tool carries a spend knob, and the `Acceptance` gains a `dispatch_run` clause. Added REQ-AI-TRIGGERED-RUNS (the two AI-triggered producers — the `dispatch_run` tool/command and the worker's `/outbox` collector — under a per-flow pre-agent-SHA `ai-trigger: allow` gate, folder-confined to `PI_DISPATCH_RUN_ROOTS`, depth/count/rate-capped, budget unchanged; operator-typed CLI/command ungated). |
 | 2026-07-22 | Coherence fix: reworded the two live "triggers no jobs" admin claims — REQ-ADMIN-VIA-PI-EXTENSION `Scope` and the `Triggers` overview bullet — to "triggers no jobs except the gated `dispatch_run` enqueue", resolving the self-contradiction with the same entry's `Statement`/`Why` `dispatch_run` clauses (still never materialised into a job's `/job` inputs). |

--- a/worker/src/budget.mjs
+++ b/worker/src/budget.mjs
@@ -1,55 +1,133 @@
 /**
  * CONST-BUDGET-BEFORE-TOKENS. The ordering IS the mechanism.
  *
- * Reserve a slot against the daily cap BEFORE a container starts. Check-after-spend means fifty
+ * Reserve a slot against the spend caps BEFORE a container starts. Check-after-spend means fifty
  * junk triggers cost fifty jobs of real money before the cap engages -- the exact scenario the cap
- * exists for. So: atomically INCR the day's counter, and only start the container if the reserved
- * number is within the cap.
+ * exists for. So: atomically INCR each active window's counter, and only start the container if every
+ * window is within its cap and outside its soft-hold band.
  *
  * INCR is atomic -- verified against a real Valkey under 20 parallel increments yielding exactly
  * 20, no lost updates -- so this needs no lock even at concurrency 3. Three jobs racing at count 9
  * with cap 10 reserve 10, 11, 12; exactly one proceeds, the others are refused, and no container
  * starts over budget.
  *
+ * Three windows bound spend on different horizons: a mandatory DAY cap, plus OPTIONAL WEEK and MONTH
+ * ceilings (REQ-SPEND-CAPS-MULTI-WINDOW). A window whose cap is null/absent is disabled -- not counted,
+ * not evaluated. On top of the hard caps a single SOFT-HOLD percentage refuses new starts once any
+ * window enters its band (e.g. >= 80% of that window's cap), a distinct operator-visible brake before
+ * the hard wall; in-flight containers are untouched because the reservation happens pre-container.
+ *
  * `redis` is any ioredis-compatible client (BullMQ bundles ioredis). Injected so the logic is
  * testable without a running server.
  */
 
-/** UTC date key. The worker is ordinary node, so Date is available (unlike the workflow sandbox). */
+/** UTC day key: `budget:YYYY-MM-DD`. */
 export function dayKey(now = new Date(), prefix = "budget") {
-	const d = now.toISOString().slice(0, 10); // YYYY-MM-DD, UTC
-	return `${prefix}:${d}`;
-}
-
-const TWO_DAYS_SECONDS = 2 * 24 * 60 * 60;
-
-/**
- * Atomically reserve one slot against today's cap. Returns { allowed, reserved, cap }.
- *
- * A refused reservation still counts -- the counter bounds container STARTS per day, and a refused
- * job spends nothing (no container) and reports on its issue. We deliberately do NOT decrement on
- * refusal: the cap is a hard daily ceiling on attempts, and letting refused attempts "give back"
- * their slot would let a burst probe the cap for free.
- *
- * A cap of 0 or negative disables running entirely (every job refused) rather than meaning
- * "unlimited" -- fail closed, since this guards money.
- */
-export async function reserveBudget(redis, { cap, now = new Date(), keyPrefix = "budget" } = {}) {
-	const key = dayKey(now, keyPrefix);
-	const reserved = Number(await redis.incr(key));
-	// Set the TTL only once, when the key is first created (reserved === 1), so a long-running
-	// day cannot have its expiry pushed forward indefinitely.
-	if (reserved === 1) await redis.expire(key, TWO_DAYS_SECONDS);
-	return { allowed: reserved <= cap, reserved, cap };
+	return `${prefix}:${now.toISOString().slice(0, 10)}`; // YYYY-MM-DD, UTC
 }
 
 /**
- * Give a reservation back. Used ONLY when the container never started because of an INFRA fault
- * AFTER reserving (e.g. the docker daemon was unreachable) -- an infra failure that spent nothing
- * should not permanently consume a cap slot. NOT used for a completed run (0/2), which really did
- * consume its slot, nor for an exit-1 infra retry (the container ran and spent), nor for a refusal
- * (which never incremented past the cap deliberately).
+ * UTC week key, bucketed by the Monday of the run's week: `budget:w:YYYY-MM-DD` (that Monday's date).
+ * Keying by an actual date sidesteps ISO week-number edge cases (week 53, year rollovers) while still
+ * mapping every run in one Mon-Sun week to one key. The `w:` sub-namespace never collides with the day
+ * key (`budget:YYYY-MM-DD`).
  */
-export async function releaseBudget(redis, { now = new Date(), keyPrefix = "budget" } = {}) {
-	await redis.decr(dayKey(now, keyPrefix));
+export function weekKey(now = new Date(), prefix = "budget") {
+	const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+	const sinceMonday = (d.getUTCDay() + 6) % 7; // Mon=0 .. Sun=6
+	d.setUTCDate(d.getUTCDate() - sinceMonday);
+	return `${prefix}:w:${d.toISOString().slice(0, 10)}`;
+}
+
+/** UTC month key: `budget:m:YYYY-MM`. The `m:` sub-namespace never collides with the day/week keys. */
+export function monthKey(now = new Date(), prefix = "budget") {
+	return `${prefix}:m:${now.toISOString().slice(0, 7)}`; // YYYY-MM, UTC
+}
+
+// Each window's TTL outlives its bucket with slack, so a stale counter is reclaimed shortly after the
+// window rolls over. Set once, on first reservation only (reserved === 1), so a busy window cannot push
+// its own expiry forward indefinitely.
+const DAY_TTL_SECONDS = 2 * 24 * 60 * 60; // outlives the UTC day
+const WEEK_TTL_SECONDS = 9 * 24 * 60 * 60; // outlives the Mon-Sun week
+const MONTH_TTL_SECONDS = 40 * 24 * 60 * 60; // outlives the longest month
+
+/**
+ * Classify one window's reserved count against its cap and the soft-hold band. PURE, and exported so the
+ * worker's `reserveBudget` and the admin panel compute the same state from the same inputs and cannot
+ * drift on where the band and the wall begin (the read-model already imports `dayKey` for the same reason).
+ *
+ *   reserved > cap                      -> "over"       (hard cap exceeded; also fails closed for cap <= 0)
+ *   reserved > floor(cap * pct / 100)   -> "soft-hold"  (inside the band; only when pct is set)
+ *   otherwise                           -> "ok"
+ *
+ * `softHoldPct` null/absent disables the band. Callers only classify ACTIVE windows (cap is a real number);
+ * a disabled window (cap null) is never passed here.
+ */
+export function windowState(reserved, cap, softHoldPct = null) {
+	if (reserved > cap) return "over";
+	if (Number.isInteger(softHoldPct) && reserved > Math.floor((cap * softHoldPct) / 100)) return "soft-hold";
+	return "ok";
+}
+
+/** The active windows for a `caps` set: day plus week/month only when their cap is set (not null/undefined). */
+function activeWindows(caps, now, keyPrefix) {
+	return [
+		{ name: "day", key: dayKey(now, keyPrefix), cap: caps?.day, ttl: DAY_TTL_SECONDS },
+		{ name: "week", key: weekKey(now, keyPrefix), cap: caps?.week, ttl: WEEK_TTL_SECONDS },
+		{ name: "month", key: monthKey(now, keyPrefix), cap: caps?.month, ttl: MONTH_TTL_SECONDS },
+	].filter((w) => w.cap !== null && w.cap !== undefined);
+}
+
+/**
+ * Atomically reserve one slot across every ACTIVE window. Returns
+ * `{ allowed, reason, blockedWindow, windows }` where `windows[name]` is `{ reserved, cap, state }` for an
+ * active window or `null` for a disabled one, and `reason` is the worst window state:
+ *   any "over"       -> "over-budget"
+ *   else any "soft-hold" -> "soft-hold"
+ *   else                 -> "ok"  (allowed)
+ * `blockedWindow` names the day>week>month-first window carrying that worst state, so the caller can say
+ * WHICH ceiling blocked. Both refusals are pre-container, so a refused job spends nothing; a soft-hold is
+ * refused exactly like over-budget, only under a distinct reason and an amber panel state.
+ *
+ * Every active window is INCR'd UNCONDITIONALLY -- the same "a refused reservation still counts, no
+ * give-back" invariant the daily cap has always had, now per window. This is deliberate: conditional
+ * increments would reintroduce the read-then-write race the atomic INCR design exists to avoid, and
+ * unconditional INCR keeps `releaseBudget` a clean symmetric DECR of the same windows. It fails closed --
+ * a burst that exhausts one window counts against the others too -- which is the money-safe direction.
+ *
+ * A cap of 0/negative on an ACTIVE window fails closed (every job "over") rather than meaning "unlimited";
+ * a DISABLED window (cap null/absent) is not counted or evaluated at all.
+ */
+export async function reserveBudget(redis, { caps, softHoldPct = null, now = new Date(), keyPrefix = "budget" } = {}) {
+	const windows = { day: null, week: null, month: null };
+	for (const w of activeWindows(caps, now, keyPrefix)) {
+		const reserved = Number(await redis.incr(w.key));
+		// Set the TTL only when the key is first created, so a long window cannot push its expiry forward.
+		if (reserved === 1) await redis.expire(w.key, w.ttl);
+		windows[w.name] = { reserved, cap: w.cap, state: windowState(reserved, w.cap, softHoldPct) };
+	}
+
+	const order = ["day", "week", "month"];
+	for (const [state, reason] of [
+		["over", "over-budget"],
+		["soft-hold", "soft-hold"],
+	]) {
+		const hit = order.find((name) => windows[name]?.state === state);
+		if (hit) return { allowed: false, reason, blockedWindow: hit, windows };
+	}
+	return { allowed: true, reason: "ok", blockedWindow: null, windows };
+}
+
+/**
+ * Give a reservation back in every window `reserveBudget` would have reserved. Used ONLY when the container
+ * never started because of an INFRA fault AFTER reserving (e.g. the docker daemon was unreachable) -- an
+ * infra failure that spent nothing should not permanently consume a slot. DECRs exactly the ACTIVE windows,
+ * mirroring `reserveBudget` so the refund cannot drift from the reservation. NOT used for a completed run
+ * (which really consumed its slot), an exit-1 infra retry (the container ran and spent), or an
+ * over-budget/soft-hold refusal (which never gives back its slot, deliberately).
+ */
+export async function releaseBudget(redis, { caps, now = new Date(), keyPrefix = "budget" } = {}) {
+	for (const w of activeWindows(caps, now, keyPrefix)) {
+		await redis.decr(w.key);
+	}
 }

--- a/worker/src/config.mjs
+++ b/worker/src/config.mjs
@@ -36,6 +36,22 @@ function nonNegativeInt(env, name, fallback) {
 	return boundedInt(env, name, fallback, 0, "a non-negative integer");
 }
 
+// An OPTIONAL bounded int: an unset or empty var is `null` (the feature it gates is disabled), a present
+// one is validated in `[min, max]` (max undefined = no upper bound) and otherwise a config error. Unlike
+// `boundedInt`, absence is a first-class "off", not a fallback default -- used by the optional week/month
+// spend ceilings and the soft-hold band, which default to disabled rather than to a number.
+function optionalBoundedInt(env, name, min, max) {
+	const raw = env[name];
+	if (raw === undefined || raw === "") return null;
+	const n = Number.parseInt(raw, 10);
+	const inRange = Number.isInteger(n) && n >= min && (max === undefined || n <= max) && String(n) === String(raw).trim();
+	if (!inRange) {
+		const want = max === undefined ? `an integer >= ${min}` : `an integer ${min}-${max}`;
+		throw configError(`invalid ${name}: ${JSON.stringify(raw)} (want ${want})`);
+	}
+	return n;
+}
+
 // Split a PATH-style list on the OS path delimiter (`;` on Windows, `:` elsewhere) so a Windows
 // drive-letter colon is not mistaken for a separator. Trims, drops empties. Entries are stored
 // verbatim; downstream (task 3.1) realpaths them, so no posix normalisation happens here.
@@ -49,7 +65,9 @@ function delimitedList(raw) {
 /**
  * Parse the worker's config from `env` (default process.env). All defaults are conservative:
  * spend controls (`PI_DAILY_CAP`, `PI_MAX_TURNS`) exist to bound money, so they default low, and a
- * cap of 0 would fail closed (budget.mjs refuses every job) rather than mean "unlimited".
+ * cap of 0 would fail closed (budget.mjs refuses every job) rather than mean "unlimited". The optional
+ * week/month ceilings and the soft-hold band default to disabled (`null`) -- the mandatory daily cap is
+ * always the primary money bound; the others are additive ceilings an operator opts into.
  */
 export function loadConfig(env = process.env, { fileExists = existsSync } = {}) {
 	const model = env.PI_MODEL ?? "claude-sonnet-4-5-20250929"; // dated snapshot; deterministic per CONST-PI-VERSION-PINNED
@@ -57,6 +75,9 @@ export function loadConfig(env = process.env, { fileExists = existsSync } = {}) 
 		valkeyUrl: env.VALKEY_URL ?? "redis://127.0.0.1:6379",
 		concurrency: positiveInt(env, "PI_CONCURRENCY", 3), // DES-CONCURRENCY-3
 		dailyCap: positiveInt(env, "PI_DAILY_CAP", 25), // bounds container STARTS per day (money)
+		weeklyCap: optionalBoundedInt(env, "PI_WEEKLY_CAP", 1), // REQ-SPEND-CAPS-MULTI-WINDOW; null = weekly window disabled
+		monthlyCap: optionalBoundedInt(env, "PI_MONTHLY_CAP", 1), // null = monthly window disabled
+		softHoldPct: optionalBoundedInt(env, "PI_SOFT_HOLD_PCT", 1, 99), // null = soft-hold band disabled
 		provider: env.PI_PROVIDER ?? "anthropic",
 		model,
 		maxTurns: positiveInt(env, "PI_MAX_TURNS", 30), // pi has no turn limit; we impose one

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -22,10 +22,10 @@ export const JOB_TIMEOUT_MS = 30 * 60 * 1000; // REQ-JOB-TIMEOUT-30M
  * Once per job, before runJob, it resolves the runtime-settings overlay via `getSettings`
  * (INT-CONFIG-OVERLAY-CONTRACT). A present-but-invalid overlay resolves to a POLICY refusal RETURNED
  * (never thrown), so BullMQ marks the job completed without a retry (CONST-RETRY-INFRA-ONLY). A valid
- * overlay fills the effective `provider`/`model`/`maxTurns`/`dailyCap` under `job.data > overlay > env`
- * precedence and re-binds the worker slot count via `applyConcurrency`. The overlay changes which value
- * the daily cap takes, never when it is checked -- reserveBudget still runs inside runJob against the
- * freshly passed cap (CONST-BUDGET-BEFORE-TOKENS).
+ * overlay fills the effective `provider`/`model`/`maxTurns`/`dailyCap`/`weeklyCap`/`monthlyCap`/`softHoldPct`
+ * under `job.data > overlay > env` precedence and re-binds the worker slot count via `applyConcurrency`.
+ * The overlay changes which values the spend caps take, never when they are checked -- reserveBudget still
+ * runs inside runJob against the freshly passed caps (CONST-BUDGET-BEFORE-TOKENS).
  */
 export function makeProcessor({ cancelJob, stopContainer, redis, getSettings, applyConcurrency = () => {}, deps, recordRun = () => {}, timeoutMs = JOB_TIMEOUT_MS }) {
 	return async function processor(job, token, signal) {
@@ -63,8 +63,8 @@ export function makeProcessor({ cancelJob, stopContainer, redis, getSettings, ap
 			// field wins; an omitted one takes the overlay value, else env, resolved at this job's start
 			// (INT-CONFIG-OVERLAY-CONTRACT). Receiver GitHub jobs carry no provider/model/maxTurns, so this fill
 			// supplies the provider the container env allowlist requires -- absent it, the allowlist refuses a job
-			// only after its budget slot is reserved. `cap: settings.dailyCap` changes which value reserveBudget
-			// takes, never when it runs.
+			// only after its budget slot is reserved. The `caps`/`softHoldPct` passed to runJob change which
+			// values reserveBudget checks, never when it runs.
 			const effectiveJob = {
 				...job.data,
 				provider: job.data.provider ?? settings.provider,
@@ -74,7 +74,10 @@ export function makeProcessor({ cancelJob, stopContainer, redis, getSettings, ap
 
 			const result = await runJob(effectiveJob, {
 				redis,
-				cap: settings.dailyCap,
+				// The three spend windows (week/month null when disabled) and the soft-hold band, resolved this
+				// job-start under overlay > env. reserveBudget checks them before the container.
+				caps: { day: settings.dailyCap, week: settings.weeklyCap, month: settings.monthlyCap },
+				softHoldPct: settings.softHoldPct,
 				...deps,
 				runContainer: (ctx) => deps.runContainer({ ...ctx, name, signal }),
 				// collectChain (INT-OUTBOX-CONTRACT) reads the completed parent's REAL BullMQ job: its `.id`

--- a/worker/src/processor.mjs
+++ b/worker/src/processor.mjs
@@ -26,7 +26,8 @@ import { EXIT_COMPLETED, EXIT_INFRA, EXIT_POLICY } from "./exit-code.mjs";
 export async function runJob(job, deps) {
 	const {
 		redis,
-		cap,
+		caps, // { day, week, month }; week/month null when that window is disabled (REQ-SPEND-CAPS-MULTI-WINDOW)
+		softHoldPct, // int 1-99 or null; the soft-hold band applied to every active window
 		mintToken, // (repo) => scoped short-lived token | null for local-folder jobs
 		isDefaultBranchProtected, // (repo, token) => boolean
 		prepareWorkspace, // (job, token) => { workspaceDir, jobDir }  (clone+materialise+prompt)
@@ -81,14 +82,23 @@ export async function runJob(job, deps) {
 			return prepared;
 		}
 
-		// Budget last-but-before-container. A refusal here spends nothing (no container starts).
-		const budget = await reserveBudget(redis, { cap, now });
+		// Budget last-but-before-container. A refusal here spends nothing (no container starts). Reserves across
+		// every active window (day + optional week/month) and the soft-hold band in one atomic pass.
+		const budget = await reserveBudget(redis, { caps, softHoldPct, now });
 		reserved = true;
 		if (!budget.allowed) {
-			await comment(job, `Over the daily budget cap (${budget.cap}). Not run.`);
-			log("over_budget", { reserved: budget.reserved, cap: budget.cap });
-			// budgetReserved true: the slot is reserved above and kept (an over-cap reservation still counts).
-			return { outcome: "policy", reason: "over-budget", exitCode: null, turns: null, budgetReserved: true }; // return => not retried
+			const w = budget.blockedWindow;
+			const win = budget.windows[w];
+			if (budget.reason === "soft-hold") {
+				await comment(job, `Soft-hold: ${w} spend ${win.reserved}/${win.cap} is inside the ${softHoldPct}% hold band. New starts paused; not run.`);
+				log("soft_hold", { window: w, reserved: win.reserved, cap: win.cap, pct: softHoldPct });
+			} else {
+				await comment(job, `Over the ${w} budget cap (${win.cap}). Not run.`);
+				log("over_budget", { window: w, reserved: win.reserved, cap: win.cap });
+			}
+			// budgetReserved true: the slot is reserved above and kept (a refused reservation still counts). Both
+			// over-budget and soft-hold are POLICY, RETURNED (not retried) -- the agent never ran.
+			return { outcome: "policy", reason: budget.reason, exitCode: null, turns: null, budgetReserved: true }; // return => not retried
 		}
 
 		const { code, aborted, turns } = await runContainer({ job, token, prepared });
@@ -129,7 +139,7 @@ export async function runJob(job, deps) {
 		// true for a real container that ran and spent (exit-1 infra / unknown exit).
 		if (e instanceof InfraRetry) e.budgetReserved = reserved && e.reason !== "container-never-started";
 		if (reserved && e instanceof InfraRetry && e.reason === "container-never-started") {
-			await releaseBudget(redis, { now });
+			await releaseBudget(redis, { caps, now });
 		}
 		throw e;
 	} finally {

--- a/worker/src/runtime-settings.mjs
+++ b/worker/src/runtime-settings.mjs
@@ -4,10 +4,10 @@ import { defaultSettingsFile } from "./config.mjs";
 
 /**
  * Runtime-settings overlay: the shared, durable truth between the admin extension and the worker
- * (INT-CONFIG-OVERLAY-CONTRACT, DES-RUNTIME-SETTINGS-FILE-OVERLAY). A flat `settings.json` with five
- * optional keys -- `model`, `provider` (non-empty strings), `maxTurns`, `dailyCap` (int >= 1),
- * `concurrency` (int 1-10) -- read by the worker at each job start and written atomically by the admin
- * extension (tmp + rename).
+ * (INT-CONFIG-OVERLAY-CONTRACT, DES-RUNTIME-SETTINGS-FILE-OVERLAY). A flat `settings.json` with eight
+ * optional keys -- `model`, `provider` (non-empty strings), `maxTurns`, `dailyCap`, `weeklyCap`,
+ * `monthlyCap` (int >= 1), `concurrency` (int 1-10), `softHoldPct` (int 1-99) -- read by the worker at
+ * each job start and written atomically by the admin extension (tmp + rename).
  *
  * `readOverlay` NEVER throws: a bad settings file returns a discriminated `{ invalid }` rather than an
  * exception, so the processor RETURNS a policy refusal (`settings-overlay-invalid`) instead of letting
@@ -24,7 +24,7 @@ import { defaultSettingsFile } from "./config.mjs";
  * Custom: overlay validated inline per config.mjs precedent; zod not in deps
  */
 
-export const KNOWN_KEYS = ["model", "provider", "maxTurns", "dailyCap", "concurrency"];
+export const KNOWN_KEYS = ["model", "provider", "maxTurns", "dailyCap", "weeklyCap", "monthlyCap", "concurrency", "softHoldPct"];
 
 function isNonEmptyString(value) {
 	return typeof value === "string" && value.trim() !== "";
@@ -68,6 +68,10 @@ function validateOverlay(candidate, log) {
 				break;
 			case "maxTurns":
 			case "dailyCap":
+			case "weeklyCap":
+			case "monthlyCap":
+				// Overlay caps are positive ints. A window is DISABLED by absence, not by a 0 -- `unset weeklyCap`
+				// drops the key so it falls through to env, which unset means the window is off (config.mjs).
 				if (!isIntAtLeast(value, 1)) return { invalid: `${key} must be an integer >= 1` };
 				overlay[key] = value;
 				break;
@@ -75,6 +79,12 @@ function validateOverlay(candidate, log) {
 				// Range-checked here, not via config's positiveInt: that helper has no upper bound and parses
 				// env strings, so it cannot enforce the 1-10 ceiling this key carries over a JSON number.
 				if (!isIntInRange(value, 1, 10)) return { invalid: "concurrency must be an integer 1-10" };
+				overlay[key] = value;
+				break;
+			case "softHoldPct":
+				// A percentage of each active cap; 100 would equal the hard wall (no band) and 0 has no meaning,
+				// so the enforced band is 1-99. Absence disables the soft-hold entirely.
+				if (!isIntInRange(value, 1, 99)) return { invalid: "softHoldPct must be an integer 1-99" };
 				overlay[key] = value;
 				break;
 			default:
@@ -111,9 +121,11 @@ export function readOverlay(path, { fs = nodeFs, log = () => {} } = {}) {
 }
 
 /**
- * Resolve the five effective settings from `config` and a validated `overlay`: overlay value where the
+ * Resolve the eight effective settings from `config` and a validated `overlay`: overlay value where the
  * overlay sets it, else the config value. Precedence is overlay > env > default only -- `config`
- * already carries env > default. `job.data` is NOT merged here; that layer is the processor's.
+ * already carries env > default. `weeklyCap`/`monthlyCap`/`softHoldPct` may resolve to `null` (their
+ * config value when unset), meaning that window / the soft-hold band is disabled. `job.data` is NOT
+ * merged here; that layer is the processor's.
  */
 export function effectiveSettings(config, overlay) {
 	const o = overlay ?? {};
@@ -122,7 +134,10 @@ export function effectiveSettings(config, overlay) {
 		model: o.model ?? config.model,
 		maxTurns: o.maxTurns ?? config.maxTurns,
 		dailyCap: o.dailyCap ?? config.dailyCap,
+		weeklyCap: o.weeklyCap ?? config.weeklyCap,
+		monthlyCap: o.monthlyCap ?? config.monthlyCap,
 		concurrency: o.concurrency ?? config.concurrency,
+		softHoldPct: o.softHoldPct ?? config.softHoldPct,
 	};
 }
 

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -127,7 +127,7 @@ export async function startWorker(
 		writeRecord(buildRecord({ job, result, error, startedAt, endedAt }));
 
 	// INT-CONFIG-OVERLAY-CONTRACT: the worker reads the runtime-settings overlay at EACH job start, so this
-	// closure -- not a value frozen at boot -- is what the processor calls per job. It resolves the five
+	// closure -- not a value frozen at boot -- is what the processor calls per job. It resolves the eight
 	// effective settings from the overlay over env; an invalid overlay returns `{ invalid }` (logged loudly,
 	// key-name-only per no-pii-in-logs) so the processor RETURNS a settings-overlay-invalid refusal instead
 	// of the run.
@@ -238,6 +238,9 @@ export async function startWorker(
 		queue: "pi-jobs",
 		concurrency: bootConcurrency, // the slot count the Worker is actually constructed with (overlay may raise/lower it)
 		dailyCap: config.dailyCap,
+		weeklyCap: config.weeklyCap, // null when the weekly window is disabled
+		monthlyCap: config.monthlyCap, // null when the monthly window is disabled
+		softHoldPct: config.softHoldPct, // null when the soft-hold band is disabled
 		image: config.jobImage,
 		valkey: config.valkeyUrl,
 		logsDir: config.logsDir,

--- a/worker/test/budget.test.mjs
+++ b/worker/test/budget.test.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { dayKey, releaseBudget, reserveBudget } from "../src/budget.mjs";
+import { dayKey, weekKey, monthKey, windowState, releaseBudget, reserveBudget } from "../src/budget.mjs";
 
-/** Minimal ioredis-compatible fake: atomic enough for single-threaded test semantics. */
+/** Minimal ioredis-compatible fake, keyed by the redis key so the three windows count independently. */
 function fakeRedis() {
 	const store = new Map();
 	const ttl = new Map();
@@ -25,51 +25,168 @@ function fakeRedis() {
 	};
 }
 
-test("dayKey is a UTC YYYY-MM-DD key", () => {
-	assert.equal(dayKey(new Date("2026-07-16T23:30:00Z")), "budget:2026-07-16");
-	// A timestamp just before UTC midnight stays on its UTC day regardless of local tz.
-	assert.equal(dayKey(new Date("2026-07-16T00:00:01Z")), "budget:2026-07-16");
+const NOW = new Date("2026-07-16T10:00:00Z");
+const DAY = "budget:2026-07-16";
+const WEEK = "budget:w:2026-07-13"; // the Monday of NOW's week
+const MONTH = "budget:m:2026-07";
+
+// ---- keys ----
+
+test("dayKey / weekKey / monthKey are distinct UTC sub-namespaces", () => {
+	assert.equal(dayKey(NOW), DAY);
+	assert.equal(weekKey(NOW), WEEK);
+	assert.equal(monthKey(NOW), MONTH);
+	// A timestamp just before UTC midnight stays on its UTC day/week/month regardless of local tz.
+	assert.equal(dayKey(new Date("2026-07-16T00:00:01Z")), DAY);
 });
 
-test("reserves within the cap, refuses beyond it, and never lets a refusal spend", async () => {
+test("weekKey buckets a whole Mon-Sun week to one Monday key, and rolls at the boundary", () => {
+	assert.equal(weekKey(new Date("2026-07-13T00:00:00Z")), WEEK, "Monday");
+	assert.equal(weekKey(new Date("2026-07-19T23:59:59Z")), WEEK, "the following Sunday is the same week");
+	assert.equal(weekKey(new Date("2026-07-20T00:00:00Z")), "budget:w:2026-07-20", "the next Monday is a new bucket");
+	// Year boundary: 2027-01-01 is a Friday, still in the week that started 2026-12-28.
+	assert.equal(weekKey(new Date("2027-01-01T00:00:00Z")), "budget:w:2026-12-28");
+});
+
+// ---- windowState (the shared classifier) ----
+
+test("windowState: ok below the band, soft-hold inside it, over beyond the cap", () => {
+	// cap 10, pct 80 -> threshold floor(8) = 8. reserved <=8 ok; 9,10 soft-hold; 11+ over.
+	assert.equal(windowState(8, 10, 80), "ok");
+	assert.equal(windowState(9, 10, 80), "soft-hold");
+	assert.equal(windowState(10, 10, 80), "soft-hold");
+	assert.equal(windowState(11, 10, 80), "over");
+	// pct null disables the band: everything up to the cap is ok, only over the cap is "over".
+	assert.equal(windowState(10, 10, null), "ok");
+	assert.equal(windowState(11, 10, null), "over");
+	// cap <= 0 fails closed: any reservation is over.
+	assert.equal(windowState(1, 0, null), "over");
+});
+
+// ---- single (day) window: the original behaviour, preserved ----
+
+test("day-only: reserves within the cap, refuses beyond it, and a refusal never gives back", async () => {
 	const redis = fakeRedis();
-	const now = new Date("2026-07-16T10:00:00Z");
 	const results = [];
-	for (let i = 0; i < 5; i++) results.push(await reserveBudget(redis, { cap: 3, now }));
+	for (let i = 0; i < 5; i++) results.push(await reserveBudget(redis, { caps: { day: 3 }, now: NOW }));
 
 	assert.deepEqual(
 		results.map((r) => r.allowed),
 		[true, true, true, false, false],
 	);
 	assert.deepEqual(
-		results.map((r) => r.reserved),
+		results.map((r) => r.windows.day.reserved),
 		[1, 2, 3, 4, 5],
 	);
+	assert.deepEqual(
+		results.map((r) => r.reason),
+		["ok", "ok", "ok", "over-budget", "over-budget"],
+	);
+	assert.equal(results[3].blockedWindow, "day");
 });
 
-test("the TTL is set once, on first reservation only", async () => {
+test("day-only: the TTL is set once, on first reservation only", async () => {
 	const redis = fakeRedis();
-	const now = new Date("2026-07-16T10:00:00Z");
-	await reserveBudget(redis, { cap: 10, now });
-	assert.ok(redis.ttl.has("budget:2026-07-16"), "TTL set on first reserve");
-	redis.ttl.delete("budget:2026-07-16");
-	await reserveBudget(redis, { cap: 10, now });
-	assert.ok(!redis.ttl.has("budget:2026-07-16"), "TTL must NOT be reset on later reserves");
+	await reserveBudget(redis, { caps: { day: 10 }, now: NOW });
+	assert.ok(redis.ttl.has(DAY), "TTL set on first reserve");
+	redis.ttl.delete(DAY);
+	await reserveBudget(redis, { caps: { day: 10 }, now: NOW });
+	assert.ok(!redis.ttl.has(DAY), "TTL must NOT be reset on later reserves");
 });
 
-test("cap 0 fails closed -- every job refused, not 'unlimited'", async () => {
+test("day cap 0 fails closed -- every job refused, not 'unlimited'", async () => {
 	const redis = fakeRedis();
-	const r = await reserveBudget(redis, { cap: 0, now: new Date("2026-07-16T10:00:00Z") });
+	const r = await reserveBudget(redis, { caps: { day: 0 }, now: NOW });
 	assert.equal(r.allowed, false);
+	assert.equal(r.reason, "over-budget");
 });
 
-test("release gives a slot back (infra-fault path only)", async () => {
+// ---- multi-window ----
+
+test("multi-window: day/week/month count on independent keys", async () => {
 	const redis = fakeRedis();
-	const now = new Date("2026-07-16T10:00:00Z");
-	await reserveBudget(redis, { cap: 3, now });
-	await reserveBudget(redis, { cap: 3, now });
-	await releaseBudget(redis, { now });
-	const r = await reserveBudget(redis, { cap: 3, now });
-	assert.equal(r.reserved, 2, "a released slot is reusable");
+	const r = await reserveBudget(redis, { caps: { day: 10, week: 20, month: 30 }, now: NOW });
+	assert.deepEqual(
+		[r.windows.day.reserved, r.windows.week.reserved, r.windows.month.reserved],
+		[1, 1, 1],
+	);
+	assert.equal(redis.store.get(DAY), 1);
+	assert.equal(redis.store.get(WEEK), 1);
+	assert.equal(redis.store.get(MONTH), 1);
+	assert.ok(redis.ttl.get(WEEK) > redis.ttl.get(DAY), "the week TTL outlives the day TTL");
+	assert.ok(redis.ttl.get(MONTH) > redis.ttl.get(WEEK), "the month TTL outlives the week TTL");
+});
+
+test("multi-window: ANY window over its cap refuses, and blockedWindow names it (day > week > month)", async () => {
+	const redis = fakeRedis();
+	redis.store.set(WEEK, 5); // the week window is already at its cap
+	const r = await reserveBudget(redis, { caps: { day: 100, week: 5, month: 100 }, now: NOW });
+	assert.equal(r.allowed, false);
+	assert.equal(r.reason, "over-budget");
+	assert.equal(r.blockedWindow, "week", "the week ceiling is the one that blocked");
+	assert.equal(r.windows.day.state, "ok", "the day window is still fine");
+});
+
+test("a disabled window (null cap) is neither counted nor evaluated", async () => {
+	const redis = fakeRedis();
+	const r = await reserveBudget(redis, { caps: { day: 10, week: null, month: null }, now: NOW });
 	assert.equal(r.allowed, true);
+	assert.equal(r.windows.week, null);
+	assert.equal(r.windows.month, null);
+	assert.ok(!redis.store.has(WEEK), "a disabled week window creates no key");
+	assert.ok(!redis.store.has(MONTH), "a disabled month window creates no key");
+});
+
+// ---- soft-hold band ----
+
+test("soft-hold: a reservation inside the band refuses with a distinct reason, still counting", async () => {
+	const redis = fakeRedis();
+	redis.store.set(DAY, 8); // next reservation lands at 9, inside the 80% band of cap 10 (threshold 8)
+	const r = await reserveBudget(redis, { caps: { day: 10 }, softHoldPct: 80, now: NOW });
+	assert.equal(r.allowed, false);
+	assert.equal(r.reason, "soft-hold");
+	assert.equal(r.blockedWindow, "day");
+	assert.equal(r.windows.day.reserved, 9);
+	assert.equal(r.windows.day.state, "soft-hold");
+});
+
+test("soft-hold: below the band the run is allowed", async () => {
+	const redis = fakeRedis();
+	redis.store.set(DAY, 6); // -> 7, below the threshold of 8
+	const r = await reserveBudget(redis, { caps: { day: 10 }, softHoldPct: 80, now: NOW });
+	assert.equal(r.allowed, true);
+	assert.equal(r.reason, "ok");
+});
+
+test("soft-hold: over-budget outranks soft-hold, and day outranks week", async () => {
+	const redis = fakeRedis();
+	redis.store.set(DAY, 10); // -> 11, OVER the day cap of 10
+	redis.store.set(WEEK, 8); // -> 9, inside the week's soft-hold band
+	const r = await reserveBudget(redis, { caps: { day: 10, week: 10 }, softHoldPct: 80, now: NOW });
+	assert.equal(r.reason, "over-budget", "a hard over beats a soft-hold");
+	assert.equal(r.blockedWindow, "day");
+	assert.equal(r.windows.week.state, "soft-hold", "the week is still surfaced as soft-hold in its window");
+});
+
+// ---- release ----
+
+test("release gives a slot back in every active window (infra never-started path)", async () => {
+	const redis = fakeRedis();
+	await reserveBudget(redis, { caps: { day: 3, week: 3, month: 3 }, now: NOW });
+	await reserveBudget(redis, { caps: { day: 3, week: 3, month: 3 }, now: NOW });
+	await releaseBudget(redis, { caps: { day: 3, week: 3, month: 3 }, now: NOW });
+	assert.equal(redis.store.get(DAY), 1);
+	assert.equal(redis.store.get(WEEK), 1);
+	assert.equal(redis.store.get(MONTH), 1);
+	const r = await reserveBudget(redis, { caps: { day: 3, week: 3, month: 3 }, now: NOW });
+	assert.equal(r.windows.day.reserved, 2, "a released slot is reusable");
+	assert.equal(r.allowed, true);
+});
+
+test("release only decrements active windows -- a disabled window is untouched", async () => {
+	const redis = fakeRedis();
+	redis.store.set(DAY, 5);
+	await releaseBudget(redis, { caps: { day: 3, week: null, month: null }, now: NOW });
+	assert.equal(redis.store.get(DAY), 4);
+	assert.ok(!redis.store.has(WEEK), "a disabled window is never decremented into existence");
 });

--- a/worker/test/config.test.mjs
+++ b/worker/test/config.test.mjs
@@ -7,6 +7,9 @@ test("loads conservative defaults with an empty-ish env", () => {
 	const c = loadConfig({});
 	assert.equal(c.concurrency, 3);
 	assert.equal(c.dailyCap, 25);
+	assert.equal(c.weeklyCap, null, "the weekly ceiling defaults to disabled");
+	assert.equal(c.monthlyCap, null, "the monthly ceiling defaults to disabled");
+	assert.equal(c.softHoldPct, null, "the soft-hold band defaults to disabled");
 	assert.equal(c.provider, "anthropic");
 	assert.equal(c.model, "claude-sonnet-4-5-20250929"); // dated, deterministic
 	assert.equal(c.maxTurns, 30);
@@ -100,6 +103,33 @@ test("logRetentionDays rejects negative and non-integer values as config errors"
 
 test("positiveInt is unchanged: a spend var of 0 still throws", () => {
 	assert.throws(() => loadConfig({ PI_DAILY_CAP: "0" }), (e) => e.piDispatchConfig === true);
+});
+
+test("weekly/monthly ceilings take explicit positive values, and absence is disabled (null)", () => {
+	const c = loadConfig({ PI_WEEKLY_CAP: "100", PI_MONTHLY_CAP: "400" });
+	assert.equal(c.weeklyCap, 100);
+	assert.equal(c.monthlyCap, 400);
+	// empty string is also "disabled", not a parse error
+	assert.equal(loadConfig({ PI_WEEKLY_CAP: "" }).weeklyCap, null);
+});
+
+test("weekly/monthly ceilings reject 0, negatives, and non-integers as config errors", () => {
+	for (const name of ["PI_WEEKLY_CAP", "PI_MONTHLY_CAP"]) {
+		for (const bad of ["0", "-1", "abc", "1.5"]) {
+			assert.throws(() => loadConfig({ [name]: bad }), (e) => e.piDispatchConfig === true, `${name}=${bad}`);
+		}
+	}
+});
+
+test("soft-hold pct takes 1-99, defaults to disabled, and rejects out-of-range or non-integer", () => {
+	assert.equal(loadConfig({ PI_SOFT_HOLD_PCT: "80" }).softHoldPct, 80);
+	assert.equal(loadConfig({ PI_SOFT_HOLD_PCT: "1" }).softHoldPct, 1);
+	assert.equal(loadConfig({ PI_SOFT_HOLD_PCT: "99" }).softHoldPct, 99);
+	assert.equal(loadConfig({}).softHoldPct, null);
+	assert.equal(loadConfig({ PI_SOFT_HOLD_PCT: "" }).softHoldPct, null);
+	for (const bad of ["0", "100", "-5", "abc", "50.5"]) {
+		assert.throws(() => loadConfig({ PI_SOFT_HOLD_PCT: bad }), (e) => e.piDispatchConfig === true, `PI_SOFT_HOLD_PCT=${bad}`);
+	}
 });
 
 test("env overrides every field", () => {

--- a/worker/test/processor.test.mjs
+++ b/worker/test/processor.test.mjs
@@ -18,7 +18,10 @@ function deps(overrides = {}) {
 	const calls = [];
 	const base = {
 		redis: fakeRedis(),
-		cap: 10,
+		// The day window is the only one active by default (week/month disabled), so the single-counter
+		// fakeRedis stays valid; soft-hold is off unless a test sets it. Mirrors a default deployment.
+		caps: { day: 10, week: null, month: null },
+		softHoldPct: null,
 		mintToken: async (repo) => (calls.push(`mint:${repo}`), "tok"),
 		isDefaultBranchProtected: async () => (calls.push("branch-check"), true),
 		prepareWorkspace: async () => (calls.push("prepare"), { workspaceDir: "/w", jobDir: "/j" }),
@@ -50,12 +53,23 @@ test("an unprotected branch refuses BEFORE any container -- and never prepares/s
 });
 
 test("over budget refuses AFTER prepare but BEFORE the container -- no provider spend", async () => {
-	// counter starts at cap, so the reservation lands over-cap.
-	const { deps: d, calls } = deps({ redis: fakeRedis(10), cap: 10 });
+	// counter starts at cap, so the reservation lands over-cap (base caps.day is 10).
+	const { deps: d, calls } = deps({ redis: fakeRedis(10) });
 	const r = await runJob(ghJob, d);
 	assert.equal(r.reason, "over-budget");
 	assert.ok(calls.includes("prepare"), "prepared (free work) before the budget gate");
 	assert.ok(!calls.includes("run-container"), "over budget => NO container, no money spent");
+});
+
+test("soft-hold refuses AFTER prepare but BEFORE the container, with a distinct soft-hold reason", async () => {
+	// day cap 5, 80% band -> threshold floor(4)=4; counter at 4 makes the reservation land at 5 (in-band).
+	const { deps: d, calls } = deps({ redis: fakeRedis(4), caps: { day: 5, week: null, month: null }, softHoldPct: 80 });
+	const r = await runJob(ghJob, d);
+	assert.equal(r.outcome, "policy");
+	assert.equal(r.reason, "soft-hold", "an in-band reservation is a soft-hold, distinct from over-budget");
+	assert.equal(r.budgetReserved, true, "the reservation still counts (no give-back)");
+	assert.ok(calls.includes("prepare"), "prepared (free work) before the budget gate");
+	assert.ok(!calls.includes("run-container"), "soft-hold => new start paused, NO container, no money spent");
 });
 
 test("a prepare policy outcome (sha-gone) RETURNS before reserveBudget -- no cap slot burned", async () => {
@@ -185,7 +199,7 @@ test("a completed return carries exitCode/turns from the container and budgetRes
 });
 
 test("an over-budget return carries null exit/turns but budgetReserved true (slot kept)", async () => {
-	const { deps: d } = deps({ redis: fakeRedis(10), cap: 10 });
+	const { deps: d } = deps({ redis: fakeRedis(10) });
 	const r = await runJob(ghJob, d);
 	assert.equal(r.reason, "over-budget");
 	assert.equal(r.exitCode, null);
@@ -279,7 +293,7 @@ test("collectChain runs ONLY on the completed branch, never on policy / abort / 
 	}
 	// over-budget (policy, pre-container)
 	{
-		const { deps: d, calls } = deps({ redis: fakeRedis(10), cap: 10 });
+		const { deps: d, calls } = deps({ redis: fakeRedis(10) });
 		await runJob(ghJob, d);
 		assert.ok(!calls.includes("collect-chain"), "over-budget must not chain");
 	}

--- a/worker/test/runtime-settings.test.mjs
+++ b/worker/test/runtime-settings.test.mjs
@@ -81,8 +81,13 @@ test("readOverlay: a non-object root (array, string, null) is invalid", () => {
 // ---- readOverlay: each known key ----
 
 test("readOverlay: valid known keys are accepted and returned as the overlay", () => {
-	const res = readObj({ model: "claude-x", provider: "anthropic", maxTurns: 12, dailyCap: 40, concurrency: 5 });
-	assert.deepEqual(res, { overlay: { model: "claude-x", provider: "anthropic", maxTurns: 12, dailyCap: 40, concurrency: 5 } });
+	const obj = { model: "claude-x", provider: "anthropic", maxTurns: 12, dailyCap: 40, weeklyCap: 200, monthlyCap: 800, concurrency: 5, softHoldPct: 80 };
+	assert.deepEqual(readObj(obj), { overlay: obj });
+});
+
+test("readOverlay: softHoldPct boundaries 1 and 99 are accepted", () => {
+	assert.deepEqual(readObj({ softHoldPct: 1 }), { overlay: { softHoldPct: 1 } });
+	assert.deepEqual(readObj({ softHoldPct: 99 }), { overlay: { softHoldPct: 99 } });
 });
 
 test("readOverlay: concurrency boundaries 1 and 10 are accepted", () => {
@@ -102,7 +107,13 @@ test("readOverlay: an invalid known key makes the whole file invalid; the reason
 		{ obj: { maxTurns: "5" }, key: "maxTurns", value: "5" },
 		{ obj: { dailyCap: 0 }, key: "dailyCap", value: null },
 		{ obj: { dailyCap: -8 }, key: "dailyCap", value: "-8" },
-		{ obj: { concurrency: 0 }, key: "concurrency", value: null },
+		{ obj: { weeklyCap: 0 }, key: "weeklyCap", value: null },
+			{ obj: { weeklyCap: 2.5 }, key: "weeklyCap", value: "2.5" },
+			{ obj: { monthlyCap: -1 }, key: "monthlyCap", value: "-1" },
+			{ obj: { softHoldPct: 0 }, key: "softHoldPct", value: null },
+			{ obj: { softHoldPct: 100 }, key: "softHoldPct", value: "100" },
+			{ obj: { softHoldPct: 50.5 }, key: "softHoldPct", value: "50.5" },
+			{ obj: { concurrency: 0 }, key: "concurrency", value: null },
 		{ obj: { concurrency: 99 }, key: "concurrency", value: "99" },
 		{ obj: { concurrency: 4.2 }, key: "concurrency", value: "4.2" },
 	];
@@ -150,20 +161,23 @@ test("readOverlay never throws across the nasty corpus", () => {
 
 // ---- effectiveSettings ----
 
-test("effectiveSettings: overlay wins where set, config fills the rest, result has exactly five keys", () => {
-	const config = { provider: "anthropic", model: "cfg-model", maxTurns: 30, dailyCap: 25, concurrency: 3, valkeyUrl: "x", jobImage: "y" };
-	const res = effectiveSettings(config, { model: "ovl-model", dailyCap: 5 });
+test("effectiveSettings: overlay wins where set, config fills the rest, result has exactly eight keys", () => {
+	const config = { provider: "anthropic", model: "cfg-model", maxTurns: 30, dailyCap: 25, weeklyCap: null, monthlyCap: null, concurrency: 3, softHoldPct: null, valkeyUrl: "x", jobImage: "y" };
+	const res = effectiveSettings(config, { model: "ovl-model", dailyCap: 5, weeklyCap: 100, softHoldPct: 80 });
 	assert.equal(res.model, "ovl-model", "overlay wins");
 	assert.equal(res.dailyCap, 5, "overlay wins");
+	assert.equal(res.weeklyCap, 100, "overlay sets an otherwise-disabled window");
+	assert.equal(res.softHoldPct, 80, "overlay sets the soft-hold band");
 	assert.equal(res.provider, "anthropic", "absent overlay key falls to config");
 	assert.equal(res.maxTurns, 30, "absent overlay key falls to config");
+	assert.equal(res.monthlyCap, null, "absent overlay key falls to config's null (disabled)");
 	assert.equal(res.concurrency, 3, "absent overlay key falls to config");
-	assert.deepEqual(Object.keys(res).sort(), ["concurrency", "dailyCap", "maxTurns", "model", "provider"]);
+	assert.deepEqual(Object.keys(res).sort(), ["concurrency", "dailyCap", "maxTurns", "model", "monthlyCap", "provider", "softHoldPct", "weeklyCap"]);
 });
 
-test("effectiveSettings: an empty overlay yields the config values verbatim for all five keys", () => {
-	const config = { provider: "anthropic", model: "cfg-model", maxTurns: 30, dailyCap: 25, concurrency: 3 };
-	assert.deepEqual(effectiveSettings(config, {}), { provider: "anthropic", model: "cfg-model", maxTurns: 30, dailyCap: 25, concurrency: 3 });
+test("effectiveSettings: an empty overlay yields the config values verbatim for all eight keys", () => {
+	const config = { provider: "anthropic", model: "cfg-model", maxTurns: 30, dailyCap: 25, weeklyCap: null, monthlyCap: null, concurrency: 3, softHoldPct: null };
+	assert.deepEqual(effectiveSettings(config, {}), config);
 });
 
 // ---- writeOverlay ----
@@ -248,8 +262,11 @@ test("writeOverlay never throws when mkdir or write fails", () => {
 
 // ---- KNOWN_KEYS ----
 
-test("KNOWN_KEYS is exported and lists exactly the five overlay keys", () => {
-	assert.deepEqual([...KNOWN_KEYS].sort(), ["concurrency", "dailyCap", "maxTurns", "model", "provider"]);
+test("KNOWN_KEYS is exported and lists exactly the eight overlay keys", () => {
+	assert.deepEqual(
+		[...KNOWN_KEYS].sort(),
+		["concurrency", "dailyCap", "maxTurns", "model", "monthlyCap", "provider", "softHoldPct", "weeklyCap"],
+	);
 });
 
 // ---- settingsFilePath ----

--- a/worker/test/settings-pickup.test.mjs
+++ b/worker/test/settings-pickup.test.mjs
@@ -66,7 +66,17 @@ const receiverGhJob = () => ({
 	data: { kind: "github", repo: "o/r", issueNumber: 1, flow: "fix", trigger: { deliveryId: "d", sender: { id: 1 } } },
 });
 
-const effective = (over = {}) => ({ provider: "anthropic", model: "claude-sonnet-4-5", maxTurns: 30, dailyCap: 10, concurrency: 3, ...over });
+const effective = (over = {}) => ({
+	provider: "anthropic",
+	model: "claude-sonnet-4-5",
+	maxTurns: 30,
+	dailyCap: 10,
+	weeklyCap: null,
+	monthlyCap: null,
+	concurrency: 3,
+	softHoldPct: null,
+	...over,
+});
 
 test("(a) P0: a receiver GitHub job with no provider/model/maxTurns reaches the container with effective values; slot reserved once", { skip }, async () => {
 	const { processor, seen, redis } = harness({ getSettings: () => effective() });
@@ -123,6 +133,19 @@ test("(d) explicit job.data values win over the overlay", { skip }, async () => 
 	assert.equal(seen.container.provider, "explicit-provider", "job.data.provider wins over the overlay");
 	assert.equal(seen.container.model, "explicit-model", "job.data.model wins over the overlay");
 	assert.equal(seen.container.maxTurns, 7, "job.data.maxTurns wins over the overlay");
+});
+
+test("(f) a soft-hold percentage set live in the overlay refuses the next in-band job before the container", { skip }, async () => {
+	// The counter sits at 4; an overlay dailyCap of 5 with softHoldPct 80 (threshold floor(4)=4) makes the
+	// next reservation land at 5 -- inside the band -- so the job is soft-held. Proves a live overlay knob
+	// takes effect at the very next job start with no restart (INT-CONFIG-OVERLAY-CONTRACT).
+	const { processor, seen } = harness({ getSettings: () => effective({ dailyCap: 5, softHoldPct: 80 }), redis: fakeRedis(4) });
+
+	const result = await processor(receiverGhJob(), "tok", new AbortController().signal);
+
+	assert.equal(result.outcome, "policy");
+	assert.equal(result.reason, "soft-hold", "the live soft-hold band is what reserveBudget checks against");
+	assert.equal(seen.containerCalls, 0, "soft-hold => new start paused, no provider spend");
 });
 
 test("(e) applyConcurrency runs with the effective concurrency on the happy path, never when the overlay is invalid", { skip }, async () => {

--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -302,11 +302,21 @@ test("runtime settings: getSettings is a top-level createWorker arg resolving ef
 	assert.equal(typeof captured.getSettings, "function", "getSettings must be a top-level createWorker arg");
 	assert.equal(captured.cap, undefined, "no static cap arg survives -- the overlay replaces the frozen daily cap");
 
-	// Calling it with an empty overlay yields the five effective keys from env/default config (env {} here).
+	// Calling it with an empty overlay yields the eight effective keys from env/default config (env {} here);
+	// the optional week/month ceilings and the soft-hold band default to disabled (null).
 	assert.deepEqual(
 		captured.getSettings(),
-		{ provider: "anthropic", model: "claude-sonnet-4-5-20250929", maxTurns: 30, dailyCap: 25, concurrency: 3 },
-		"getSettings resolves the five effective keys from env/default config when the overlay is empty",
+		{
+			provider: "anthropic",
+			model: "claude-sonnet-4-5-20250929",
+			maxTurns: 30,
+			dailyCap: 25,
+			weeklyCap: null,
+			monthlyCap: null,
+			concurrency: 3,
+			softHoldPct: null,
+		},
+		"getSettings resolves the eight effective keys from env/default config when the overlay is empty",
 	);
 
 	const started = logs.find((l) => l.event === "worker_started");


### PR DESCRIPTION
Closes #19.

## What

Extends the pre-container budget check from a single **daily** window to **three** windows plus a **soft-hold band**:

- **Daily** cap stays mandatory (`PI_DAILY_CAP`, default 25).
- **Weekly / monthly** ceilings are optional (`PI_WEEKLY_CAP`, `PI_MONTHLY_CAP` / overlay `weeklyCap`, `monthlyCap`). Unset ⇒ that window is disabled — not counted, not evaluated.
- **Soft-hold band** (`PI_SOFT_HOLD_PCT` / overlay `softHoldPct`, 1–99). Once any active window reaches this % of its cap, new starts are **refused** with a distinct `soft-hold` reason (in-flight containers finish, since the reservation is pre-container). Unset ⇒ disabled.

A job is admitted only when **every** active window is within its cap **and** outside the band. `over-budget` outranks `soft-hold`; the refusal names the blocking window (day > week > month).

## Design decisions

- **Enforcing soft-hold** (confirmed with maintainer): the band pauses new starts, it isn't advisory. `over-budget` still wins when a hard cap is also breached.
- **Unconditional multi-INCR**, fail-closed: preserves the existing *"a refused reservation still counts, no give-back"* invariant per window and avoids reintroducing the read-then-write race the atomic-INCR design exists to prevent. `releaseBudget` mirrors the active windows so the infra-refund can't drift.
- **Keys**: `budget:YYYY-MM-DD` (day, unchanged — no migration), `budget:w:<Monday-UTC>` (week), `budget:m:YYYY-MM` (month). Each gets its own set-once TTL.
- **Shared `windowState()`** classifier drives both worker enforcement and the admin panel, so the two can't drift on where amber/red begins (same reason the read-model already imports `dayKey`).
- **Monochrome panel**: `clip()` strips ANSI (asserted by `panel.test.mjs`), so "amber" renders as a **textual** `soft-hold` / `over` marker, not a colour.

## Invariant preserved

`CONST-BUDGET-BEFORE-TOKENS` is unchanged — still **job-count** caps, still **check-and-increment before the container**. Only *how many windows* are counted changed; the ordering that is the mechanism is untouched. Token caps remain the separate, structurally-lagging problem tracked at OQ-010.

## Specs

- **New** `REQ-SPEND-CAPS-MULTI-WINDOW`.
- Extended `CONST-BUDGET-BEFORE-TOKENS`, `INT-CONFIG-OVERLAY-CONTRACT`, `DES-RUNTIME-SETTINGS-FILE-OVERLAY`, `REQ-RUNTIME-SETTINGS-PICKUP`, `.env.example`.

## Tests

Full suite green: **594 pass / 0 fail** (15 skips are the `VALKEY_TEST_URL`-gated integration tests, CI-only). New coverage: multi-window refusal + `blockedWindow` priority, soft-hold band (worker + processor + live-overlay pickup + admin render/dashboard/panel), window-disable, config parsing, `windowState` boundaries, release-across-windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3npQvQXLWsW6qsrRMAmNL