### PR TITLE
feat(tokens): token accounting + optional token budget & daily cap (#25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ PI_DAILY_CAP=25        # max job containers started per day (mandatory window)
 # PI_MONTHLY_CAP=400   # optional monthly ceiling on container starts; unset = monthly window disabled
 # PI_SOFT_HOLD_PCT=80  # optional soft-hold band (1-99): once any window hits this % of its cap, new starts
                        # pause (in-flight jobs finish) and the panel meter turns amber; unset = disabled
+# PI_MAX_TOKENS=       # optional per-job token budget: the runner aborts the agent once cumulative usage exceeds it.
+                       # LAGGING (spends before it can see the total) -- a single-job runaway backstop, not before-the-spend;
+                       # PI_MAX_TURNS stays the proactive lever. Unset = per-job token budget disabled (usage is still recorded).
+# PI_DAILY_TOKEN_CAP=  # optional daily token cap: once a day's recorded spend reaches it, the NEXT job is refused pre-container.
+                       # Check-AFTER by nature (token cost is only known post-run), unlike PI_DAILY_CAP; unset = disabled
 PI_CONCURRENCY=3       # how many jobs run in parallel
 
 # --- Infrastructure ---

--- a/admin/src/dashboard.ts
+++ b/admin/src/dashboard.ts
@@ -383,7 +383,7 @@ function renderRunList(rows: any[], selected: number, w: number): string[] {
     const cursor = i === selected ? "›" : " ";
     if (row.kind === "active") return clip(`${cursor} * ACTIVE ${row.jobId} running`, w);
     const run = row.record;
-    const cells = [run?.jobId, run?.target, run?.flow, run?.outcome, run?.turns]
+    const cells = [run?.jobId, run?.target, run?.flow, run?.outcome, run?.turns, run?.tokens?.total]
       .map((f) => (f === null || f === undefined ? "-" : String(f)))
       .join(" · ");
     return clip(`${cursor} ${cells}`, w);
@@ -437,6 +437,10 @@ function renderRunDetail(record: any): string[] {
     ["outcome", r.outcome],
     ["reason", r.reason],
     ["turns", r.turns],
+    // Per-job token accounting (issue #25): total tokens and cost-USD, or `-` when the container died
+    // before reporting usage. r.tokens is `{ input, output, total, cost }` | null.
+    ["tokens", r.tokens?.total],
+    ["cost", typeof r.tokens?.cost === "number" ? `$${r.tokens.cost.toFixed(4)}` : null],
     ["exitCode", r.exitCode],
     ["budgetReserved", r.budgetReserved],
     ["attempt", r.attempt],

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -395,13 +395,16 @@ function applyUnset(settingsFile: string, tokens: string[], notify: Notify): voi
 }
 
 /**
- * Coerce a raw token to the settings value its key expects: the three numeric keys parse via `Number` (a
- * non-numeric token becomes `NaN`, which `writeOverlay` then rejects with a key-only reason); `model` and
- * `provider` keep the raw string. Bounds and integer-ness stay in `writeOverlay`, the single validator.
+ * Coerce a raw token to the settings value its key expects: `model` and `provider` keep the raw string;
+ * every other overlay key is numeric and parses via `Number` (a non-numeric token becomes `NaN`, which
+ * `writeOverlay` then rejects with a key-only reason). Keying off the two string exceptions rather than an
+ * enumerated numeric list keeps this in lockstep with `KNOWN_KEYS` -- a new numeric knob (weekly/monthly
+ * caps, the token caps) is coerced without a second edit here. Bounds and integer-ness stay in
+ * `writeOverlay`, the single validator.
  */
 function coerceSettingValue(key: string, raw: string): number | string {
-  if (key === "maxTurns" || key === "dailyCap" || key === "concurrency") return Number(raw);
-  return raw;
+  if (key === "model" || key === "provider") return raw;
+  return Number(raw);
 }
 
 /**

--- a/admin/src/render.mjs
+++ b/admin/src/render.mjs
@@ -4,7 +4,7 @@
  * testable with plain fixtures.
  *
  * PII discipline (no-pii-in-logs, INT-RUN-HISTORY-FILE-CONTRACT): a renderer only ever sees the PII-free
- * record fields (`target` is `repo#issue` / `local:<basename>` only), the five settings keys, scheduler
+ * record fields (`target` is `repo#issue` / `local:<basename>` only), the ten settings keys, scheduler
  * keys, and flow labels. Raw `.log` bytes are untrusted, PII-bearing container output and NEVER reach a
  * renderer -- the logs overlay in index.ts is their only surface, so there is deliberately no code path
  * from here to a `.log` file (asserted by render.test.mjs).
@@ -12,7 +12,7 @@
 
 import { windowState } from "@pi-dispatch/worker/budget";
 
-const SETTINGS_KEYS = ["model", "provider", "maxTurns", "dailyCap", "weeklyCap", "monthlyCap", "concurrency", "softHoldPct"];
+const SETTINGS_KEYS = ["model", "provider", "maxTurns", "dailyCap", "weeklyCap", "monthlyCap", "maxTokens", "dailyTokenCap", "concurrency", "softHoldPct"];
 
 // The three spend windows and the overlay cap key each reads. Order is day -> week -> month.
 const BUDGET_WINDOWS = [
@@ -28,6 +28,10 @@ const RUN_COLUMNS = [
   { key: "outcome", header: "OUTCOME" },
   { key: "reason", header: "REASON" },
   { key: "turns", header: "TURNS" },
+  // Per-job token accounting (issue #25). `tokens` is `{ input, output, total, cost }` | null; a derive
+  // reaches into it so a null record still reads "-", and cost renders as a $-prefixed fixed-decimal.
+  { key: "tokens", header: "TOKENS", derive: (r) => cell(r?.tokens?.total) },
+  { key: "cost", header: "COST", derive: (r) => (typeof r?.tokens?.cost === "number" ? `$${r.tokens.cost.toFixed(4)}` : "-") },
   // Derived: a `d<n>` chain-depth marker for an outbox-chained child, "-" for a root run. A custom
   // derive is needed because `cell()` would render depth 0 as "0"; here depth 0/null/absent all read "-".
   { key: "chain", header: "CHAIN", derive: (r) => (r?.chainDepth > 0 ? `d${r.chainDepth}` : "-") },
@@ -155,7 +159,7 @@ function schedulerLine(s) {
   return `${id}  next ${next}${drift}`;
 }
 
-/** Render the settings overlay view: all five keys, unset ones marked, or the fail-closed invalid reason. */
+/** Render the settings overlay view: every overlay key, unset ones marked, or the fail-closed invalid reason. */
 export function renderSettingsView(settings) {
   const path = settings?.path ?? "(unknown path)";
   if (settings && settings.invalid) return `Settings (${path}): invalid: ${settings.invalid}`;

--- a/admin/test/dashboard.test.mjs
+++ b/admin/test/dashboard.test.mjs
@@ -32,6 +32,7 @@ const SNAPSHOT = {
       outcome: "completed",
       reason: null,
       turns: 4,
+      tokens: { input: 4000, output: 1000, total: 5000, cost: 0.0523 },
       endedAt: "2026-07-21T00:00:00.000Z",
     },
   ],
@@ -297,6 +298,8 @@ test("Enter on a run opens its detail dump, and Esc backs out to the list withou
   const detail = comp.render(80).join("\n");
   assert.match(detail, /run j1/, "the detail view titles on the selected run");
   assert.match(detail, /attempt: -/, "a detail-only field renders, absent as '-'");
+  assert.match(detail, /tokens: 5000/, "the drill-in surfaces total tokens");
+  assert.match(detail, /cost: \$0\.0523/, "the drill-in surfaces cost as $-prefixed USD");
 
   comp.handleInput("\x1b");
   await flush();

--- a/admin/test/render.test.mjs
+++ b/admin/test/render.test.mjs
@@ -52,6 +52,19 @@ test("renderRuns aligns columns with a header and a data row, including the chai
   assert.match(out, /\bd1\b/, "a chained child renders a d<n> depth marker");
 });
 
+test("renderRuns surfaces per-job tokens and cost, and dashes them when usage is absent", () => {
+  const out = renderRuns([
+    { jobId: "j1", target: "o/r#5", flow: "fix", outcome: "completed", turns: 4, tokens: { input: 4000, output: 1000, total: 5000, cost: 0.0523 }, endedAt: "2026-07-21T00:00:00.000Z" },
+    { jobId: "j2", target: "o/r#6", flow: "fix", outcome: "failed", turns: null, tokens: null, endedAt: "2026-07-21T00:01:00.000Z" },
+  ]);
+  assert.match(out, /TOKENS/);
+  assert.match(out, /COST/);
+  assert.match(out, /\b5000\b/, "total tokens render for a run that reported usage");
+  assert.match(out, /\$0\.0523/, "cost renders as a $-prefixed fixed-decimal");
+  const noUsageRow = out.split("\n").find((l) => l.includes("j2"));
+  assert.match(noUsageRow, /-/, "a run without usage dashes its token/cost cells");
+});
+
 test("renderRuns renders a fully-null record as dashes (chain column included)", () => {
   const out = renderRuns([{ jobId: null, target: null, flow: null, outcome: null, reason: null, turns: null, chainDepth: null, endedAt: null }]);
   assert.match(out, /CHAIN/);
@@ -127,15 +140,17 @@ test("renderTriggers reports an unreachable scheduler read", () => {
   assert.match(renderTriggers({ schedulers: { unreachable: "down" }, flows: { rules: {} } }), /unreachable \(down\)/);
 });
 
-test("renderSettingsView lists all eight keys, unset ones marked", () => {
-  const out = renderSettingsView({ path: "/s", overlay: { model: "claude", dailyCap: 5, weeklyCap: 100, softHoldPct: 80 } });
+test("renderSettingsView lists all ten keys, unset ones marked", () => {
+  const out = renderSettingsView({ path: "/s", overlay: { model: "claude", dailyCap: 5, weeklyCap: 100, softHoldPct: 80, maxTokens: 500000 } });
   assert.match(out, /Settings \(\/s\)/);
   assert.match(out, /model: claude/);
   assert.match(out, /dailyCap: 5/);
   assert.match(out, /weeklyCap: 100/);
   assert.match(out, /softHoldPct: 80/);
+  assert.match(out, /maxTokens: 500000/);
   assert.match(out, /provider: \(unset\)/);
   assert.match(out, /monthlyCap: \(unset\)/);
+  assert.match(out, /dailyTokenCap: \(unset\)/);
   assert.match(out, /concurrency: \(unset\)/);
 });
 

--- a/admin/test/wiring.test.mjs
+++ b/admin/test/wiring.test.mjs
@@ -274,8 +274,12 @@ test("argument completion offers subcommands then run ids", async () => {
 
 test("argument completion offers the known settings keys for `set`/`unset`", async () => {
   const { def } = await loadRegistered();
+  // "da" prefixes both dailyCap and dailyTokenCap, in KNOWN_KEYS order.
   const set = await def.getArgumentCompletions("set da");
-  assert.deepEqual(set, [{ value: "set dailyCap", label: "dailyCap" }]);
+  assert.deepEqual(set, [
+    { value: "set dailyCap", label: "dailyCap" },
+    { value: "set dailyTokenCap", label: "dailyTokenCap" },
+  ]);
   const unset = await def.getArgumentCompletions("unset con");
   assert.deepEqual(unset, [{ value: "unset concurrency", label: "concurrency" }]);
   // No key matches -> null.

--- a/image/runner/run-job.mjs
+++ b/image/runner/run-job.mjs
@@ -16,6 +16,7 @@ import {
 	decideExit,
 	EXIT_INFRA,
 } from "./src/outcome.mjs";
+import { attachTokenBudget } from "./src/token-budget.mjs";
 import { attachTurnBudget } from "./src/turn-budget.mjs";
 
 const PROMPT_PATH = "/job/prompt.md";
@@ -89,10 +90,16 @@ async function main() {
 		onAbort: (turns) => log("turn_budget_exceeded", { turns, maxTurns: cfg.maxTurns }),
 	});
 
+	// Always-on token meter; aborts only when cfg.maxTokens is set (lagging backstop, OQ-010).
+	const tokenBudget = attachTokenBudget(session, cfg.maxTokens, {
+		onAbort: (tokens) => log("token_budget_exceeded", { tokens, maxTokens: cfg.maxTokens }),
+	});
+
 	try {
 		await session.prompt(prompt);
 	} finally {
 		budget.unsubscribe();
+		tokenBudget.unsubscribe();
 		unsubscribeTerminal();
 		// Runs the cleanup callbacks providers register via registerSessionResourceCleanup. Every
 		// official SDK example disposes; skipping it can leak a provider transport and hang the
@@ -103,9 +110,11 @@ async function main() {
 	const outcome = decideExit({
 		budgetAborted: budget.state.aborted,
 		budgetTurns: budget.state.turns,
+		tokenAborted: tokenBudget.state.aborted,
 		terminal,
 	});
-	log("exit", { ...outcome, turns: budget.state.turns });
+	const { input, output, total, cost } = tokenBudget.state;
+	log("exit", { ...outcome, turns: budget.state.turns, tokens: { input, output, total, cost } });
 	return outcome.code;
 }
 

--- a/image/runner/src/config.mjs
+++ b/image/runner/src/config.mjs
@@ -13,11 +13,13 @@ export function parseRunnerEnv(env) {
 	const provider = requireEnv(env, "PI_PROVIDER");
 	const model = requireEnv(env, "PI_MODEL");
 	const maxTurns = parsePositiveInt(env, "PI_MAX_TURNS");
+	const maxTokens = parseOptionalPositiveInt(env, "PI_MAX_TOKENS");
 
 	return {
 		provider,
 		model,
 		maxTurns,
+		maxTokens,
 		retry: {
 			maxRetries: parsePositiveInt(env, "PI_RETRY_MAX", 2),
 			baseDelayMs: parsePositiveInt(env, "PI_RETRY_BASE_MS", 2000),
@@ -37,6 +39,22 @@ function parsePositiveInt(env, name, fallback) {
 		if (fallback !== undefined) return fallback;
 		throw configError(`missing required env: ${name}`);
 	}
+	const n = Number.parseInt(raw, 10);
+	if (!Number.isInteger(n) || n < 1 || String(n) !== String(raw).trim()) {
+		throw configError(`invalid ${name}: ${JSON.stringify(raw)} (want a positive integer)`);
+	}
+	return n;
+}
+
+/**
+ * An OPTIONAL positive-int knob: an absent or empty var is `null` (the cap is disabled), not an
+ * error. A present value is validated identically to parsePositiveInt -- a malformed cap is a
+ * config error (exit 2), never a silently-ignored knob. This is the "unset means off" shape
+ * parsePositiveInt cannot express, used by the optional PI_MAX_TOKENS budget.
+ */
+function parseOptionalPositiveInt(env, name) {
+	const raw = env[name];
+	if (raw === undefined || raw === "") return null;
 	const n = Number.parseInt(raw, 10);
 	if (!Number.isInteger(n) || n < 1 || String(n) !== String(raw).trim()) {
 		throw configError(`invalid ${name}: ${JSON.stringify(raw)} (want a positive integer)`);

--- a/image/runner/src/outcome.mjs
+++ b/image/runner/src/outcome.mjs
@@ -72,14 +72,22 @@ export function captureTerminal(previous, event) {
 }
 
 /**
- * The final exit decision. Budget-abort is checked FIRST and wins over stopReason, so a future
+ * The final exit decision. A budget-abort is checked FIRST and wins over stopReason, so a future
  * upstream change to how an abort surfaces as a stopReason cannot silently turn a blown budget
  * into exit 0. This is the composition the runner's own comment calls load-bearing; it lives
  * here so it can be tested without a container.
+ *
+ * Both budgets abort via session.abort(), which surfaces as `stopReason: "aborted"`. Intercepting
+ * them here is what distinguishes an intentional cap (policy, not retried) from the generic abort,
+ * and names WHICH cap fired. The turn budget is checked before the token budget only for a stable
+ * order; in practice one abort ends the run, so at most one flag is set.
  */
-export function decideExit({ budgetAborted, budgetTurns, terminal }) {
+export function decideExit({ budgetAborted, budgetTurns, tokenAborted, terminal }) {
 	if (budgetAborted) {
 		return { code: EXIT_POLICY, reason: "turn_budget", turns: budgetTurns };
+	}
+	if (tokenAborted) {
+		return { code: EXIT_POLICY, reason: "token_budget" };
 	}
 	return classifyStopReason(terminal);
 }

--- a/image/runner/src/token-budget.mjs
+++ b/image/runner/src/token-budget.mjs
@@ -1,0 +1,59 @@
+/**
+ * Token accounting + optional per-job token budget (issue #25, unblocked by OQ-010).
+ *
+ * pi 0.80.7 emits per-turn token usage on subscribe() as `event.message.usage` -- a required
+ * `Usage` on the assistant AgentMessage. This attaches a synchronous listener that ACCUMULATES
+ * that usage across turns. The meter is always on, so a job's token and cost totals land in run
+ * history whether or not a cap is set; when a cap is set, it aborts the session once the running
+ * total exceeds it.
+ *
+ * A token cap is structurally LAGGING (OQ-010): usage is known only AFTER a turn runs, so the
+ * abort fires only once the breaching turn's tokens are already spent. It is a single-job runaway
+ * backstop -- finer-grained than maxTurns because turns vary wildly in token cost -- NOT a
+ * before-the-spend cap. maxTurns (REQ-RUNNER-TURN-BUDGET) stays the one proactive per-job lever.
+ *
+ * Two properties are inherited from attachTurnBudget and are not stylistic:
+ *
+ * 1. The listener is SYNCHRONOUS. `_emit` is an unawaited `for (const l of listeners) l(event)`,
+ *    so an async listener is fire-and-forget and the next turn can start before the cap check
+ *    runs -- overshooting further than the lag already forces.
+ *
+ * 2. `void session.abort()`. abort() returns a promise but flips the AbortController
+ *    synchronously first, so the signal is set the instant we call it. Do not await inside the
+ *    listener.
+ *
+ * Usage is accumulated on turn_end ONLY. Each turn is a distinct billed API call, so summing the
+ * per-turn usage yields the job's total billed tokens and cost. `agent_end` carries `messages[]`,
+ * a terminal snapshot of those same messages -- accumulating it too would double-count.
+ */
+export function attachTokenBudget(session, maxTokens, { onAbort } = {}) {
+	if (maxTokens !== null && maxTokens !== undefined && (!Number.isInteger(maxTokens) || maxTokens < 1)) {
+		throw new Error(`invalid PI_MAX_TOKENS: ${maxTokens}`);
+	}
+	const cap = maxTokens ?? null;
+
+	const state = { input: 0, output: 0, total: 0, cost: 0, aborted: false };
+
+	const unsubscribe = session.subscribe((event) => {
+		if (event.type !== "turn_end") return;
+		const message = event.message;
+		if (message?.role !== "assistant" || !message.usage) return;
+		const usage = message.usage;
+
+		state.input += usage.input ?? 0;
+		state.output += usage.output ?? 0;
+		// totalTokens is the BILLED total (input + output + cache read/write), so state.total >= input +
+		// output -- deliberately, not a bug. The cap and the daily counter must key on billed tokens, so do
+		// not "fix" this to input+output. cost is a per-turn object; sum its `.total` (USD).
+		state.total += usage.totalTokens ?? 0;
+		state.cost += usage.cost?.total ?? 0;
+
+		if (cap !== null && state.total > cap && !state.aborted) {
+			state.aborted = true;
+			onAbort?.(state.total);
+			void session.abort();
+		}
+	});
+
+	return { state, unsubscribe };
+}

--- a/image/runner/test/config.test.mjs
+++ b/image/runner/test/config.test.mjs
@@ -10,8 +10,26 @@ test("parses a valid environment", () => {
 	assert.equal(cfg.provider, "anthropic");
 	assert.equal(cfg.model, "claude-x");
 	assert.equal(cfg.maxTurns, 20);
+	assert.equal(cfg.maxTokens, null); // optional, unset -> cap disabled
 	assert.equal(cfg.retry.maxRetries, 2); // default
 	assert.equal(cfg.retry.baseDelayMs, 2000); // default
+});
+
+test("PI_MAX_TOKENS is optional: unset is null, a valid value parses", () => {
+	assert.equal(parseRunnerEnv({ ...base }).maxTokens, null);
+	assert.equal(parseRunnerEnv({ ...base, PI_MAX_TOKENS: "" }).maxTokens, null);
+	assert.equal(parseRunnerEnv({ ...base, PI_MAX_TOKENS: "500000" }).maxTokens, 500000);
+});
+
+test("a malformed PI_MAX_TOKENS is a config error, not a silently-ignored cap", () => {
+	for (const bad of ["0", "-1", "1.5", "abc", "12x", " "]) {
+		try {
+			parseRunnerEnv({ ...base, PI_MAX_TOKENS: bad });
+			assert.fail(`expected throw for PI_MAX_TOKENS=${JSON.stringify(bad)}`);
+		} catch (error) {
+			assert.equal(error.piDispatchExit, EXIT_POLICY, `PI_MAX_TOKENS=${JSON.stringify(bad)}`);
+		}
+	}
 });
 
 // Every deterministic misconfiguration must be a TAGGED config error (exit 2), so the queue

--- a/image/runner/test/outcome.test.mjs
+++ b/image/runner/test/outcome.test.mjs
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import {
 	classifyStopReason,
 	classifyThrow,
+	decideExit,
 	EXIT_COMPLETED,
 	EXIT_INFRA,
 	EXIT_POLICY,
@@ -69,4 +70,24 @@ test("an unknown stopReason is infra, not assumed benign", () => {
 
 test("no terminal message is infra -- absence of evidence is not success", () => {
 	assert.equal(classifyStopReason(undefined).code, EXIT_INFRA);
+});
+
+// decideExit: a cap-abort surfaces as stopReason "aborted"; intercepting it names WHICH cap fired
+// and keeps it a policy outcome (exit 2, not retried) rather than the generic "aborted".
+test("token-budget abort exits 2 with reason token_budget", () => {
+	const outcome = decideExit({ budgetAborted: false, tokenAborted: true, terminal: { stopReason: "aborted" } });
+	assert.equal(outcome.code, EXIT_POLICY);
+	assert.equal(outcome.reason, "token_budget");
+});
+
+test("turn-budget abort wins over token-budget for a stable reason", () => {
+	const outcome = decideExit({ budgetAborted: true, budgetTurns: 31, tokenAborted: true, terminal: {} });
+	assert.equal(outcome.reason, "turn_budget");
+	assert.equal(outcome.turns, 31);
+});
+
+test("no abort defers to the stopReason classification", () => {
+	const outcome = decideExit({ budgetAborted: false, tokenAborted: false, terminal: { stopReason: "stop" } });
+	assert.equal(outcome.code, EXIT_COMPLETED);
+	assert.equal(outcome.reason, "stop");
 });

--- a/image/runner/test/pinned-api.test.mjs
+++ b/image/runner/test/pinned-api.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 
@@ -70,6 +71,32 @@ test("the resource-loader options the instruction model depends on still exist",
 	for (const method of ["reload", "getAppendSystemPrompt", "getAgentsFiles", "getSkills"]) {
 		assert.ok(loader.includes(method), `DefaultResourceLoader.${method} missing at the pin`);
 	}
+});
+
+test("the pinned pi-ai still exposes the Usage shape the runner's token meter reads", { skip }, () => {
+  // REQ-UPSTREAM-CONTRACT-TESTS for issue #25 / OQ-010. The runner accumulates per-turn
+  // `event.message.usage` (a required `Usage` on the assistant AgentMessage). `Usage` is a TYPE-only
+  // export -- no runtime value on `mod` -- so a `typeof mod.Usage` check is the wrong tool. Assert the
+  // pinned .d.ts still declares the field and its shape, so a pin bump that drops or reshapes usage fails
+  // HERE rather than turning every job's token accounting silently to zero. Resolve pi-ai from
+  // pi-coding-agent's own context so this checks the exact copy the runner uses.
+  // pi-ai is ESM-only (its `exports` has no `require` condition and hides ./package.json), so resolve its
+  // main entry (./dist/index.js) via import.meta.resolve and read the sibling types.d.ts. The lockfile pins
+  // pi-ai to the same 0.80.7 pi-coding-agent depends on, so the hoisted copy is the pinned artifact.
+  const typesPath = join(dirname(fileURLToPath(import.meta.resolve("@earendil-works/pi-ai"))), "types.d.ts");
+  const src = readFileSync(typesPath, "utf8");
+
+  assert.match(src, /\n\s*usage:\s*Usage;/, "AssistantMessage.usage: Usage must remain a REQUIRED field (not optional, not renamed)");
+
+  const usage = src.match(/export interface Usage \{([\s\S]*?)\n\}/);
+  assert.ok(usage, "the Usage interface must exist in the pinned pi-ai");
+  for (const field of ["input", "output", "totalTokens", "cost"]) {
+    assert.match(usage[1], new RegExp(`\\b${field}\\b`), `Usage.${field} must remain declared -- the token meter sums it`);
+  }
+  // The meter dereferences usage.cost.total, so `cost` must stay an OBJECT declaring `total`. A bare-name
+  // check on `cost` would keep passing if a pin bump flattened it to `cost: number`, while the meter
+  // silently recorded $0 for every job -- the exact silent-zero this contract test exists to prevent.
+  assert.match(usage[1], /cost:\s*\{[\s\S]*?\btotal\b/, "Usage.cost must remain an object declaring `total` -- the meter reads usage.cost.total");
 });
 
 test("the runner imports nothing the pinned package does not export", { skip }, () => {

--- a/image/runner/test/token-budget.test.mjs
+++ b/image/runner/test/token-budget.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { attachTokenBudget } from "../src/token-budget.mjs";
+
+/**
+ * A stand-in for AgentSession reproducing the two properties the budget depends on: `_emit` is a
+ * synchronous unawaited loop, and abort() flips its signal synchronously before any await. Mirrors
+ * turn-budget.test.mjs's fake so the two budgets are verified against the same session contract.
+ */
+function fakeSession() {
+	const listeners = [];
+	const session = {
+		aborted: false,
+		abortCalls: 0,
+		subscribe(listener) {
+			listeners.push(listener);
+			return () => listeners.splice(listeners.indexOf(listener), 1);
+		},
+		async abort() {
+			session.abortCalls += 1;
+			session.aborted = true; // sync, before any await -- as pi does
+			await Promise.resolve();
+		},
+		emit(event) {
+			for (const l of listeners) l(event); // sync, unawaited -- as pi does
+		},
+	};
+	return session;
+}
+
+/** A turn_end event carrying an assistant message with the given usage, as pi 0.80.7 emits. */
+function turnEnd(usage) {
+	return { type: "turn_end", message: { role: "assistant", usage } };
+}
+
+const usage = ({ input = 0, output = 0, total = input + output, cost = 0 }) => ({
+	input,
+	output,
+	totalTokens: total,
+	cost: { total: cost },
+});
+
+test("accumulates usage across turns (meter is always on, no cap)", () => {
+	const session = fakeSession();
+	const budget = attachTokenBudget(session, null);
+
+	session.emit(turnEnd(usage({ input: 100, output: 20, cost: 0.01 })));
+	session.emit(turnEnd(usage({ input: 200, output: 30, cost: 0.02 })));
+
+	assert.equal(budget.state.input, 300);
+	assert.equal(budget.state.output, 50);
+	assert.equal(budget.state.total, 350);
+	assert.equal(Math.round(budget.state.cost * 100) / 100, 0.03);
+	assert.equal(budget.state.aborted, false, "no cap means never abort");
+	assert.equal(session.aborted, false);
+});
+
+test("aborts once the cumulative total exceeds the cap", () => {
+	const session = fakeSession();
+	const budget = attachTokenBudget(session, 1000);
+
+	session.emit(turnEnd(usage({ input: 400, output: 100 }))); // 500 total
+	assert.equal(session.aborted, false, "must not abort at or below the cap");
+
+	session.emit(turnEnd(usage({ input: 400, output: 200 }))); // 500 + 600 = 1100 cumulative -> over
+	assert.equal(session.aborted, true);
+	assert.equal(budget.state.aborted, true);
+	assert.equal(budget.state.total, 1100);
+});
+
+test("abort fires exactly once even if more usage arrives", () => {
+	const session = fakeSession();
+	attachTokenBudget(session, 100);
+	for (let i = 0; i < 5; i++) session.emit(turnEnd(usage({ input: 100, output: 100 })));
+	assert.equal(session.abortCalls, 1);
+});
+
+test("the signal is set synchronously inside the listener", () => {
+	const session = fakeSession();
+	attachTokenBudget(session, 10);
+	session.emit(turnEnd(usage({ input: 20, output: 0 })));
+	assert.equal(session.aborted, true, "abort must land before emit() returns");
+});
+
+test("accumulates on turn_end only -- agent_end must not double-count", () => {
+	const session = fakeSession();
+	const budget = attachTokenBudget(session, null);
+	const message = { role: "assistant", usage: usage({ input: 100, output: 50 }) };
+	session.emit({ type: "turn_end", message });
+	// agent_end carries the same messages[] as a terminal snapshot; accumulating it would double.
+	session.emit({ type: "agent_end", messages: [message] });
+	session.emit({ type: "message_update", message });
+	assert.equal(budget.state.total, 150);
+});
+
+test("ignores turn_end without assistant usage", () => {
+	const session = fakeSession();
+	const budget = attachTokenBudget(session, null);
+	session.emit({ type: "turn_end", message: { role: "tool", usage: usage({ input: 999 }) } });
+	session.emit({ type: "turn_end", message: { role: "assistant" } }); // no usage
+	session.emit({ type: "turn_end" }); // no message
+	assert.equal(budget.state.total, 0);
+	assert.equal(budget.state.input, 0);
+});
+
+test("a null or absent cap is a pure meter, not an error", () => {
+	assert.doesNotThrow(() => attachTokenBudget(fakeSession(), null));
+	assert.doesNotThrow(() => attachTokenBudget(fakeSession(), undefined));
+});
+
+test("rejects a nonsensical cap rather than running unbounded", () => {
+	for (const bad of [0, -1, 1.5, Number.NaN]) {
+		assert.throws(() => attachTokenBudget(fakeSession(), bad), /invalid PI_MAX_TOKENS/);
+	}
+});

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -196,7 +196,7 @@ Evidence convention as in `constitution.md`.
   |---|---|---|
   | `0` | Agent completed — **including** concluding "I cannot fix this" | Success. Never retried |
   | `1` | Infrastructure failure (container died, network, provider 5xx/429) | Retryable |
-  | `2` | Budget or policy refusal (cap exhausted, turn budget hit) | Not retried |
+  | `2` | Budget or policy refusal (cap exhausted, turn budget hit, token budget hit) | Not retried |
 
   **A worker-initiated termination overrides the numeric code.** When the worker itself stops the
   container — `docker stop` on the 30-minute timeout (`cancelJob`) or on graceful shutdown, delivering
@@ -220,11 +220,18 @@ Evidence convention as in `constitution.md`.
   | Extension error in `before_agent_start` | **throws** (preflight) | `1` |
   | Provider 429 / 5xx / network death | `stopReason: "error"` | `1` — infra, retryable |
   | Our turn budget or timeout aborts | `stopReason: "aborted"` | `2` |
+  | Our per-job **token budget** aborts | `stopReason: "aborted"` | `2` — `decideExit` intercepts it as `reason: "token_budget"` BEFORE the generic `"aborted"`, exactly as the turn budget is intercepted (`REQ-TOKEN-ACCOUNTING-AND-CAPS`) |
   | Normal completion | `stopReason: "stop"` \| `"toolUse"` | `0` |
   | **Output truncated at the token limit** | `stopReason: "length"` | `0`, **but log it** — it is a completed run, not a silent failure, and must not be mistaken for either |
 
   `StopReason` is exactly `"stop" | "length" | "toolUse" | "error" | "aborted"` — enumerate all five. A
   default-to-`0` branch would map `"length"` to success without anyone noticing the agent was cut off.
+
+  The runner's `exit` log line carries two **read-only telemetry** fields beside the outcome — `turns` and
+  `tokens` (`{ input, output, total, cost }`, the per-job usage totals). Both are recovered host-side
+  (`parseExitTurns` / `parseExitTokens`) into the run record and **must not feed exit-code or retry
+  classification** — that is this protocol's job. The catch-path exit line (a preflight throw, no session
+  ran) omits both, so each parses to `null`.
 - **Why**: This exit code **is** the mechanism `CONST-RETRY-INFRA-ONLY` is implemented by. The worker
   has no other channel to distinguish "the agent ran and said no" from "the container died" — collapse
   them and you either burn money blind-retrying determinate outcomes, or you silently swallow real infra
@@ -359,7 +366,10 @@ Evidence convention as in `constitution.md`.
     job dies of something unrelated to its actual work.
   - Env **passed by the worker**: the configured provider's key variable(s), derived — not hardcoded
     (see below); `GITHUB_TOKEN` (scoped, short-lived — GitHub-backed jobs only); `PI_JOB_ID`; `PI_PROVIDER`;
-    `PI_MODEL`; `PI_MAX_TURNS`; `PI_CODING_AGENT_DIR` (if not `$HOME/.pi/agent`)
+    `PI_MODEL`; `PI_MAX_TURNS`; `PI_MAX_TOKENS` (the per-job token budget — forwarded ONLY when set, omitted
+    otherwise so the runner meters usage without a cap; `REQ-TOKEN-ACCOUNTING-AND-CAPS`); `PI_CODING_AGENT_DIR`
+    (if not `$HOME/.pi/agent`). Note `PI_DAILY_TOKEN_CAP` is **worker-only and is NOT forwarded** — the daily
+    token counter is enforced host-side, and the container stays queue/budget-blind (`no-broad-env-into-container`).
   - Env **baked into the image**, because they are facts about the image and not choices a job makes:
     `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`, `PLAYWRIGHT_MCP_BROWSER=chromium`,
     `PLAYWRIGHT_MCP_SANDBOX=false`. **`PLAYWRIGHT_MCP_BROWSER` is load-bearing**: `playwright-cli`
@@ -524,6 +534,7 @@ Evidence convention as in `constitution.md`.
     "reason":    "<fixed enum: worker-abort|over-budget|unprotected-branch|runner-policy|container-never-started|settings-overlay-invalid|...>" | null,
     "exitCode":  <int> | null,
     "turns":     <int> | null,
+    "tokens":    { "input": <int>, "output": <int>, "total": <int>, "cost": <number> } | null,  // per-job usage totals; null when the container died before the exit line
     "budgetReserved": <bool> | null,
     "attempt":   <int>,
     "parentJobId": "<job id: same id-space as jobId>" | null,
@@ -557,8 +568,13 @@ Evidence convention as in `constitution.md`.
   the collector returns a running `refused` count, and the record stores it verbatim (`0` = none), so the runs
   view can surface "2 refused" rather than a bare yes/no. The `reason` enum is **untouched**: a chain refusal is
   **pre-enqueue of the child**, so there is no child record and no new terminal reason — `chainRefused` is
-  a separate count on the **parent**, never an enum value.
-- **Traces to**: `REQ-DURABLE-RUN-HISTORY`, `REQ-LOCAL-JOB-VISIBILITY`, `INT-RUNNER-EXIT-CODE-PROTOCOL`
+  a separate count on the **parent**, never an enum value. The `tokens` field is **additive and nullable**
+  in exactly the same way — an explicit no-spread literal `{ input, output, total, cost }` of the runner's
+  per-job usage totals (`REQ-TOKEN-ACCOUNTING-AND-CAPS`), or `null` when the container died before emitting
+  the runner `exit` line. It is PII-free by construction: integer token counts and a numeric cost only, no
+  payload text. It is read-only telemetry recovered from the exit line (`parseExitTokens`) exactly as
+  `turns` is, and like `turns` it never feeds exit-code or retry classification (`INT-RUNNER-EXIT-CODE-PROTOCOL`).
+- **Traces to**: `REQ-DURABLE-RUN-HISTORY`, `REQ-LOCAL-JOB-VISIBILITY`, `INT-RUNNER-EXIT-CODE-PROTOCOL`, `REQ-TOKEN-ACCOUNTING-AND-CAPS`
 - **Acceptance**: Given a job reaching a terminal state, exactly one `.json` keyed by its sanitized job
   id exists; its `outcome` matches the queue outcome (`completed` / `policy` / `failed`); no field carries
   issue or comment body text (`target` is `repo#issue` / `local:<basename>` only); `turns` is `null` when
@@ -622,6 +638,8 @@ Evidence convention as in `constitution.md`.
     "dailyCap":    <optional, int >= 1>,             // jobs admitted per day (mandatory window; env default 25)
     "weeklyCap":   <optional, int >= 1>,             // jobs admitted per ISO week; unset -> weekly window disabled
     "monthlyCap":  <optional, int >= 1>,             // jobs admitted per calendar month; unset -> monthly window disabled
+    "maxTokens":     <optional, int >= 1>,           // per-job token budget (in-run abort); unset -> per-job token budget disabled
+    "dailyTokenCap": <optional, int >= 1>,           // daily token cap (check-AFTER; refuses next job); unset -> daily token counter disabled
     "concurrency": <optional, int 1-10>,             // worker slot count
     "softHoldPct": <optional, int 1-99>              // soft-hold band as a % of each active cap; unset -> band disabled
   }
@@ -641,10 +659,16 @@ Evidence convention as in `constitution.md`.
   `dailyCap`/`weeklyCap`/`monthlyCap`/`softHoldPct` are resolved at the existing pre-container cap check, so
   the overlay changes *which values* the caps and band take, never *when* they are checked
   (`CONST-BUDGET-BEFORE-TOKENS`, `REQ-SPEND-CAPS-MULTI-WINDOW`). An unset `weeklyCap`/`monthlyCap` disables
-  that window; an unset `softHoldPct` disables the band. See `DES-RUNTIME-SETTINGS-FILE-OVERLAY` for why a
-  file, why atomic, and why a present-but-invalid file fails closed.
+  that window; an unset `softHoldPct` disables the band. The two token knobs (`REQ-TOKEN-ACCOUNTING-AND-CAPS`)
+  resolve the same way but differ in *where* they act: `maxTokens` is forwarded into the container
+  (`PI_MAX_TOKENS`, `INT-CONTAINER-RUNTIME-CONTRACT`) and enforced in-run by the runner; `dailyTokenCap` is
+  worker-only and, unlike the job-count caps, is enforced **check-AFTER** — a read of prior recorded spend
+  before the container plus an `INCRBY` of the job's tokens after it — because token cost is knowable only
+  post-run. This is the one overlay knob whose enforcement is not at the same pre-container check point as
+  the rest; `CONST-BUDGET-BEFORE-TOKENS` (job count, check-before) is unchanged. See
+  `DES-RUNTIME-SETTINGS-FILE-OVERLAY` for why a file, why atomic, and why a present-but-invalid file fails closed.
 - **Traces to**: `DES-RUNTIME-SETTINGS-FILE-OVERLAY`, `DES-ADMIN-VIA-PI-EXTENSION`,
-  `CONST-BUDGET-BEFORE-TOKENS`, `CONST-RETRY-INFRA-ONLY`, `REQ-SPEND-CAPS-MULTI-WINDOW`
+  `CONST-BUDGET-BEFORE-TOKENS`, `CONST-RETRY-INFRA-ONLY`, `REQ-SPEND-CAPS-MULTI-WINDOW`, `REQ-TOKEN-ACCOUNTING-AND-CAPS`
 - **Acceptance**: Given a present-but-invalid file, when a job starts, then the processor returns a policy
   refusal `settings-overlay-invalid` before `reserveBudget` — no budget slot consumed, no container
   started, not retried; given a job whose data omits `model`/`provider`/`maxTurns`, when it starts, then
@@ -663,6 +687,7 @@ Evidence convention as in `constitution.md`.
 | 2026-07-21 | Extended INT-CONFIG-OVERLAY-CONTRACT's write protocol: an invalid existing file is repaired by the next write, which rebuilds from scratch with the sanitized candidate and surfaces a loud key-only notice — the fail-closed guarantee is stated to live only on the worker's job-start read. |
 | 2026-07-22 | Added INT-OUTBOX-CONTRACT (container→worker `/outbox` request files: `request-<n>.json` byte-capped at 4 KiB, `folder`-ignored same-folder-only, validation order count→size→regular-file→parse→charset→host-computed depth→`ai-trigger` gate→enqueue, retry-idempotent child ids, completed-only collection, no mount for github parents, `task` as DATA never in the run record). Extended INT-CONTAINER-JOB-INPUTS and INT-CONTAINER-RUNTIME-CONTRACT with the writable `/outbox` mount (local jobs only; absent for github). Appended `parentJobId`/`chainDepth`/`chainRefused` (additive, nullable, no-spread) to INT-RUN-HISTORY-FILE-CONTRACT's record — the `reason` enum untouched, since a chain refusal is pre-enqueue of the child. |
 | 2026-07-21 | Added INT-CONFIG-OVERLAY-CONTRACT (admin extension → worker `settings.json` overlay: optional keys with bounds, atomic tmp+rename write, per-job-start read, fail-closed `settings-overlay-invalid` on a present-but-invalid file). Reworded INT-RUN-HISTORY-FILE-CONTRACT's boundary from worker→panel to worker→admin extension (repointing the read-model rationale to `DES-ADMIN-VIA-PI-EXTENSION`) and added `settings-overlay-invalid` to its `reason` enum. Clarified in INT-SCHEDULES-FILE-CONTRACT that `provider`/`model`/`maxTurns` are pure passthrough — absent from an entry means absent from job data, resolved against the overlay/env at job start. De-numeralized the intro (contract count no longer stated). |
+| 2026-07-22 | Token accounting (issue #25 / `REQ-TOKEN-ACCOUNTING-AND-CAPS`): INT-RUN-HISTORY-FILE-CONTRACT record gains an additive, nullable `tokens` `{ input, output, total, cost }` field (recovered from the exit line by `parseExitTokens`, read-only telemetry like `turns`); INT-RUNNER-EXIT-CODE-PROTOCOL gains the `token_budget` policy-`2` row and documents `tokens` on the exit line; INT-CONFIG-OVERLAY-CONTRACT gains the `maxTokens`/`dailyTokenCap` overlay keys and records that the daily token cap is the one knob enforced check-AFTER; INT-CONTAINER-RUNTIME-CONTRACT gains `PI_MAX_TOKENS` (forwarded only when set) and records that `PI_DAILY_TOKEN_CAP` is worker-only and never forwarded. |
 | 2026-07-21 | Added INT-RUN-HISTORY-FILE-CONTRACT (worker→panel run-history read-model files). |
 | 2026-07-17 | Added INT-SCHEDULES-FILE-CONTRACT, documenting the implemented `schedules.json` host-file shape (`PI_SCHEDULES_FILE`): `local`-only, `:`-free unique `id`, `task` as DATA, and load-time rejection of malformed/`github`/duplicate/missing-folder entries. |
 | 2026-07-15 | Initial. Extracted from `DESIGN.md` v0.1 §5.1, §5.3, §5.4, §5.5. `INT-SDK-SESSION-OPTIONS` is **new** — the source doc left the SDK option set unverified (its §10) and was wrong about the print-mode flag shape and the mode union. `PLAYWRIGHT_BROWSERS_PATH` added to the runtime contract: the source doc's Dockerfile was broken as written for non-root execution. The source doc's code sketches are deliberately **not** carried over — the real Dockerfile and handler are the truth, and a spec that mirrors them drifts on the first commit. |

--- a/specs/open-questions.md
+++ b/specs/open-questions.md
@@ -195,10 +195,12 @@ Status values: `OPEN` (unanswered) · `WATCH` (not a question — a known-incomi
 - **What closed it**: spike #21, verified against the pinned npm artifact (per the evidence convention in
   `constitution.md` — a sha is not a version; cf. `OQ-005`). Recorded here so the answer is durable and
   greppable rather than dying with the closed issue.
-- **Unblocks**: the follow-up (#25) for per-job token budget + daily token counter + run-history token
-  fields (deferred deliberately — this was an investigation-only spike). The capture hook already exists:
-  the runner reads `event.message` on `turn_end` today (`captureTerminal`,
-  `image/runner/src/outcome.mjs:68-72`), it simply never touches `.usage`.
+- **Unblocks**: the follow-up (#25), now **landed** as `REQ-TOKEN-ACCOUNTING-AND-CAPS` — per-job token/cost
+  accounting in the run record + admin views, an optional in-run per-job token budget, and an optional daily
+  token counter (check-after). The capture hook this OQ pointed at (`captureTerminal`,
+  `image/runner/src/outcome.mjs`, reading `event.message` on `turn_end`) is now joined by a synchronous
+  `attachTokenBudget` meter that sums `event.message.usage`; the lagging-control constraint recorded above is
+  what shapes that REQ's check-after daily cap.
 - **Evidence (pinned artifact — authoritative)**: `npm @earendil-works/pi-coding-agent@0.80.7 →
   dist/core/agent-session.d.ts:255` (`subscribe(listener)`), `:84` (`AgentSessionEventListener`), `:40-82`
   (`AgentSessionEvent` is the `AgentEvent` union plus session-only events) · `npm
@@ -251,3 +253,4 @@ adversarial passes did.
 | 2026-07-21 | Added OQ-008 (runtime trigger editing — cron toggle, label→flow — deferred; the admin extension ships triggers display-only). |
 | 2026-07-22 | Added OQ-009 (chaining from a GitHub-job parent, and cross-folder chaining, deferred; this slice ships same-folder, local-parent-only chaining). |
 | 2026-07-22 | Added OQ-010 — spike #21 closed **YES**: pinned pi `0.80.7` emits per-turn token usage on the `subscribe()` stream (nested `event.message.usage`), verified against the npm artifact. Records the lagging-control constraint and unblocks a follow-up for the token-cap chain. |
+| 2026-07-22 | OQ-010 **Unblocks** retargeted: the #25 follow-up landed as `REQ-TOKEN-ACCOUNTING-AND-CAPS` (per-job token/cost accounting + optional in-run per-job token budget + optional check-after daily token cap). The recorded lagging-control constraint is what shapes that REQ's asymmetry with `CONST-BUDGET-BEFORE-TOKENS`. |

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -364,8 +364,8 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
 ## REQ-RUNTIME-SETTINGS-PICKUP
 
 - **Statement**: The worker shall honour overlay changes without a restart: `model`, `provider`,
-  `maxTurns`, `dailyCap`, `weeklyCap`, `monthlyCap`, and `softHoldPct` resolve per job at job start, and
-  `concurrency` is applied at the worker's next job pickup.
+  `maxTurns`, `dailyCap`, `weeklyCap`, `monthlyCap`, `maxTokens`, `dailyTokenCap`, and `softHoldPct`
+  resolve per job at job start, and `concurrency` is applied at the worker's next job pickup.
 - **Why**: A settings edit at 11pm must not require a service restart. The worker re-reads the overlay in
   its processor at each job start — no watcher and no reload signal (see `DES-RUNTIME-SETTINGS-FILE-OVERLAY`).
 - **Traces to**: `DES-RUNTIME-SETTINGS-FILE-OVERLAY`, `INT-CONFIG-OVERLAY-CONTRACT`,
@@ -393,8 +393,8 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
   it pauses new starts (in-flight containers finish, since the reservation is pre-container) and turns the
   panel meter amber, so an operator is warned and can raise a cap or intervene rather than discovering the
   ceiling only when jobs start refusing. These remain **job-count** caps (container starts), not tokens —
-  the thing knowable *before* a run — so `CONST-BUDGET-BEFORE-TOKENS` is unchanged; token caps are a
-  separate, structurally lagging problem tracked at `OQ-010`.
+  the thing knowable *before* a run — so `CONST-BUDGET-BEFORE-TOKENS` is unchanged; the token controls are a
+  separate, structurally lagging problem addressed by `REQ-TOKEN-ACCOUNTING-AND-CAPS` (`OQ-010`).
 - **Traces to**: `CONST-BUDGET-BEFORE-TOKENS`, `DES-RUNTIME-SETTINGS-FILE-OVERLAY`,
   `INT-CONFIG-OVERLAY-CONTRACT`, `REQ-RUNTIME-SETTINGS-PICKUP`
 - **Acceptance**: Given any active window over its cap, when a job starts, then it is refused `over-budget`
@@ -404,6 +404,42 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
   (and no `PI_WEEKLY_CAP`), when a job starts, then the weekly window is neither counted nor evaluated; given
   a `softHoldPct` set live in the overlay, when the next job starts, then the band takes effect with no
   restart; given a refused reservation, when the window rolls over, then its counter is reclaimed by TTL.
+
+## REQ-TOKEN-ACCOUNTING-AND-CAPS
+
+- **Statement**: The harness shall (a) **account** every job's token usage — the runner accumulates the
+  per-turn `usage` pi emits on `subscribe()` (`OQ-010`) into per-job totals `{ input, output, total, cost }`,
+  emits them on the `exit` line, and the worker persists them in the run record and surfaces them in the admin
+  run views; (b) provide an **optional per-job token budget** (`maxTokens` / `PI_MAX_TOKENS`) that the runner
+  enforces in-run by aborting the session once cumulative tokens exceed it, exiting policy (`2`) with
+  `reason: "token_budget"`; and (c) provide an **optional daily token cap** (`dailyTokenCap` /
+  `PI_DAILY_TOKEN_CAP`) that refuses a new job pre-container once the day's recorded spend has reached it.
+  Both caps are unset-means-disabled and resolve `job.data > overlay > env` per job; accounting is always on.
+- **Why**: pi bounds neither tokens nor money; before this, spend was visible only on the provider bill.
+  Accounting is the high-value piece — per-job token/cost in the run history is what lets an operator tune the
+  **proactive** levers (`maxTurns`, the job-count caps). The two token caps are **backstops**, and both are
+  structurally **lagging** (`OQ-010`): a token's cost is knowable only *after* its turn runs. So `maxTokens`
+  can only abort *after* the breaching turn is already paid for (finer-grained than `maxTurns`, since turns
+  vary wildly in token cost), and `dailyTokenCap` can only stop the *next* job. This forces a deliberate
+  **asymmetry** with `CONST-BUDGET-BEFORE-TOKENS`: the job-count cap is check-**before** (it can, a count is
+  knowable pre-run); the daily token cap is check-**after** — a read-only check of prior recorded spend before
+  the container (consuming no job-count slot) plus an `INCRBY` of the job's tokens after it. The constitution
+  governs only the *job-count* cap's ordering and is unchanged; this is a differently-shaped control, not a
+  relaxation of it. Under concurrency the daily counter is best-effort — N in-flight jobs each pass the check
+  before any records, so the day can overshoot by up to N per-job budgets — which is acceptable for a lagging
+  backstop and is not the job-count cap's atomic guarantee.
+- **Traces to**: `OQ-010`, `REQ-RUNNER-TURN-BUDGET`, `REQ-UPSTREAM-CONTRACT-TESTS`,
+  `CONST-BUDGET-BEFORE-TOKENS`, `INT-RUNNER-EXIT-CODE-PROTOCOL`, `INT-RUN-HISTORY-FILE-CONTRACT`,
+  `INT-CONFIG-OVERLAY-CONTRACT`, `INT-CONTAINER-RUNTIME-CONTRACT`, `REQ-SPEND-CAPS-MULTI-WINDOW`
+- **Acceptance**: Given any completed job, when it ends, then its run record carries a `tokens`
+  `{ input, output, total, cost }` object and the admin run views show its total and cost; given `maxTokens`
+  set and a job whose cumulative usage exceeds it, when the budget is hit, then the runner aborts, exits `2`
+  with `reason: "token_budget"`, and the queue does not retry it; given `dailyTokenCap` set and a day whose
+  recorded spend has reached it, when the next job starts, then it is refused pre-container with
+  `daily-token-cap`, spends zero provider tokens, and consumes no job-count slot; given a container that ran
+  and spent, when it ends on any outcome, then its tokens are added to the daily counter; given both caps
+  unset, then usage is still accounted and no job is ever refused or aborted for tokens; given a pin bump that
+  drops or reshapes `Usage`, then `REQ-UPSTREAM-CONTRACT-TESTS` fails the build, not a live job.
 
 ---
 
@@ -434,3 +470,4 @@ wait-list working as designed, not a failure — see `README.md`.
 | 2026-07-22 | Added REQ-SPEND-CAPS-MULTI-WINDOW: the pre-container budget check now spans a mandatory daily cap plus optional weekly/monthly ceilings and a soft-hold percentage band (enforcing — refuses new starts in-band with a distinct `soft-hold` reason). Extended REQ-RUNTIME-SETTINGS-PICKUP's key list to include `weeklyCap`/`monthlyCap`/`softHoldPct`. `CONST-BUDGET-BEFORE-TOKENS` unchanged (still job-count, still check-before-start). |
 | 2026-07-22 | Amended REQ-ADMIN-VIA-PI-EXTENSION to the three-tool framing — `dispatch_run` is a third, spend-knobless model-callable enqueue gated by `DES-AI-TRIGGER-FLOW-GATE`; the `Statement` and `Why` both drop the superseded reads-plus-pause/resume-only categorical, keeping the cap-integrity rationale on the new premise that no model tool carries a spend knob, and the `Acceptance` gains a `dispatch_run` clause. Added REQ-AI-TRIGGERED-RUNS (the two AI-triggered producers — the `dispatch_run` tool/command and the worker's `/outbox` collector — under a per-flow pre-agent-SHA `ai-trigger: allow` gate, folder-confined to `PI_DISPATCH_RUN_ROOTS`, depth/count/rate-capped, budget unchanged; operator-typed CLI/command ungated). |
 | 2026-07-22 | Coherence fix: reworded the two live "triggers no jobs" admin claims — REQ-ADMIN-VIA-PI-EXTENSION `Scope` and the `Triggers` overview bullet — to "triggers no jobs except the gated `dispatch_run` enqueue", resolving the self-contradiction with the same entry's `Statement`/`Why` `dispatch_run` clauses (still never materialised into a job's `/job` inputs). |
+| 2026-07-22 | Added REQ-TOKEN-ACCOUNTING-AND-CAPS (issue #25, unblocked by OQ-010): per-job token/cost accounting in the run record + admin views; an optional in-run per-job token budget (`maxTokens`/`PI_MAX_TOKENS`, exits policy `token_budget`); and an optional daily token cap (`dailyTokenCap`/`PI_DAILY_TOKEN_CAP`) enforced **check-AFTER** — the deliberate asymmetry with `CONST-BUDGET-BEFORE-TOKENS`, which is unchanged (still job-count, still check-before). Extended REQ-RUNTIME-SETTINGS-PICKUP's key list with `maxTokens`/`dailyTokenCap`; retargeted REQ-SPEND-CAPS-MULTI-WINDOW's OQ-010 forward-reference to the new REQ. |

--- a/worker/src/budget.mjs
+++ b/worker/src/budget.mjs
@@ -44,6 +44,14 @@ export function monthKey(now = new Date(), prefix = "budget") {
 	return `${prefix}:m:${now.toISOString().slice(0, 7)}`; // YYYY-MM, UTC
 }
 
+/**
+ * UTC day key for the daily TOKEN counter: `budget:t:YYYY-MM-DD`. The `t:` sub-namespace never collides
+ * with the job-count day/week/month keys -- token spend and job count are separate ledgers.
+ */
+export function tokenDayKey(now = new Date(), prefix = "budget") {
+	return `${prefix}:t:${now.toISOString().slice(0, 10)}`; // YYYY-MM-DD, UTC
+}
+
 // Each window's TTL outlives its bucket with slack, so a stale counter is reclaimed shortly after the
 // window rolls over. Set once, on first reservation only (reserved === 1), so a busy window cannot push
 // its own expiry forward indefinitely.
@@ -130,4 +138,42 @@ export async function releaseBudget(redis, { caps, now = new Date(), keyPrefix =
 	for (const w of activeWindows(caps, now, keyPrefix)) {
 		await redis.decr(w.key);
 	}
+}
+
+/**
+ * The daily TOKEN cap check -- read-only, no increment. Returns `{ allowed, reason, spent, cap }`.
+ *
+ * This is the deliberate ASYMMETRY to `reserveBudget` (issue #25 / OQ-010). A job's token cost is
+ * knowable only AFTER it runs, so a token cap cannot check-and-increment BEFORE the spend the way the
+ * job-COUNT cap does (CONST-BUDGET-BEFORE-TOKENS, which governs only the ordering of the job-count cap
+ * and stays unchanged). Instead the token count is a check-BEFORE read of PRIOR jobs' recorded spend
+ * (this function) paired with a record-AFTER `INCRBY` (`recordTokenSpend`). It can only stop the NEXT
+ * job once a day's accumulated spend has reached the cap -- a lagging backstop, not a before-the-spend
+ * cap; `maxTurns` remains the one proactive per-job lever. Being read-only it consumes nothing, so it
+ * safely precedes the job-count reservation and a refusal here spends no job-count slot.
+ *
+ * `cap` null/absent disables the cap (always allowed). A cap <= 0 fails closed (spent >= 0 always
+ * blocks), matching `reserveBudget`'s fail-closed posture on a nonsensical cap.
+ */
+export async function checkTokenCap(redis, { cap, now = new Date(), keyPrefix = "budget" } = {}) {
+	if (cap === null || cap === undefined) return { allowed: true, reason: "ok", spent: 0, cap: null };
+	const spent = Number(await redis.get(tokenDayKey(now, keyPrefix))) || 0;
+	if (spent >= cap) return { allowed: false, reason: "daily-token-cap", spent, cap };
+	return { allowed: true, reason: "ok", spent, cap };
+}
+
+/**
+ * Record a job's token spend against the daily counter -- the record-AFTER half of the lagging token cap
+ * (see `checkTokenCap`). `INCRBY` by the job's total tokens; set the day TTL once, on first write, so a
+ * busy day cannot push its own expiry forward (mirrors `reserveBudget`'s set-once TTL). Under concurrency
+ * the counter is best-effort: N in-flight jobs each passed `checkTokenCap` before any recorded, so the
+ * daily total can overshoot the cap by up to N per-job budgets -- expected and acceptable for a lagging
+ * backstop (OQ-010). Returns the new counter value. `tokens` is assumed a non-negative integer (the
+ * caller guards `> 0`), so the first-write TTL test `total === tokens` holds.
+ */
+export async function recordTokenSpend(redis, tokens, { now = new Date(), keyPrefix = "budget" } = {}) {
+	const key = tokenDayKey(now, keyPrefix);
+	const total = Number(await redis.incrby(key, tokens));
+	if (total === tokens) await redis.expire(key, DAY_TTL_SECONDS);
+	return total;
 }

--- a/worker/src/config.mjs
+++ b/worker/src/config.mjs
@@ -81,6 +81,8 @@ export function loadConfig(env = process.env, { fileExists = existsSync } = {}) 
 		provider: env.PI_PROVIDER ?? "anthropic",
 		model,
 		maxTurns: positiveInt(env, "PI_MAX_TURNS", 30), // pi has no turn limit; we impose one
+		maxTokens: optionalBoundedInt(env, "PI_MAX_TOKENS", 1), // issue #25; null = per-job token budget disabled (lagging in-run backstop)
+		dailyTokenCap: optionalBoundedInt(env, "PI_DAILY_TOKEN_CAP", 1), // issue #25; null = daily token counter disabled (check-AFTER, host-side)
 		jobImage: env.PI_JOB_IMAGE ?? "pi-job:latest",
 		jobsDir: env.PI_JOBS_DIR ?? defaultJobsDir(),
 		schedulesFile: env.PI_SCHEDULES_FILE ?? null, // DES-CRON-VIA-BULLMQ-SCHEDULER: schedule list is a host file; null = cron disabled

--- a/worker/src/env-allowlist.mjs
+++ b/worker/src/env-allowlist.mjs
@@ -29,7 +29,7 @@ export function providerKeyVars(provider, hostEnv) {
  * Throws if the provider is not configured -- a deterministic misconfiguration the caller maps to
  * a pre-spend refusal, never a launched-then-failed container.
  */
-export function buildContainerEnv({ provider, model, maxTurns, jobId, githubToken, hostEnv }) {
+export function buildContainerEnv({ provider, model, maxTurns, maxTokens, jobId, githubToken, hostEnv }) {
 	const keyVars = providerKeyVars(provider, hostEnv);
 	if (!keyVars || keyVars.length === 0) {
 		const error = new Error(`provider ${provider} has no configured credential in the worker environment`);
@@ -41,6 +41,9 @@ export function buildContainerEnv({ provider, model, maxTurns, jobId, githubToke
 		PI_PROVIDER: provider,
 		PI_MODEL: model,
 		PI_MAX_TURNS: String(maxTurns),
+		// The optional per-job token budget (issue #25). Absent/null => variable omitted (docker-run skips
+		// undefined), so the runner attaches a pure meter with no cap. Never an empty string.
+		PI_MAX_TOKENS: maxTokens === null || maxTokens === undefined ? undefined : String(maxTokens),
 		PI_JOB_ID: jobId,
 		// Baked into the image, but harmless to restate; kept here so the container contract is
 		// visible in one place. INT-CONTAINER-RUNTIME-CONTRACT.

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -50,7 +50,7 @@ export function makeProcessor({ cancelJob, stopContainer, redis, getSettings, ap
 				// job completed and does not retry a file that can never parse (CONST-RETRY-INFRA-ONLY). Resolved
 				// before runJob, so no budget slot is reserved and no container starts (CONST-BUDGET-BEFORE-TOKENS).
 				// recordRun leaves the durable settings-overlay-invalid trace for the admin extension.
-				const result = { outcome: "policy", reason: "settings-overlay-invalid", exitCode: null, turns: null, budgetReserved: false };
+				const result = { outcome: "policy", reason: "settings-overlay-invalid", exitCode: null, turns: null, tokens: null, budgetReserved: false };
 				recordRun({ job, result, startedAt, endedAt: new Date().toISOString() });
 				return result;
 			}
@@ -70,6 +70,7 @@ export function makeProcessor({ cancelJob, stopContainer, redis, getSettings, ap
 				provider: job.data.provider ?? settings.provider,
 				model: job.data.model ?? settings.model,
 				maxTurns: job.data.maxTurns ?? settings.maxTurns,
+				maxTokens: job.data.maxTokens ?? settings.maxTokens, // optional per-job token budget (issue #25); null => runner meter only
 			};
 
 			const result = await runJob(effectiveJob, {
@@ -78,6 +79,9 @@ export function makeProcessor({ cancelJob, stopContainer, redis, getSettings, ap
 				// job-start under overlay > env. reserveBudget checks them before the container.
 				caps: { day: settings.dailyCap, week: settings.weeklyCap, month: settings.monthlyCap },
 				softHoldPct: settings.softHoldPct,
+				// The daily TOKEN cap (issue #25), same overlay > env resolution. Check-AFTER, so it gates the
+				// NEXT job on prior recorded spend; null => the daily token counter is disabled.
+				tokenCap: settings.dailyTokenCap,
 				...deps,
 				runContainer: (ctx) => deps.runContainer({ ...ctx, name, signal }),
 				// collectChain (INT-OUTBOX-CONTRACT) reads the completed parent's REAL BullMQ job: its `.id`

--- a/worker/src/processor.mjs
+++ b/worker/src/processor.mjs
@@ -1,4 +1,4 @@
-import { releaseBudget, reserveBudget } from "./budget.mjs";
+import { checkTokenCap, recordTokenSpend, releaseBudget, reserveBudget } from "./budget.mjs";
 import { configError } from "./config.mjs";
 import { EXIT_COMPLETED, EXIT_INFRA, EXIT_POLICY } from "./exit-code.mjs";
 
@@ -28,6 +28,8 @@ export async function runJob(job, deps) {
 		redis,
 		caps, // { day, week, month }; week/month null when that window is disabled (REQ-SPEND-CAPS-MULTI-WINDOW)
 		softHoldPct, // int 1-99 or null; the soft-hold band applied to every active window
+		tokenCap = null, // int or null; the daily TOKEN cap (issue #25). Check-AFTER, so it gates the NEXT job on prior spend
+		recordSpend = recordTokenSpend, // injected so the post-container INCRBY is testable/stubbable
 		mintToken, // (repo) => scoped short-lived token | null for local-folder jobs
 		isDefaultBranchProtected, // (repo, token) => boolean
 		prepareWorkspace, // (job, token) => { workspaceDir, jobDir }  (clone+materialise+prompt)
@@ -68,8 +70,8 @@ export async function runJob(job, deps) {
 			if (!(await isDefaultBranchProtected(job.repo, token))) {
 				await comment(job, "Refused: the default branch is not protected. See SECURITY.md.");
 				log("refused_unprotected", { repo: job.repo });
-				// exitCode/turns null: refused pre-container, so no container exit or turn count exists.
-				return { outcome: "policy", reason: "unprotected-branch", exitCode: null, turns: null, budgetReserved: false }; // return => not retried
+				// exitCode/turns/tokens null: refused pre-container, so no container exit, turn, or token count exists.
+				return { outcome: "policy", reason: "unprotected-branch", exitCode: null, turns: null, tokens: null, budgetReserved: false }; // return => not retried
 			}
 		}
 
@@ -80,6 +82,21 @@ export async function runJob(job, deps) {
 		// Mirrors the branch-protection policy return above.
 		if (prepared?.outcome === "policy") {
 			return prepared;
+		}
+
+		// Daily TOKEN cap (issue #25): the deliberate check-AFTER control. Token cost is only known
+		// post-run, so this cannot check-and-increment before the spend the way the job-count cap does
+		// (CONST-BUDGET-BEFORE-TOKENS). It is a read-only GET of prior jobs' recorded spend -- it consumes
+		// nothing, so it precedes reserveBudget's INCR and a refusal here burns no job-count slot. It can
+		// only stop the NEXT job once the day's accumulated spend has reached the cap; the actual INCRBY
+		// happens post-container via recordSpend. Reported before the job-count cap only because both are
+		// spend gates; the more-actionable branch-protection precondition is still reported first above.
+		const tokenGate = await checkTokenCap(redis, { cap: tokenCap, now });
+		if (!tokenGate.allowed) {
+			await comment(job, `Over the daily token cap (${tokenGate.spent}/${tokenGate.cap} tokens). Not run.`);
+			log("over_token_budget", { spent: tokenGate.spent, cap: tokenGate.cap });
+			// budgetReserved false: refused before reserveBudget, so no job-count slot was consumed.
+			return { outcome: "policy", reason: "daily-token-cap", exitCode: null, turns: null, tokens: null, budgetReserved: false }; // return => not retried
 		}
 
 		// Budget last-but-before-container. A refusal here spends nothing (no container starts). Reserves across
@@ -98,19 +115,30 @@ export async function runJob(job, deps) {
 			}
 			// budgetReserved true: the slot is reserved above and kept (a refused reservation still counts). Both
 			// over-budget and soft-hold are POLICY, RETURNED (not retried) -- the agent never ran.
-			return { outcome: "policy", reason: budget.reason, exitCode: null, turns: null, budgetReserved: true }; // return => not retried
+			return { outcome: "policy", reason: budget.reason, exitCode: null, turns: null, tokens: null, budgetReserved: true }; // return => not retried
 		}
 
-		const { code, aborted, turns } = await runContainer({ job, token, prepared });
+		const { code, aborted, turns, tokens } = await runContainer({ job, token, prepared });
 		log("container_exit", { exitCode: code, aborted });
+
+		// Record token spend post-run (the check-AFTER half of the lagging token cap). The container ran,
+		// so it spent real tokens on EVERY path that reaches here -- abort, completed, policy, AND the infra
+		// throws below (an exit-1 container still spent before failing). Record before classifying so all of
+		// them are accounted. Only when the cap is enabled (nothing reads the counter otherwise) and the run
+		// reported a positive total. NEVER throws: money is already spent, so a Redis blip here must not turn
+		// a completed paid job into a failure (mirrors the sink/comment/cleanup fault-isolation posture).
+		const tokensSpent = tokens?.total ?? 0;
+		if (tokenCap !== null && tokenCap !== undefined && tokensSpent > 0) {
+			await recordSpend(redis, tokensSpent, { now }).catch((err) => log("token_spend_error", { reason: err?.message }));
+		}
 
 		// A WORKER-initiated stop (30-min timeout via cancelJob, or graceful-shutdown docker stop) kills
 		// the container -> exit 143/137. That is our decision, not an infra fault: it is POLICY and must
 		// NOT retry, or a wedged job re-runs into a second PR / double spend. Keyed on the abort FLAG,
 		// not the code -- an unbidden 137 (kernel OOM) carries `aborted: false`, falls to the switch, and
 		// stays infra-retryable.
-		// exitCode/turns carry the container's own exit and turn count; budgetReserved true post-reserve.
-		if (aborted) return { outcome: "policy", reason: "worker-abort", exitCode: code, turns, budgetReserved: true };
+		// exitCode/turns/tokens carry the container's own exit, turn count, and usage totals; budgetReserved true post-reserve.
+		if (aborted) return { outcome: "policy", reason: "worker-abort", exitCode: code, turns, tokens, budgetReserved: true };
 
 		switch (code) {
 			case EXIT_COMPLETED: {
@@ -120,14 +148,14 @@ export async function runJob(job, deps) {
 				// over-budget, infra): an InfraRetry job is retried, so chaining there would double-enqueue.
 				// collectChain never throws; chainEnqueued/chainRefused are additive telemetry only.
 				const chain = await collectChain({ job, prepared });
-				return { outcome: "completed", exitCode: code, turns, budgetReserved: true, chainEnqueued: chain.enqueued, chainRefused: chain.refused };
+				return { outcome: "completed", exitCode: code, turns, tokens, budgetReserved: true, chainEnqueued: chain.enqueued, chainRefused: chain.refused };
 			}
 			case EXIT_POLICY:
-				return { outcome: "policy", reason: "runner-policy", exitCode: code, turns, budgetReserved: true };
+				return { outcome: "policy", reason: "runner-policy", exitCode: code, turns, tokens, budgetReserved: true };
 			case EXIT_INFRA:
-				throw new InfraRetry(`infra failure, container exit ${code}`, { exitCode: code, turns });
+				throw new InfraRetry(`infra failure, container exit ${code}`, { exitCode: code, turns, tokens });
 			default:
-				throw new InfraRetry(`unknown container exit ${code}`, { exitCode: code, turns });
+				throw new InfraRetry(`unknown container exit ${code}`, { exitCode: code, turns, tokens });
 		}
 	} catch (e) {
 		// A spawn fault (docker daemon down / binary missing) reserved a slot but never started a
@@ -149,13 +177,14 @@ export async function runJob(job, deps) {
 
 /** Thrown for the retryable (infra) class only. The BullMQ processor lets this propagate to retry. */
 export class InfraRetry extends Error {
-	constructor(message, { cause, reason, exitCode, turns, budgetReserved } = {}) {
+	constructor(message, { cause, reason, exitCode, turns, tokens, budgetReserved } = {}) {
 		super(message, cause ? { cause } : undefined);
 		this.name = "InfraRetry";
 		this.piDispatchRetry = true;
 		this.reason = reason ?? message;
 		this.exitCode = exitCode ?? null;
 		this.turns = turns ?? null;
+		this.tokens = tokens ?? null;
 		this.budgetReserved = budgetReserved ?? null;
 	}
 }

--- a/worker/src/run-container.mjs
+++ b/worker/src/run-container.mjs
@@ -28,13 +28,13 @@ export function makeRunContainer({
 	image,
 	hostEnv = process.env,
 	onOutput = (c) => process.stdout.write(c),
-	openJobLog = () => ({ write() {}, close: async () => ({ turns: null }) }),
+	openJobLog = () => ({ write() {}, close: async () => ({ turns: null, tokens: null }) }),
 	spawnFn = spawn,
 }) {
 	// async so a synchronous throw (e.g. buildContainerEnv on an unconfigured provider) surfaces as
 	// a rejection, uniformly awaitable by the processor and by tests.
 	return async function runContainer({ job, token, prepared, name, signal }) {
-		if (signal?.aborted) return { code: 137, aborted: true, turns: null }; // killed before it could start
+		if (signal?.aborted) return { code: 137, aborted: true, turns: null, tokens: null }; // killed before it could start
 
 		// Closed env allowlist: only the provider key + the declared PI_* vars. Throws (config) if
 		// the provider is unconfigured -- the processor turns that into a pre-spend refusal.
@@ -42,6 +42,7 @@ export function makeRunContainer({
 			provider: job.provider,
 			model: job.model,
 			maxTurns: job.maxTurns,
+			maxTokens: job.maxTokens, // optional per-job token budget (issue #25); undefined => runner meter only
 			jobId: name,
 			githubToken: token ?? undefined,
 			hostEnv,
@@ -80,14 +81,16 @@ export function makeRunContainer({
 			});
 			child.on("close", async (code) => {
 				const aborted = signal?.aborted === true; // capture BEFORE the await
-				// A rejecting sink.close is swallowed so a misbehaving sink cannot hang the run; turns falls back to null.
+				// A rejecting sink.close is swallowed so a misbehaving sink cannot hang the run; turns/tokens fall back to null.
 				let turns = null;
+				let tokens = null;
 				try {
-					({ turns } = await sink.close());
+					({ turns, tokens } = await sink.close());
 				} catch {
 					turns = null;
+					tokens = null;
 				}
-				resolve(aborted ? { code: code ?? 137, aborted: true, turns } : { code: code ?? 1, aborted: false, turns });
+				resolve(aborted ? { code: code ?? 137, aborted: true, turns, tokens } : { code: code ?? 1, aborted: false, turns, tokens });
 			});
 		});
 	};

--- a/worker/src/run-history.mjs
+++ b/worker/src/run-history.mjs
@@ -62,6 +62,38 @@ export function parseExitTurns(text) {
 }
 
 /**
+ * Recover the agent's token usage from buffered container stdout, or `null` if it is not reported.
+ *
+ * Mirrors `parseExitTurns`: scan from the end for the last `exit` event and read its `tokens` object
+ * (`{ input, output, total, cost }`). Only the success exit line carries it
+ * (`image/runner/run-job.mjs`); the catch-path exit line omits it, and a container that died before the
+ * runner's exit line yields none -- all three cases are `null`.
+ *
+ * Read-only telemetry, exactly like `parseExitTurns`: NEVER throws and MUST NOT feed exit-code or retry
+ * classification (INT-RUNNER-EXIT-CODE-PROTOCOL). A malformed or non-object `tokens` (or one missing a
+ * numeric `total`) is `null`, never a partial that could poison the daily token counter.
+ */
+export function parseExitTokens(text) {
+	if (typeof text !== "string") return null;
+	const lines = text.split("\n");
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i].trim();
+		if (line === "") continue;
+		let parsed;
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			continue; // docker/agent noise or a truncated final line
+		}
+		if (parsed?.event !== "exit") continue;
+		const t = parsed?.tokens;
+		if (t && typeof t === "object" && !Array.isArray(t) && typeof t.total === "number") return t;
+		return null;
+	}
+	return null;
+}
+
+/**
  * Build the durable run record from the full BullMQ job wrapper and the run's outcome.
  *
  * The record is id-only by construction: an EXPLICIT object literal that reads exactly the stable,
@@ -90,6 +122,10 @@ export function buildRecord({ job, result, error, startedAt, endedAt }) {
 		reason: source.reason ?? null,
 		exitCode: source.exitCode ?? null,
 		turns: source.turns ?? null,
+		// Token accounting (INT-RUN-HISTORY-FILE-CONTRACT): additive and nullable, an explicit literal, no
+		// spread. The runner's per-job usage totals `{ input, output, total, cost }`, or null when the
+		// container died before the exit line. PII-free -- integer token counts and numeric cost only.
+		tokens: source.tokens ?? null,
 		budgetReserved: source.budgetReserved ?? null,
 		attempt: job.attemptsMade ?? 0,
 		// Chain telemetry (INT-RUN-HISTORY-FILE-CONTRACT): additive and nullable, explicit literals, no spread.
@@ -165,8 +201,9 @@ export function makeLogSink({ logsDir, enabled, fs = nodeFs, log = () => {} }) {
 		}
 
 		async function close({ timeoutMs = 2000 } = {}) {
-			// Capture turns from the tail first, so the count survives even if the flush errors or times out.
+			// Capture turns and tokens from the tail first, so they survive even if the flush errors or times out.
 			const turns = parseExitTurns(tail);
+			const tokens = parseExitTokens(tail);
 			try {
 				if (stream !== null) {
 					const s = stream;
@@ -190,7 +227,7 @@ export function makeLogSink({ logsDir, enabled, fs = nodeFs, log = () => {} }) {
 			} catch (err) {
 				log("log_sink_error", { jobId, reason: err?.message });
 			}
-			return { turns };
+			return { turns, tokens };
 		}
 
 		return { write, close };

--- a/worker/src/runtime-settings.mjs
+++ b/worker/src/runtime-settings.mjs
@@ -4,10 +4,11 @@ import { defaultSettingsFile } from "./config.mjs";
 
 /**
  * Runtime-settings overlay: the shared, durable truth between the admin extension and the worker
- * (INT-CONFIG-OVERLAY-CONTRACT, DES-RUNTIME-SETTINGS-FILE-OVERLAY). A flat `settings.json` with eight
+ * (INT-CONFIG-OVERLAY-CONTRACT, DES-RUNTIME-SETTINGS-FILE-OVERLAY). A flat `settings.json` with ten
  * optional keys -- `model`, `provider` (non-empty strings), `maxTurns`, `dailyCap`, `weeklyCap`,
- * `monthlyCap` (int >= 1), `concurrency` (int 1-10), `softHoldPct` (int 1-99) -- read by the worker at
- * each job start and written atomically by the admin extension (tmp + rename).
+ * `monthlyCap`, `maxTokens`, `dailyTokenCap` (int >= 1), `concurrency` (int 1-10), `softHoldPct`
+ * (int 1-99) -- read by the worker at each job start and written atomically by the admin extension
+ * (tmp + rename). `maxTokens`/`dailyTokenCap` are the optional token controls (issue #25).
  *
  * `readOverlay` NEVER throws: a bad settings file returns a discriminated `{ invalid }` rather than an
  * exception, so the processor RETURNS a policy refusal (`settings-overlay-invalid`) instead of letting
@@ -24,7 +25,7 @@ import { defaultSettingsFile } from "./config.mjs";
  * Custom: overlay validated inline per config.mjs precedent; zod not in deps
  */
 
-export const KNOWN_KEYS = ["model", "provider", "maxTurns", "dailyCap", "weeklyCap", "monthlyCap", "concurrency", "softHoldPct"];
+export const KNOWN_KEYS = ["model", "provider", "maxTurns", "dailyCap", "weeklyCap", "monthlyCap", "maxTokens", "dailyTokenCap", "concurrency", "softHoldPct"];
 
 function isNonEmptyString(value) {
 	return typeof value === "string" && value.trim() !== "";
@@ -70,8 +71,11 @@ function validateOverlay(candidate, log) {
 			case "dailyCap":
 			case "weeklyCap":
 			case "monthlyCap":
-				// Overlay caps are positive ints. A window is DISABLED by absence, not by a 0 -- `unset weeklyCap`
-				// drops the key so it falls through to env, which unset means the window is off (config.mjs).
+			case "maxTokens":
+			case "dailyTokenCap":
+				// Overlay caps are positive ints. A window/cap is DISABLED by absence, not by a 0 -- `unset weeklyCap`
+				// drops the key so it falls through to env, which unset means the window is off (config.mjs). The
+				// token knobs (maxTokens, dailyTokenCap) follow the same "absent = disabled" shape (issue #25).
 				if (!isIntAtLeast(value, 1)) return { invalid: `${key} must be an integer >= 1` };
 				overlay[key] = value;
 				break;
@@ -121,11 +125,11 @@ export function readOverlay(path, { fs = nodeFs, log = () => {} } = {}) {
 }
 
 /**
- * Resolve the eight effective settings from `config` and a validated `overlay`: overlay value where the
+ * Resolve the ten effective settings from `config` and a validated `overlay`: overlay value where the
  * overlay sets it, else the config value. Precedence is overlay > env > default only -- `config`
- * already carries env > default. `weeklyCap`/`monthlyCap`/`softHoldPct` may resolve to `null` (their
- * config value when unset), meaning that window / the soft-hold band is disabled. `job.data` is NOT
- * merged here; that layer is the processor's.
+ * already carries env > default. `weeklyCap`/`monthlyCap`/`maxTokens`/`dailyTokenCap`/`softHoldPct` may
+ * resolve to `null` (their config value when unset), meaning that window / cap / band is disabled.
+ * `job.data` is NOT merged here; that layer is the processor's.
  */
 export function effectiveSettings(config, overlay) {
 	const o = overlay ?? {};
@@ -136,6 +140,8 @@ export function effectiveSettings(config, overlay) {
 		dailyCap: o.dailyCap ?? config.dailyCap,
 		weeklyCap: o.weeklyCap ?? config.weeklyCap,
 		monthlyCap: o.monthlyCap ?? config.monthlyCap,
+		maxTokens: o.maxTokens ?? config.maxTokens,
+		dailyTokenCap: o.dailyTokenCap ?? config.dailyTokenCap,
 		concurrency: o.concurrency ?? config.concurrency,
 		softHoldPct: o.softHoldPct ?? config.softHoldPct,
 	};

--- a/worker/test/budget.test.mjs
+++ b/worker/test/budget.test.mjs
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { dayKey, weekKey, monthKey, windowState, releaseBudget, reserveBudget } from "../src/budget.mjs";
+import {
+	checkTokenCap,
+	dayKey,
+	monthKey,
+	recordTokenSpend,
+	releaseBudget,
+	reserveBudget,
+	tokenDayKey,
+	weekKey,
+	windowState,
+} from "../src/budget.mjs";
 
 /** Minimal ioredis-compatible fake, keyed by the redis key so the three windows count independently. */
 function fakeRedis() {
@@ -14,10 +24,18 @@ function fakeRedis() {
 			store.set(k, v);
 			return v;
 		},
+		async incrby(k, n) {
+			const v = (store.get(k) ?? 0) + n;
+			store.set(k, v);
+			return v;
+		},
 		async decr(k) {
 			const v = (store.get(k) ?? 0) - 1;
 			store.set(k, v);
 			return v;
+		},
+		async get(k) {
+			return store.has(k) ? String(store.get(k)) : null; // ioredis GET returns a string or null
 		},
 		async expire(k, s) {
 			ttl.set(k, s);
@@ -189,4 +207,67 @@ test("release only decrements active windows -- a disabled window is untouched",
 	await releaseBudget(redis, { caps: { day: 3, week: null, month: null }, now: NOW });
 	assert.equal(redis.store.get(DAY), 4);
 	assert.ok(!redis.store.has(WEEK), "a disabled window is never decremented into existence");
+});
+
+// ---- daily token counter (issue #25): check-BEFORE (read) + record-AFTER (INCRBY) ----
+
+const TOKEN_DAY = "budget:t:2026-07-16";
+
+test("tokenDayKey is a distinct t: sub-namespace, never colliding with the job-count keys", () => {
+	assert.equal(tokenDayKey(NOW), TOKEN_DAY);
+	assert.notEqual(tokenDayKey(NOW), dayKey(NOW), "token ledger and job-count ledger are separate keys");
+});
+
+test("checkTokenCap: a null cap is disabled -- always allowed, reads nothing", async () => {
+	const redis = fakeRedis();
+	redis.store.set(TOKEN_DAY, 9_999_999);
+	const r = await checkTokenCap(redis, { cap: null, now: NOW });
+	assert.deepEqual(r, { allowed: true, reason: "ok", spent: 0, cap: null });
+});
+
+test("checkTokenCap: allowed below the cap, refused once accumulated spend reaches it", async () => {
+	const redis = fakeRedis();
+	assert.equal((await checkTokenCap(redis, { cap: 1000, now: NOW })).allowed, true, "no prior spend -> allowed");
+
+	redis.store.set(TOKEN_DAY, 999);
+	const below = await checkTokenCap(redis, { cap: 1000, now: NOW });
+	assert.deepEqual(below, { allowed: true, reason: "ok", spent: 999, cap: 1000 });
+
+	redis.store.set(TOKEN_DAY, 1000); // reached the cap
+	const at = await checkTokenCap(redis, { cap: 1000, now: NOW });
+	assert.equal(at.allowed, false, "at the cap the NEXT job is refused (>=)");
+	assert.equal(at.reason, "daily-token-cap");
+	assert.equal(at.spent, 1000);
+});
+
+test("checkTokenCap: read-only -- it never mutates the counter", async () => {
+	const redis = fakeRedis();
+	redis.store.set(TOKEN_DAY, 500);
+	await checkTokenCap(redis, { cap: 1000, now: NOW });
+	assert.equal(redis.store.get(TOKEN_DAY), 500, "a check must consume nothing (it precedes reserveBudget)");
+});
+
+test("checkTokenCap: a cap <= 0 fails closed (every job blocked), matching reserveBudget", async () => {
+	const redis = fakeRedis();
+	const r = await checkTokenCap(redis, { cap: 0, now: NOW });
+	assert.equal(r.allowed, false, "spent 0 >= cap 0 blocks -- a nonsensical cap is not 'unlimited'");
+});
+
+test("recordTokenSpend: INCRBY accumulates and sets the day TTL once, on first write", async () => {
+	const redis = fakeRedis();
+	assert.equal(await recordTokenSpend(redis, 400, { now: NOW }), 400);
+	assert.equal(redis.ttl.get(TOKEN_DAY), 2 * 24 * 60 * 60, "TTL set on the first write");
+
+	redis.ttl.delete(TOKEN_DAY); // prove the second write does NOT re-set it
+	assert.equal(await recordTokenSpend(redis, 600, { now: NOW }), 1000, "accumulates across jobs");
+	assert.equal(redis.ttl.has(TOKEN_DAY), false, "a busy day cannot push its own expiry forward");
+});
+
+test("check-before + record-after compose: prior jobs' recorded spend gates the next", async () => {
+	const redis = fakeRedis();
+	await recordTokenSpend(redis, 700, { now: NOW });
+	await recordTokenSpend(redis, 400, { now: NOW }); // 1100 recorded
+	const gate = await checkTokenCap(redis, { cap: 1000, now: NOW });
+	assert.equal(gate.allowed, false, "the lagging cap stops the NEXT job once the day is over budget");
+	assert.equal(gate.spent, 1100);
 });

--- a/worker/test/config.test.mjs
+++ b/worker/test/config.test.mjs
@@ -10,6 +10,8 @@ test("loads conservative defaults with an empty-ish env", () => {
 	assert.equal(c.weeklyCap, null, "the weekly ceiling defaults to disabled");
 	assert.equal(c.monthlyCap, null, "the monthly ceiling defaults to disabled");
 	assert.equal(c.softHoldPct, null, "the soft-hold band defaults to disabled");
+	assert.equal(c.maxTokens, null, "the per-job token budget defaults to disabled");
+	assert.equal(c.dailyTokenCap, null, "the daily token cap defaults to disabled");
 	assert.equal(c.provider, "anthropic");
 	assert.equal(c.model, "claude-sonnet-4-5-20250929"); // dated, deterministic
 	assert.equal(c.maxTurns, 30);
@@ -129,6 +131,19 @@ test("soft-hold pct takes 1-99, defaults to disabled, and rejects out-of-range o
 	assert.equal(loadConfig({ PI_SOFT_HOLD_PCT: "" }).softHoldPct, null);
 	for (const bad of ["0", "100", "-5", "abc", "50.5"]) {
 		assert.throws(() => loadConfig({ PI_SOFT_HOLD_PCT: bad }), (e) => e.piDispatchConfig === true, `PI_SOFT_HOLD_PCT=${bad}`);
+	}
+});
+
+test("token controls take explicit positive values, default to disabled, and reject bad values", () => {
+	const c = loadConfig({ PI_MAX_TOKENS: "500000", PI_DAILY_TOKEN_CAP: "20000000" });
+	assert.equal(c.maxTokens, 500000, "per-job token budget from env");
+	assert.equal(c.dailyTokenCap, 20000000, "daily token cap from env");
+	assert.equal(loadConfig({}).maxTokens, null, "absence disables the per-job token budget");
+	assert.equal(loadConfig({ PI_DAILY_TOKEN_CAP: "" }).dailyTokenCap, null, "empty string is disabled, not an error");
+	for (const name of ["PI_MAX_TOKENS", "PI_DAILY_TOKEN_CAP"]) {
+		for (const bad of ["0", "-1", "abc", "1.5"]) {
+			assert.throws(() => loadConfig({ [name]: bad }), (e) => e.piDispatchConfig === true, `${name}=${bad}`);
+		}
 	}
 });
 

--- a/worker/test/env-allowlist.test.mjs
+++ b/worker/test/env-allowlist.test.mjs
@@ -71,6 +71,15 @@ test("a local-folder job (no token) gets NO GITHUB_TOKEN var at all -- not an em
 	assert.ok(!("GITHUB_TOKEN" in env), "absent token must mean absent variable");
 });
 
+test("PI_MAX_TOKENS is forwarded only when the per-job budget is set", { skip }, () => {
+	const withCap = buildContainerEnv({ provider: "anthropic", model: "m", maxTurns: 5, maxTokens: 500000, jobId: "j", hostEnv: HOST });
+	assert.equal(withCap.PI_MAX_TOKENS, "500000", "a set cap is forwarded as a string, like PI_MAX_TURNS");
+
+	// null/absent => undefined, which docker-run.mjs skips -> the runner attaches a pure meter, no cap.
+	const noCap = buildContainerEnv({ provider: "anthropic", model: "m", maxTurns: 5, maxTokens: null, jobId: "j", hostEnv: HOST });
+	assert.equal(noCap.PI_MAX_TOKENS, undefined, "an unset cap is omitted, never an empty string");
+});
+
 test("an unconfigured provider throws a config-tagged error (=> pre-spend refusal)", { skip }, () => {
 	assert.throws(
 		() => buildContainerEnv({ provider: "google", model: "m", maxTurns: 5, jobId: "j", hostEnv: HOST }),

--- a/worker/test/processor.test.mjs
+++ b/worker/test/processor.test.mjs
@@ -3,13 +3,16 @@ import { test } from "node:test";
 import { InfraRetry, runJob } from "../src/processor.mjs";
 
 /** A fake redis whose counter we can preset, to force over/under budget. `decrCalls` spies
- *  releaseBudget, so tests assert the slot is (or is not) given back and never double-released. */
-function fakeRedis(start = 0) {
+ *  releaseBudget, so tests assert the slot is (or is not) given back and never double-released.
+ *  `tokenSpent` presets the daily TOKEN counter that `checkTokenCap`'s read-only GET consults. */
+function fakeRedis(start = 0, tokenSpent = 0) {
 	let n = start;
 	const redis = { decrCalls: 0, incrCalls: 0 };
 	redis.incr = async () => (redis.incrCalls++, ++n);
 	redis.decr = async () => (redis.decrCalls++, --n);
 	redis.expire = async () => {};
+	// The daily token counter is a separate key; GET returns its current value (a string) or null.
+	redis.get = async () => (tokenSpent > 0 ? String(tokenSpent) : null);
 	return redis;
 }
 
@@ -303,4 +306,69 @@ test("collectChain runs ONLY on the completed branch, never on policy / abort / 
 		await runJob(ghJob, d);
 		assert.ok(!calls.includes("collect-chain"), "an unprotected branch must not chain");
 	}
+});
+
+// ---- daily token cap (issue #25): check-BEFORE reserveBudget, record-AFTER the container ----
+
+test("daily token cap refuses BEFORE reserveBudget when the day is over budget -- no job-count slot burned", async () => {
+	// The token counter is preset over the cap; checkTokenCap runs before reserveBudget's INCR.
+	const redis = fakeRedis(0, 2000);
+	const { deps: d, calls } = deps({ redis, tokenCap: 1500 });
+	const r = await runJob(ghJob, d);
+	assert.equal(r.outcome, "policy");
+	assert.equal(r.reason, "daily-token-cap");
+	assert.equal(r.budgetReserved, false, "a token-cap refusal consumes no job-count slot");
+	assert.equal(redis.incrCalls, 0, "reserveBudget (job-count INCR) is never reached");
+	assert.ok(!calls.includes("run-container"), "no container, no provider spend");
+});
+
+test("under the token cap: the run proceeds and records its spend AFTER the container", async () => {
+	const recorded = [];
+	const { deps: d } = deps({
+		redis: fakeRedis(0, 500),
+		tokenCap: 1_000_000,
+		runContainer: async () => ({ code: 0, aborted: false, turns: 3, tokens: { input: 4000, output: 1000, total: 5000, cost: 0.1 } }),
+		recordSpend: async (_redis, tokens) => (recorded.push(tokens), 5500),
+	});
+	const r = await runJob(ghJob, d);
+	assert.equal(r.outcome, "completed");
+	assert.deepEqual(r.tokens, { input: 4000, output: 1000, total: 5000, cost: 0.1 }, "usage totals thread into the result");
+	assert.deepEqual(recorded, [5000], "the job's total tokens are INCRBY'd into the daily counter after the run");
+});
+
+test("token spend is recorded even on a runner-policy exit -- the container still spent", async () => {
+	const recorded = [];
+	const { deps: d } = deps({
+		tokenCap: 1_000_000,
+		runContainer: async () => ({ code: 2, aborted: false, turns: 9, tokens: { total: 4000 } }),
+		recordSpend: async (_redis, tokens) => recorded.push(tokens),
+	});
+	const r = await runJob(ghJob, d);
+	assert.equal(r.outcome, "policy");
+	assert.equal(r.reason, "runner-policy");
+	assert.deepEqual(recorded, [4000], "a policy exit that ran a container is accounted, not free");
+});
+
+test("with the token cap disabled (null), the counter is never recorded", async () => {
+	const recorded = [];
+	const { deps: d } = deps({
+		// tokenCap omitted => defaults to null
+		runContainer: async () => ({ code: 0, aborted: false, turns: 1, tokens: { total: 5000 } }),
+		recordSpend: async (_redis, tokens) => recorded.push(tokens),
+	});
+	const r = await runJob(ghJob, d);
+	assert.equal(r.outcome, "completed");
+	assert.deepEqual(recorded, [], "nothing reads the counter when the cap is off, so nothing writes it");
+});
+
+test("a Redis failure while recording token spend never fails a completed, paid job", async () => {
+	const { deps: d } = deps({
+		tokenCap: 1_000_000,
+		runContainer: async () => ({ code: 0, aborted: false, turns: 2, tokens: { total: 5000 } }),
+		recordSpend: async () => {
+			throw new Error("valkey down");
+		},
+	});
+	const r = await runJob(ghJob, d);
+	assert.equal(r.outcome, "completed", "money is already spent -- a counter blip must not turn success into failure");
 });

--- a/worker/test/run-container.test.mjs
+++ b/worker/test/run-container.test.mjs
@@ -106,7 +106,7 @@ test("an already-aborted signal returns {code:137, aborted:true} and NEVER spawn
 	const ac = new AbortController();
 	ac.abort();
 	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: ac.signal });
-	assert.deepEqual(result, { code: 137, aborted: true, turns: null });
+	assert.deepEqual(result, { code: 137, aborted: true, turns: null, tokens: null });
 	assert.equal(rec.cmd, undefined, "no container may start once the timeout has fired");
 });
 
@@ -126,20 +126,20 @@ test("launches docker with the isolation argv and returns the container's exit c
 test("exit 1 (infra) is returned, not thrown -- it is retryable, not a spawn error", { skip }, async () => {
 	const runContainer = mod.makeRunContainer({ image: "pi-job:x", hostEnv: HOST, spawnFn: fakeSpawn({}, 1) });
 	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: new AbortController().signal });
-	assert.deepEqual(result, { code: 1, aborted: false, turns: null });
+	assert.deepEqual(result, { code: 1, aborted: false, turns: null, tokens: null });
 });
 
 test("close 137 while the worker aborted => {code:137, aborted:true} (our docker stop is POLICY)", { skip }, async () => {
 	const ac = new AbortController();
 	const runContainer = mod.makeRunContainer({ image: "pi-job:x", hostEnv: HOST, spawnFn: fakeSpawnAbortedThenClose(ac, 137) });
 	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: ac.signal });
-	assert.deepEqual(result, { code: 137, aborted: true, turns: null });
+	assert.deepEqual(result, { code: 137, aborted: true, turns: null, tokens: null });
 });
 
 test("close 137 with a signal that never aborted => {code:137, aborted:false} (kernel OOM stays infra)", { skip }, async () => {
 	const runContainer = mod.makeRunContainer({ image: "pi-job:x", hostEnv: HOST, spawnFn: fakeSpawn({}, 137) });
 	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: new AbortController().signal });
-	assert.deepEqual(result, { code: 137, aborted: false, turns: null });
+	assert.deepEqual(result, { code: 137, aborted: false, turns: null, tokens: null });
 });
 
 test("refuses before spawning if the provider is unconfigured (pre-spend guard)", { skip }, async () => {
@@ -199,7 +199,7 @@ test("hostile sink: a throwing write and a rejecting close neither hang nor cras
 		spawnFn: fakeSpawnWithData({}, { chunks: ["x"], exitCode: 0 }),
 	});
 	const result = await runContainer({ job: JOB, prepared: PREPARED, name: "j1", signal: new AbortController().signal });
-	assert.deepEqual(result, { code: 0, aborted: false, turns: null }, "the swallowed sink faults leave code/aborted intact and turns null");
+	assert.deepEqual(result, { code: 0, aborted: false, turns: null, tokens: null }, "the swallowed sink faults leave code/aborted intact and turns/tokens null");
 });
 
 test("never-started: the sink is still closed (best-effort teardown) and the reject reason is unchanged", { skip }, async () => {

--- a/worker/test/run-history.test.mjs
+++ b/worker/test/run-history.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { basename, join } from "node:path";
 import { test } from "node:test";
-import { buildRecord, makeLogReaper, makeLogSink, makeRecordWriter, parseExitTurns, sanitizeJobId } from "../src/run-history.mjs";
+import { buildRecord, makeLogReaper, makeLogSink, makeRecordWriter, parseExitTokens, parseExitTurns, sanitizeJobId } from "../src/run-history.mjs";
 
 /**
  * A fake writable that records chunks and lets a test drive `finish`/`error` timing.
@@ -173,6 +173,47 @@ test("parseExitTurns never throws across the full corpus", () => {
 	}
 });
 
+// ---- parseExitTokens (issue #25): mirrors parseExitTurns, reads the usage object off the exit line ----
+
+test("parseExitTokens reads the tokens object off the success exit line", () => {
+	const tokens = { input: 300, output: 50, total: 350, cost: 0.02 };
+	assert.deepEqual(parseExitTokens(`{"event":"exit","code":0,"turns":7,"tokens":${JSON.stringify(tokens)}}`), tokens);
+});
+
+test("parseExitTokens returns null for the catch-path exit line that omits tokens", () => {
+	assert.equal(parseExitTokens('{"event":"exit","code":2,"reason":"config"}'), null);
+});
+
+test("parseExitTokens returns the LAST exit line's tokens when two are present", () => {
+	const text = '{"event":"exit","tokens":{"total":1}}\n{"event":"exit","tokens":{"total":9}}';
+	assert.deepEqual(parseExitTokens(text), { total: 9 });
+});
+
+test("parseExitTokens rejects a malformed tokens value rather than storing a partial", () => {
+	// A non-object, an array, or an object missing a numeric total must not poison the daily counter.
+	assert.equal(parseExitTokens('{"event":"exit","tokens":42}'), null);
+	assert.equal(parseExitTokens('{"event":"exit","tokens":[1,2]}'), null);
+	assert.equal(parseExitTokens('{"event":"exit","tokens":{"input":10}}'), null, "no numeric total -> null");
+});
+
+test("parseExitTokens never throws across the same corpus that stresses parseExitTurns", () => {
+	for (const input of ['{"event":"exit","tokens":{"total":1}}', '{"event":"exi', "", undefined, null, 42, "null"]) {
+		assert.doesNotThrow(() => parseExitTokens(input), `input=${JSON.stringify(input)}`);
+	}
+});
+
+test("buildRecord stores a completed run's tokens object as an explicit field", () => {
+	const tokens = { input: 1000, output: 200, total: 1200, cost: 0.05 };
+	const record = buildRecord({
+		job: { id: "gh-t", attemptsMade: 0, name: "github", data: { kind: "github", repo: "o/r", issueNumber: 1 } },
+		result: { outcome: "completed", turns: 4, tokens },
+		startedAt: "2026-07-18T00:00:00.000Z",
+		endedAt: "2026-07-18T00:01:00.000Z",
+	});
+	assert.deepEqual(record.tokens, tokens);
+	assert.equal(record.turns, 4);
+});
+
 test("buildRecord for a github job keeps id-only fields and admits no PII", () => {
 	const job = {
 		id: "gh-x",
@@ -192,6 +233,7 @@ test("buildRecord for a github job keeps id-only fields and admits no PII", () =
 	assert.equal(record.kind, "github");
 	assert.equal(record.flow, "fix");
 	assert.equal(record.turns, null);
+	assert.equal(record.tokens, null, "a result without tokens defaults the field to null");
 	assert.equal(record.exitCode, null);
 	assert.equal(record.budgetReserved, null);
 	assert.equal(record.reason, null);

--- a/worker/test/runtime-settings.test.mjs
+++ b/worker/test/runtime-settings.test.mjs
@@ -81,7 +81,7 @@ test("readOverlay: a non-object root (array, string, null) is invalid", () => {
 // ---- readOverlay: each known key ----
 
 test("readOverlay: valid known keys are accepted and returned as the overlay", () => {
-	const obj = { model: "claude-x", provider: "anthropic", maxTurns: 12, dailyCap: 40, weeklyCap: 200, monthlyCap: 800, concurrency: 5, softHoldPct: 80 };
+	const obj = { model: "claude-x", provider: "anthropic", maxTurns: 12, dailyCap: 40, weeklyCap: 200, monthlyCap: 800, maxTokens: 500000, dailyTokenCap: 2000000, concurrency: 5, softHoldPct: 80 };
 	assert.deepEqual(readObj(obj), { overlay: obj });
 });
 
@@ -110,6 +110,10 @@ test("readOverlay: an invalid known key makes the whole file invalid; the reason
 		{ obj: { weeklyCap: 0 }, key: "weeklyCap", value: null },
 			{ obj: { weeklyCap: 2.5 }, key: "weeklyCap", value: "2.5" },
 			{ obj: { monthlyCap: -1 }, key: "monthlyCap", value: "-1" },
+			{ obj: { maxTokens: 0 }, key: "maxTokens", value: null },
+			{ obj: { maxTokens: -5 }, key: "maxTokens", value: "-5" },
+			{ obj: { dailyTokenCap: 0 }, key: "dailyTokenCap", value: null },
+			{ obj: { dailyTokenCap: 2.5 }, key: "dailyTokenCap", value: "2.5" },
 			{ obj: { softHoldPct: 0 }, key: "softHoldPct", value: null },
 			{ obj: { softHoldPct: 100 }, key: "softHoldPct", value: "100" },
 			{ obj: { softHoldPct: 50.5 }, key: "softHoldPct", value: "50.5" },
@@ -161,22 +165,24 @@ test("readOverlay never throws across the nasty corpus", () => {
 
 // ---- effectiveSettings ----
 
-test("effectiveSettings: overlay wins where set, config fills the rest, result has exactly eight keys", () => {
-	const config = { provider: "anthropic", model: "cfg-model", maxTurns: 30, dailyCap: 25, weeklyCap: null, monthlyCap: null, concurrency: 3, softHoldPct: null, valkeyUrl: "x", jobImage: "y" };
-	const res = effectiveSettings(config, { model: "ovl-model", dailyCap: 5, weeklyCap: 100, softHoldPct: 80 });
+test("effectiveSettings: overlay wins where set, config fills the rest, result has exactly ten keys", () => {
+	const config = { provider: "anthropic", model: "cfg-model", maxTurns: 30, dailyCap: 25, weeklyCap: null, monthlyCap: null, maxTokens: null, dailyTokenCap: null, concurrency: 3, softHoldPct: null, valkeyUrl: "x", jobImage: "y" };
+	const res = effectiveSettings(config, { model: "ovl-model", dailyCap: 5, weeklyCap: 100, softHoldPct: 80, maxTokens: 500000, dailyTokenCap: 2000000 });
 	assert.equal(res.model, "ovl-model", "overlay wins");
 	assert.equal(res.dailyCap, 5, "overlay wins");
 	assert.equal(res.weeklyCap, 100, "overlay sets an otherwise-disabled window");
 	assert.equal(res.softHoldPct, 80, "overlay sets the soft-hold band");
+	assert.equal(res.maxTokens, 500000, "overlay sets the otherwise-disabled per-job token budget");
+	assert.equal(res.dailyTokenCap, 2000000, "overlay sets the otherwise-disabled daily token cap");
 	assert.equal(res.provider, "anthropic", "absent overlay key falls to config");
 	assert.equal(res.maxTurns, 30, "absent overlay key falls to config");
 	assert.equal(res.monthlyCap, null, "absent overlay key falls to config's null (disabled)");
 	assert.equal(res.concurrency, 3, "absent overlay key falls to config");
-	assert.deepEqual(Object.keys(res).sort(), ["concurrency", "dailyCap", "maxTurns", "model", "monthlyCap", "provider", "softHoldPct", "weeklyCap"]);
+	assert.deepEqual(Object.keys(res).sort(), ["concurrency", "dailyCap", "dailyTokenCap", "maxTokens", "maxTurns", "model", "monthlyCap", "provider", "softHoldPct", "weeklyCap"]);
 });
 
-test("effectiveSettings: an empty overlay yields the config values verbatim for all eight keys", () => {
-	const config = { provider: "anthropic", model: "cfg-model", maxTurns: 30, dailyCap: 25, weeklyCap: null, monthlyCap: null, concurrency: 3, softHoldPct: null };
+test("effectiveSettings: an empty overlay yields the config values verbatim for all ten keys", () => {
+	const config = { provider: "anthropic", model: "cfg-model", maxTurns: 30, dailyCap: 25, weeklyCap: null, monthlyCap: null, maxTokens: null, dailyTokenCap: null, concurrency: 3, softHoldPct: null };
 	assert.deepEqual(effectiveSettings(config, {}), config);
 });
 
@@ -262,10 +268,10 @@ test("writeOverlay never throws when mkdir or write fails", () => {
 
 // ---- KNOWN_KEYS ----
 
-test("KNOWN_KEYS is exported and lists exactly the eight overlay keys", () => {
+test("KNOWN_KEYS is exported and lists exactly the ten overlay keys", () => {
 	assert.deepEqual(
 		[...KNOWN_KEYS].sort(),
-		["concurrency", "dailyCap", "maxTurns", "model", "monthlyCap", "provider", "softHoldPct", "weeklyCap"],
+		["concurrency", "dailyCap", "dailyTokenCap", "maxTokens", "maxTurns", "model", "monthlyCap", "provider", "softHoldPct", "weeklyCap"],
 	);
 });
 

--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -302,8 +302,8 @@ test("runtime settings: getSettings is a top-level createWorker arg resolving ef
 	assert.equal(typeof captured.getSettings, "function", "getSettings must be a top-level createWorker arg");
 	assert.equal(captured.cap, undefined, "no static cap arg survives -- the overlay replaces the frozen daily cap");
 
-	// Calling it with an empty overlay yields the eight effective keys from env/default config (env {} here);
-	// the optional week/month ceilings and the soft-hold band default to disabled (null).
+	// Calling it with an empty overlay yields the ten effective keys from env/default config (env {} here);
+	// the optional week/month ceilings, token controls, and the soft-hold band default to disabled (null).
 	assert.deepEqual(
 		captured.getSettings(),
 		{
@@ -313,10 +313,12 @@ test("runtime settings: getSettings is a top-level createWorker arg resolving ef
 			dailyCap: 25,
 			weeklyCap: null,
 			monthlyCap: null,
+			maxTokens: null,
+			dailyTokenCap: null,
 			concurrency: 3,
 			softHoldPct: null,
 		},
-		"getSettings resolves the eight effective keys from env/default config when the overlay is empty",
+		"getSettings resolves the ten effective keys from env/default config when the overlay is empty",
 	);
 
 	const started = logs.find((l) => l.event === "worker_started");


### PR DESCRIPTION
Closes #25. Implements the full deferred chain from spike #21 (OQ-010): pinned pi `0.80.7` exposes per-turn usage on `subscribe()`, so the harness can now meter and bound tokens.

## What's in it

**1. Token accounting (always on).** New `attachTokenBudget` (`image/runner/src/token-budget.mjs`, mirrors `attachTurnBudget`) sums `event.message.usage` on `turn_end` (assistant only — `agent_end` would double-count) into `{input, output, total, cost}`. Emitted on the `exit` line, recovered host-side by `parseExitTokens`, persisted in the run record, and surfaced in the admin run views (RUN_DETAIL, list, `/dispatch runs` columns, settings view).

**2. Per-job token budget** — `PI_MAX_TOKENS` / overlay `maxTokens`. The runner aborts the session once cumulative tokens exceed the cap, exiting policy (`2`) with `reason:"token_budget"` — intercepted in `decideExit` before the generic `"aborted"`, so it is never mis-classified as retryable infra. Forwarded into the container only when set.

**3. Daily token cap** — `PI_DAILY_TOKEN_CAP` / overlay `dailyTokenCap`. Deliberately **check-AFTER** (a token's cost is knowable only post-run): `checkTokenCap` reads prior spend *before* `reserveBudget` (so a refusal burns no job-count slot), `recordTokenSpend` `INCRBY`s *after* the container. This is the documented asymmetry with `CONST-BUDGET-BEFORE-TOKENS`, which stays **unchanged** (still job-count, still check-before). Worker-only; never forwarded to the container.

**4. Upstream-contract test** guards the pinned `Usage` shape — including that `cost` stays an object declaring `total` (a flatten to a bare number would else silently record `$0` for every job). A pin bump that drops/reshapes usage fails the build, not a live job.

**Specs:** new `REQ-TOKEN-ACCOUNTING-AND-CAPS`; amendments to `INT-RUN-HISTORY-FILE-CONTRACT`, `INT-RUNNER-EXIT-CODE-PROTOCOL`, `INT-CONFIG-OVERLAY-CONTRACT`, `INT-CONTAINER-RUNTIME-CONTRACT`; `OQ-010` "Unblocks" retargeted.

## Design note — why the caps are backstops, not the main event

A token cap is structurally **lagging**: `maxTurns` stays the one *proactive* per-job lever. `maxTokens` can only abort *after* the breaching turn is paid for; `dailyTokenCap` can only stop the *next* job. The high-value piece is the **accounting** — per-job token/cost in the run history is what lets you tune the proactive levers. Under concurrency the daily counter is best-effort (N in-flight jobs can each pass the check before any records).

## Incidental fix

Admin `coerceSettingValue` only coerced three keys to `Number`, so `set weeklyCap` (from #28) and the new token keys produced a string that `writeOverlay` rejected. It now coerces every non-string overlay key.

## Testing

- **All 662 repo tests pass** (0 fail, 15 pi/node-gated skips). New coverage: runner token-budget + config + decideExit; worker budget counter + parseExitTokens + processor wiring + overlay keys; admin render/detail/settings/completion; the hardened pinned-`Usage` contract test.
- Independent adversarial review confirmed no double-spend, no wrong exit code, no silent-zero accounting against the pinned `0.80.7` types.

> [!NOTE]
> `KNOWN_KEYS` grows from 8 to 10 (`maxTokens`, `dailyTokenCap`); several count-asserting tests updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)