### PR TITLE
docs(readme): stronger pitch + regenerated admin-panel screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,16 @@ npx pi-dispatch run ./my-project --task "dedupe the imports in src/" --flow tidy
   a **daily cap** checked *before* any tokens are spent, so a runaway can't quietly drain your API budget.
 - **Nothing is dropped.** Fifty triggers at once become fifty durable queued jobs, drained at a fixed
   concurrency (default 3) and surviving a reboot (Valkey with AOF).
-- **Three triggers, one job contract.** A CLI command, a cron schedule, or a GitHub issue/PR — each
-  produces the same job, runs through the same box, and shows up in the same panel.
+- **Three triggers, one job contract.** A CLI command, a **cron schedule**, or a GitHub issue/PR — each
+  produces the same job, runs through the same box, and shows up in the same panel. The scheduler is the
+  unattended one: recurring work on your own hardware — a nightly tidy, a weekly dependency bump, a docs
+  regen, a scheduled frontend visual check — the same autonomous-agent-on-a-timer idea as a hosted
+  routine, but the run happens in *your* container under *your* queue and spend caps.
+- **The container image is yours to shape.** Every job runs in your
+  [`image/Dockerfile`](image/Dockerfile) — bake in a project's exact toolchain and system libraries. It
+  already ships **Playwright + Chromium**, so a flow can build your frontend, screenshot it, and iterate
+  on the *rendered* result (before/after images attach to the PR). A hosted routine runs in a fixed
+  environment; here the box bends to the project.
 - **Your project steers the agent** using pi's native layout — `.pi/APPEND_SYSTEM.md` for the persona,
   `.pi/skills/<name>/SKILL.md` for skills, read from your committed files. pi-dispatch ships no persona of
   its own, only a small immutable safety floor baked into the image that your instructions add to and
@@ -310,14 +318,25 @@ flowchart TD
   EN -->|"Valkey down"| E503["503 — GitHub redelivers,<br/>deduped by GUID"]
 ```
 
-## Should you use this instead of the Claude Code GitHub Action?
+## How it compares
 
-For GitHub automation, often no — and you should know that up front.
+**vs the Claude Code GitHub Action.** For GitHub automation, often reach for the action —
 [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) (MIT, ~8.4k stars) is
 GA and does label-triggered issue automation for 10% of the effort. pi-dispatch is for a narrower case:
 **you run pi, on your own hardware, and you want a real queue, a container boundary, and — the part the
 action can't do — to run flows against local folders**, not just GitHub repos, without hosted-runner
 minutes.
+
+**vs Claude Code routines and `/loop`.** A routine runs a recurring agent task on a cron schedule (managed,
+in the cloud); `/loop` repeats a prompt on an interval inside your session. For generic recurring work
+they're simpler — nothing to host — and often the right call. pi-dispatch's cron trigger is the same idea
+with a different centre of gravity: the run happens in **a container image you build**, on **your**
+hardware, under **your** queue and spend caps. That is the edge when the task needs an environment a hosted
+routine cannot give it — a project's exact toolchain and system libraries, or the baked-in **Playwright +
+Chromium** that lets a scheduled flow build a frontend, screenshot it, and iterate until it renders right,
+then attach the before/after to a PR. Rule of thumb: if the recurring task is *"run a prompt,"* use a
+routine; if it is *"run this project's real build / test / visual loop on a schedule, in an image I
+control,"* that is this.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,44 @@
 # pi-dispatch
 
-**Run the [pi](https://github.com/earendil-works/pi) coding agent, in a container, against your own
-folders — on your own machine or server.**
+**Run the [pi](https://github.com/earendil-works/pi) coding agent as a service: it opens a repo or folder
+in a locked-down container, does the work, and shuts the container down — triggered on demand, on a
+schedule, or by a GitHub issue or pull request, with a durable queue, a spend cap, and a live admin
+panel.**
 
-> `pi-dispatch` below is `npx pi-dispatch` from the repo (a workspace bin); or `npm link` it onto your PATH.
-
-Point it at a project folder, give it a task, and pi does the work inside a locked-down container:
+pi is an excellent agent. It has no job queue, no concurrency control, no spend limit, and — by its own
+README — no permission system. **pi-dispatch is exactly that missing operational layer, and nothing
+else.** Everything below the container is pi; everything above it is a few hundred reviewed lines.
 
 ```
 npx pi-dispatch run ./my-project --task "dedupe the imports in src/" --flow tidy
 ```
 
-pi is an excellent agent. It has no job queue, no concurrency control, no spend limit, and — by its own
-README — no permission system. pi-dispatch is that missing layer, and nothing else: a durable queue, a
-per-job container boundary, a turn budget, and a daily spend cap. Everything below the container is pi;
-everything above it is a few hundred lines of code.
+> `pi-dispatch` above is `npx pi-dispatch` from this repo (a workspace bin); or `npm link` it onto your PATH.
 
-**Your project tells the agent what to do**, using pi's own layout — `.pi/APPEND_SYSTEM.md` for the
-persona, `.pi/skills/<name>/SKILL.md` for skills. Not a format we invented; pi's native skills, read
-from your committed files. pi-dispatch ships no persona of its own — only a small, immutable safety floor
-baked into the image that your instructions add to and cannot remove.
+![The /dispatch dashboard overlay — live queue state, day/week/month spend meters, the unified triggers pane (cron, label, comment, pull_request), and the interactive runs list, in one framed TUI](docs/images/dispatch-dashboard.svg)
+
+## Why pi-dispatch
+
+- **The container is the security boundary, not a promise.** pi has no permission system, so every job
+  runs `--cap-drop=ALL`, non-root, ephemeral, `no-new-privileges`, with your instructions mounted
+  read-only — the agent cannot rewrite its own guardrails or reach your host.
+- **Spend is bounded before a container starts** — a per-job **turn budget** (pi has none of its own) and
+  a **daily cap** checked *before* any tokens are spent, so a runaway can't quietly drain your API budget.
+- **Nothing is dropped.** Fifty triggers at once become fifty durable queued jobs, drained at a fixed
+  concurrency (default 3) and surviving a reboot (Valkey with AOF).
+- **Three triggers, one job contract.** A CLI command, a cron schedule, or a GitHub issue/PR — each
+  produces the same job, runs through the same box, and shows up in the same panel.
+- **Your project steers the agent** using pi's native layout — `.pi/APPEND_SYSTEM.md` for the persona,
+  `.pi/skills/<name>/SKILL.md` for skills, read from your committed files. pi-dispatch ships no persona of
+  its own, only a small immutable safety floor baked into the image that your instructions add to and
+  cannot remove.
+- **A live admin panel that binds no network port** — a pi extension in your own session: watch the
+  queue, meter spend, browse every run's PII-free record, tail a running job, and pause/resume, all
+  locally with no model involvement.
+
+Drive it and read its output from the `/dispatch` overlay above, or the matching slash commands:
+
+![Transcript of /dispatch status, /dispatch runs, and /dispatch triggers in a pi session — queue counts, the run-history table with per-job token and cost accounting, and the unified {on,run} triggers list](docs/images/dispatch-commands.svg)
 
 ---
 
@@ -51,6 +70,8 @@ folders you can restore, and commit first.
 
 ## What runs, and what protects you
 
+The local path, end to end — the same queue, container, and budget every trigger flows through:
+
 ```mermaid
 flowchart LR
   CLI["pi-dispatch run ./folder --task ..."] -->|enqueue| Q[("Valkey + BullMQ<br/>the wait-list, AOF")]
@@ -61,16 +82,9 @@ flowchart LR
   PI -->|"edits in place"| F[("your folder")]
 ```
 
-- **The container is the security boundary.** pi has no permission system, so every job runs
-  `--cap-drop=ALL`, non-root, ephemeral, with your instructions mounted read-only. The agent cannot
-  rewrite its own guardrails or reach your host.
-- **Spend is bounded twice.** A per-job **turn budget** (pi has none of its own) and a **daily cap**
-  checked *before* a container starts, so a runaway can't quietly burn your API budget. Also set a spend
-  limit on the API key itself.
-- **Nothing is dropped.** Fifty jobs at once become fifty queued jobs, drained at a fixed concurrency
-  (default 3). Valkey persists them across a reboot.
-
-Read [`SECURITY.md`](SECURITY.md) before you rely on it — it states plainly what is and is not defended.
+The three guarantees from **Why pi-dispatch** — a container boundary, spend bounded *before* a container
+starts, and nothing dropped — are exactly what this path enforces. Read [`SECURITY.md`](SECURITY.md)
+before you rely on it: it states plainly what is and is not defended.
 
 ## Run as a service
 
@@ -154,17 +168,15 @@ worker's **boot reaper** clears on the next start, rather than draining cleanly.
 
 ## Admin (pi extension)
 
-The admin surface is a **pi extension** in [`admin/`](admin/) that loads into *your own* interactive pi
-session — no daemon, no web app, **no network port at all**. Load it with `pi -e admin/src/index.ts` from
-this checkout, add that path to the `"extensions"` array in `~/.pi/agent/settings.json`, or just run pi
-inside this checkout: the in-repo `.pi/extensions` shim auto-loads once you've trusted the project.
+The admin surface — the dashboard and command transcript shown at the top of this README — is a **pi
+extension** in [`admin/`](admin/) that loads into *your own* interactive pi session — no daemon, no web
+app, **no network port at all**. Load it with `pi -e admin/src/index.ts` from this checkout, add that path
+to the `"extensions"` array in `~/.pi/agent/settings.json`, or just run pi inside this checkout: the
+in-repo `.pi/extensions` shim auto-loads once you've trusted the project.
 
-Bare `/dispatch` opens a live dashboard overlay — one snapshot per second, `p`/`r` to pause/resume the
-queue in place:
-
-![The /dispatch dashboard overlay: queue state, budget, recent runs, schedulers with next-fire drift, and the settings overlay in one live TUI panel](docs/images/dispatch-dashboard.svg)
-
-It adds `/dispatch` commands that run **locally, with no model involvement**:
+Bare `/dispatch` opens the live dashboard overlay — one snapshot per second, `p`/`r` to pause/resume the
+queue in place, `↑`/`↓` and `Enter` to drill into a run or tail the active job. It adds `/dispatch`
+commands that run **locally, with no model involvement**:
 
 - `status` — queue counts, paused state, budget; `budget` — today's spend against the daily cap
 - `pause` / `resume` — the queue on/off switch
@@ -172,8 +184,6 @@ It adds `/dispatch` commands that run **locally, with no model involvement**:
 - `triggers` — the configured triggers (display only)
 - `run <folder> <flow> [task]` — enqueue a flow against a local folder (operator-typed; the dirty-tree guard still applies)
 - `settings` / `set <key> <value>` / `unset <key>` — the runtime overlay
-
-![Transcript of /dispatch status, /dispatch runs and /dispatch triggers output in a pi session](docs/images/dispatch-commands.svg)
 
 `/dispatch pause|resume|status` are a second interface over the **same durable switch** as
 `pi-dispatch pause|resume|status` (see **Steer the running worker** above), not a new mechanism; `runs`
@@ -205,56 +215,62 @@ host-enforced, so the in-container agent controls nothing.
 
 The worker keeps a durable, per-job record under `PI_LOGS_DIR` (default: your OS temp dir,
 `.../pi-dispatch/logs`). Every job writes an id-only status record `logs/<jobId>.json` — stable ids only
-(the delivery GUID, `repo#issue`), never issue or comment text. Set `PI_CAPTURE_JOB_LOGS=1` to **also**
+(the delivery GUID, `repo#number`), never issue or comment text. Set `PI_CAPTURE_JOB_LOGS=1` to **also**
 capture the container's raw stdout/stderr to `logs/<jobId>.log`; this is **opt-in and off by default**,
 because that raw stream can contain issue and comment text (PII). Both files stay host-side, are never
 mounted into the job container, and are gitignored. A boot-time sweep prunes anything older than
 `PI_LOG_RETENTION_DAYS` (default 30; `0` keeps them forever).
 
-## Scheduling recurring jobs
+## Triggers: cron, labels, comments, pull requests
 
-A cron schedule is a trigger, not a new job kind: each entry runs a local folder through a flow on a cron
-pattern. Cron entries live in the unified **`triggers.json`** alongside the GitHub triggers, and cron is
-**off by default** for the worker — it fires cron entries only when `PI_TRIGGERS_FILE` points at the file.
+Every standing trigger — cron schedules and GitHub triggers alike — lives in one unified
+**`triggers.json`**, a list of `{ on, run }` pairs read by both the worker (cron) and the receiver
+(GitHub). Point both services at it with `PI_TRIGGERS_FILE`; the worker treats it as optional (unset =
+cron off), the receiver requires it.
+
+```jsonc
+{ "triggers": [
+  { "on": { "type": "cron", "id": "nightly", "pattern": "0 3 * * *" },
+    "run": { "kind": "local", "folder": "/srv/site", "flow": "tidy", "task": "run the nightly tidy" } },
+  { "on": { "type": "label", "any": ["pi:frontend"] },              "run": { "kind": "github", "flow": "frontend-fix" } },
+  { "on": { "type": "comment", "phrase": "@pi" },                   "run": { "kind": "github", "flow": "fix" } },
+  { "on": { "type": "pull_request", "action": ["labeled"], "any": ["pi:review"] }, "run": { "kind": "github", "flow": "review" } }
+] }
+```
+
+The `on × run` matrix is the trust boundary, enforced fail-loud at load: a `cron` trigger must run
+`local` (it has no webhook delivery, issue/PR number, or body), and every webhook trigger runs `github`.
+
+### Scheduling recurring jobs
+
+A cron trigger runs a local folder through a flow on a cron pattern — `pattern` is a 5- or 6-field cron
+expression; `provider`, `model`, and `maxTurns` are optional on `run` and fall back to the worker's
+defaults. A cron `folder` is a **host path** — the worker runs on the host
+([`DES-WORKER-ON-HOST`](specs/design.md)) and mounts that folder into the job container, so it must be
+readable by the worker's user.
 
 ```bash
-# 1. Copy the template and edit it
 cp triggers.example.json triggers.json   # then edit the cron entry's "folder" to a REAL absolute path
-
-# 2. Point the services at it (absolute path), and restart the worker
-#    In .env:  PI_TRIGGERS_FILE=/absolute/path/to/triggers.json
+# In .env:  PI_TRIGGERS_FILE=/absolute/path/to/triggers.json
 npx pi-dispatch worker
 ```
 
-Every trigger is an `{ on, run }` pair. A cron trigger is
-`{ "on": { "type": "cron", "id", "pattern" }, "run": { "kind": "local", "folder", "flow", "task" } }`,
-where `pattern` is a 5- or 6-field cron expression; `provider`, `model`, and `maxTurns` are optional on
-`run` and fall back to the worker's defaults. A cron `folder` is a **host path** — the worker runs on the
-host ([`DES-WORKER-ON-HOST`](specs/design.md)) and mounts that folder into the job container, so it must
-be readable by the worker's user.
+Copying `triggers.example.json` verbatim makes the worker **refuse to start** with
+`configError: folder does not exist` until a cron trigger's `folder` names a real path — fail-loud on
+purpose, so a broken trigger never silently fails to fire.
 
-- **A cron trigger runs locally.** `run.kind` must be `"local"`; the loader rejects a cron trigger with
-  `run.kind:"github"` at startup — a cron trigger has no webhook delivery, issue number, or body to work.
-- **Editing `folder` is mandatory.** Copying `triggers.example.json` verbatim makes the worker **refuse
-  to start** with `configError: folder does not exist` until a cron trigger's `folder` names a real path.
-  This is fail-loud on purpose: a broken trigger never silently fails to fire.
-
-## Advanced: GitHub automation
+## GitHub automation
 
 pi-dispatch can also be triggered by GitHub — label an issue, and a container works it on a fresh clone,
 opens a PR, and comments back. A repo **webhook** drives it (set a `WEBHOOK_SECRET`), and the worker
 authenticates to GitHub via `GITHUB_AUTH_SOURCE`: `gh` (a `gh auth token`) or a repo-scoped fine-grained
 **PAT** by default. A GitHub **App is optional** — it buys stronger token scoping and is what you need
-for multi-tenant.
-
-Which labels, which comment phrase, and which pull_request actions fire a flow are configured in the same
-unified **`triggers.json`** as the cron entries above — each a `{ on, run }` pair whose `on.type` is
-`label`, `comment`, or `pull_request` and whose `run` is `{ "kind": "github", "flow" }`. The receiver
-**requires** `PI_TRIGGERS_FILE` to point at that file.
+for multi-tenant. Which labels, comment phrases, and pull_request actions fire which flow is configured in
+the same unified **`triggers.json`** above; the receiver **requires** `PI_TRIGGERS_FILE`.
 
 ```mermaid
 flowchart LR
-  GH["GitHub repo<br/>issue labeled, or @pi comment"] -->|"webhook, HMAC-signed"| R
+  GH["GitHub repo<br/>issue labeled, @pi comment, or PR"] -->|"webhook, HMAC-signed"| R
   subgraph EDGE["receiver/ — public edge, binds 0.0.0.0"]
     R["verify raw-body HMAC (401 on mismatch)<br/>filter: label allowlist, author gate, bot-loop"]
   end
@@ -270,21 +286,16 @@ flowchart LR
 - Only a collaborator's label or `@pi` comment starts a job (the label *is* the approval step).
 - Beyond labeled issues, pi-dispatch also handles **pull requests**: label a PR, comment on a PR, or fire
   automatically when a PR is opened or updated — the auto (`opened`/`synchronize`/`reopened`) path is
-  gated on the PR author being a collaborator.
+  gated on the PR author being a collaborator, so a fork PR from a stranger never auto-fires. A PR trigger
+  just runs the configured flow; the flow (a repo skill) reviews, comments, or pushes to the PR via `gh`.
 - The agent gets a **repo-scoped, short-lived token** — and, honestly: that token *can* merge, because
   GitHub gates push and merge behind the same `contents: write` scope. **Branch protection on your
   default branch is the real control**, so the worker **refuses** an unprotected repo. `SECURITY.md` has
   the detail.
-- The **admin surface** is a pi extension (`admin/`) loaded into your own interactive pi session —
-  `/dispatch` commands plus a TUI dashboard. It operates the queue (the same durable `queue.pause()` as
-  `pi-dispatch pause`), shows runs, logs, and budget, and edits runtime settings via the `settings.json`
-  overlay. It binds no port at all; its one job-triggering tool, `dispatch_run`, is folder-allowlisted,
-  flow-gated, and rate-limited. It never edits your persona (those live in your project's `.pi/`, in git,
-  reviewed) and does not edit flows this slice (deferred). See **Admin (pi extension)**.
 
 Every delivery runs the same gate before anything is queued — the signature is checked over the raw bytes
 *before* the body is parsed, and the `sender.id` bot-loop guard fires before the author check (so the
-receiver's own comments can never re-trigger a job):
+receiver's own comments, and the agent's own push to a PR head, can never re-trigger a job):
 
 ```mermaid
 flowchart TD
@@ -292,7 +303,7 @@ flowchart TD
   V -->|no| E401["401 — reject, enqueue nothing"]
   V -->|yes| S{"sender.id ==<br/>our own id?"}
   S -->|"yes"| D204a["204 — drop (bot-loop guard)"]
-  S -->|no| A{"allowlisted label,<br/>or collaborator @pi?"}
+  S -->|no| A{"allowlisted label, collaborator @pi,<br/>or collaborator-authored PR?"}
   A -->|no| D204b["204 — drop"]
   A -->|yes| EN{"enqueue to Valkey"}
   EN -->|ok| A202["202 — queued<br/>(duplicate delivery = no-op, deduped by GUID)"]
@@ -310,12 +321,12 @@ minutes.
 
 ## Status
 
-The local-folder path (image, worker, `pi-dispatch run` / `worker`), the GitHub webhook path
-(receiver → queue → clone → PR), and scheduled (cron) triggers for local folders are built and work; the
-worker runs in a terminal or as an OS service on Linux, macOS or Windows (see **Run as a service**). The
-admin surface ships as a pi extension (see **Admin (pi extension)**). The design is specified in
-[`specs/`](specs/) — start with [`specs/constitution.md`](specs/constitution.md) for the non-negotiables
-and [`specs/design.md`](specs/design.md) for the decisions and what was rejected.
+The local-folder path (image, worker, `pi-dispatch run` / `worker`), the GitHub path (receiver → queue →
+clone → PR for both issues and pull requests), and scheduled (cron) triggers for local folders are built
+and work; the worker runs in a terminal or as an OS service on Linux, macOS or Windows (see **Run as a
+service**). The admin surface ships as a pi extension (see **Admin (pi extension)**). The design is
+specified in [`specs/`](specs/) — start with [`specs/constitution.md`](specs/constitution.md) for the
+non-negotiables and [`specs/design.md`](specs/design.md) for the decisions and what was rejected.
 
 ## Contributing
 

--- a/docs/images/dispatch-commands.svg
+++ b/docs/images/dispatch-commands.svg
@@ -1,32 +1,32 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1057 461" width="1057" height="461" role="img" aria-label="pi — /dispatch commands">
-  <rect width="1057" height="461" rx="10" fill="#0d1117" stroke="#30363d"/>
-  <rect width="1057" height="34" rx="10" fill="#161b22"/>
-  <rect y="24" width="1057" height="10" fill="#161b22"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 894 485" width="894" height="485" role="img" aria-label="pi — /dispatch status · runs · triggers">
+  <rect width="894" height="485" rx="10" fill="#0d1117" stroke="#30363d"/>
+  <rect width="894" height="34" rx="10" fill="#161b22"/>
+  <rect y="24" width="894" height="10" fill="#161b22"/>
   <circle cx="20" cy="17" r="6" fill="#ff5f57"/>
   <circle cx="42" cy="17" r="6" fill="#febc2e"/>
   <circle cx="64" cy="17" r="6" fill="#28c840"/>
-  <text x="528.5" y="21" text-anchor="middle" fill="#8b949e" font-size="12" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">pi — /dispatch commands</text>
-  <g font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">
-  <text x="18" y="62.3" fill="#7ee787" xml:space="preserve">&gt; /dispatch status</text>
-  <text x="18" y="81.3" fill="#7ee787" xml:space="preserve">Queue: running</text>
-  <text x="18" y="100.3" fill="#c9d1d9" xml:space="preserve">  waiting 2  active 1  paused 0  delayed 0  failed 1</text>
-  <text x="18" y="119.3" fill="#c9d1d9" xml:space="preserve">  workers: 1</text>
-  <text x="18" y="138.3" fill="#79c0ff" xml:space="preserve">Budget: reserved 7 / cap 25 (overlay)</text>
-  <text x="18" y="157.3" fill="#c9d1d9" xml:space="preserve"></text>
-  <text x="18" y="176.3" fill="#7ee787" xml:space="preserve">&gt; /dispatch runs 4</text>
-  <text x="18" y="195.3" fill="#79c0ff" xml:space="preserve">JOB ID                                   TARGET              FLOW          OUTCOME    REASON       TURNS  ENDED</text>
-  <text x="18" y="214.3" fill="#c9d1d9" xml:space="preserve">gh-8f2e41d0-6c9a-4b7e-9d3f-2a1b0c9d8e7f  edgehero/my-app#42  backend-fix   completed  -            14     2026-07-22T09:41:03.512Z</text>
-  <text x="18" y="233.3" fill="#c9d1d9" xml:space="preserve">repeat:nightly-tidy:1784972800000        local:my-app        tidy          completed  -            9      2026-07-22T03:00:41.007Z</text>
-  <text x="18" y="252.3" fill="#c9d1d9" xml:space="preserve">gh-1b7c9a52-40de-4f11-8f6a-c3d2e1f0a9b8  edgehero/my-app#41  frontend-fix  policy     over-budget  -      2026-07-21T22:18:59.310Z</text>
-  <text x="18" y="271.3" fill="#c9d1d9" xml:space="preserve">local-3f9d2c                             local:side-project  tidy          failed     -            27     2026-07-21T20:02:17.845Z</text>
-  <text x="18" y="290.3" fill="#c9d1d9" xml:space="preserve"></text>
-  <text x="18" y="309.3" fill="#7ee787" xml:space="preserve">&gt; /dispatch triggers</text>
-  <text x="18" y="328.3" fill="#79c0ff" xml:space="preserve">Schedulers:</text>
-  <text x="18" y="347.3" fill="#c9d1d9" xml:space="preserve">  repeat:nightly-tidy  next 2026-07-23T03:00:00.000Z</text>
-  <text x="18" y="366.3" fill="#f0b72f" xml:space="preserve">  repeat:weekly-deps  next 2026-07-22T09:58:25.000Z  overdue by 95s</text>
-  <text x="18" y="385.3" fill="#c9d1d9" xml:space="preserve"></text>
-  <text x="18" y="404.3" fill="#79c0ff" xml:space="preserve">Label -&gt; flow:</text>
-  <text x="18" y="423.3" fill="#c9d1d9" xml:space="preserve">  pi:frontend -&gt; frontend-fix</text>
-  <text x="18" y="442.3" fill="#c9d1d9" xml:space="preserve">  pi:backend -&gt; backend-fix</text>
-  </g>
+  <text x="447" y="21" text-anchor="middle" fill="#8b949e" font-size="12" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">pi — /dispatch status · runs · triggers</text>
+  <text x="16" y="46" xml:space="preserve" fill="#58a6ff" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">› /dispatch status</text>
+  <text x="16" y="65" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">Queue: running</text>
+  <text x="16" y="84" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">  waiting 2  active 1  paused 0  delayed 0  failed 0</text>
+  <text x="16" y="103" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">  workers: 1</text>
+  <text x="16" y="122" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace"></text>
+  <text x="16" y="141" xml:space="preserve" fill="#58a6ff" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">› /dispatch runs</text>
+  <text x="16" y="160" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">JOB ID      TARGET        FLOW          OUTCOME    REASON    TURNS  TOKENS  COST     CHAIN  ENDED</text>
+  <text x="16" y="179" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">gh-a91f     acme/web#412  frontend-fix  completed  -         14     54330   $0.2712  -      2026-07-23T09:37Z</text>
+  <text x="16" y="198" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">gh-7c02     acme/web#409  review        completed  -         6      24020   $0.1041  -      2026-07-23T09:12Z</text>
+  <text x="16" y="217" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">local-4d8b  local:site    tidy          completed  -         9      34900   $0.1620  d1     2026-07-23T03:00Z</text>
+  <text x="16" y="236" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">gh-1e55     acme/api#88   backend-fix   no-fix     cant-fix  21     80400   $0.4015  -      2026-07-22T18:44Z</text>
+  <text x="16" y="255" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace"></text>
+  <text x="16" y="274" xml:space="preserve" fill="#58a6ff" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">› /dispatch triggers</text>
+  <text x="16" y="293" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">Schedulers:</text>
+  <text x="16" y="312" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">  repeat:nightly-tidy  next 2026-07-24T03:01:00.000Z</text>
+  <text x="16" y="331" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace"></text>
+  <text x="16" y="350" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">Triggers:</text>
+  <text x="16" y="369" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">  cron  nightly-tidy  0 3 * * * → /srv/site/tidy</text>
+  <text x="16" y="388" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">  label  any[pi:frontend] → frontend-fix</text>
+  <text x="16" y="407" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">  label  any[pi:backend] → backend-fix</text>
+  <text x="16" y="426" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">  comment  "@pi" → fix</text>
+  <text x="16" y="445" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">  pull_request  action[labeled] any[pi:review] → review</text>
+  <text x="16" y="464" xml:space="preserve" fill="#c9d1d9" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">  pull_request  action[opened,synchronize] → review</text>
 </svg>

--- a/docs/images/dispatch-dashboard.svg
+++ b/docs/images/dispatch-dashboard.svg
@@ -1,37 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1057 556" width="1057" height="556" role="img" aria-label="pi — /dispatch dashboard (live overlay)">
-  <rect width="1057" height="556" rx="10" fill="#0d1117" stroke="#30363d"/>
-  <rect width="1057" height="34" rx="10" fill="#161b22"/>
-  <rect y="24" width="1057" height="10" fill="#161b22"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 649 998" width="649" height="998" role="img" aria-label="pi — /dispatch dashboard (live overlay)">
+  <rect width="649" height="998" rx="10" fill="#0d1117" stroke="#30363d"/>
+  <rect width="649" height="34" rx="10" fill="#161b22"/>
+  <rect y="24" width="649" height="10" fill="#161b22"/>
   <circle cx="20" cy="17" r="6" fill="#ff5f57"/>
   <circle cx="42" cy="17" r="6" fill="#febc2e"/>
   <circle cx="64" cy="17" r="6" fill="#28c840"/>
-  <text x="528.5" y="21" text-anchor="middle" fill="#8b949e" font-size="12" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">pi — /dispatch dashboard (live overlay)</text>
-  <g font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">
-  <text x="18" y="62.3" fill="#79c0ff" xml:space="preserve">pi-dispatch dashboard</text>
-  <text x="18" y="81.3" fill="#c9d1d9" xml:space="preserve"></text>
-  <text x="18" y="100.3" fill="#7ee787" xml:space="preserve">Queue: running</text>
-  <text x="18" y="119.3" fill="#c9d1d9" xml:space="preserve">  waiting 2  active 1  paused 0  delayed 0  failed 1</text>
-  <text x="18" y="138.3" fill="#c9d1d9" xml:space="preserve">  workers: 1</text>
-  <text x="18" y="157.3" fill="#c9d1d9" xml:space="preserve"></text>
-  <text x="18" y="176.3" fill="#79c0ff" xml:space="preserve">Budget: reserved 7 / cap 25 (overlay)</text>
-  <text x="18" y="195.3" fill="#c9d1d9" xml:space="preserve"></text>
-  <text x="18" y="214.3" fill="#79c0ff" xml:space="preserve">JOB ID                                   TARGET              FLOW          OUTCOME    REASON       TURNS  ENDED</text>
-  <text x="18" y="233.3" fill="#c9d1d9" xml:space="preserve">gh-8f2e41d0-6c9a-4b7e-9d3f-2a1b0c9d8e7f  edgehero/my-app#42  backend-fix   completed  -            14     2026-07-22T09:41:03.512Z</text>
-  <text x="18" y="252.3" fill="#c9d1d9" xml:space="preserve">repeat:nightly-tidy:1784972800000        local:my-app        tidy          completed  -            9      2026-07-22T03:00:41.007Z</text>
-  <text x="18" y="271.3" fill="#c9d1d9" xml:space="preserve">gh-1b7c9a52-40de-4f11-8f6a-c3d2e1f0a9b8  edgehero/my-app#41  frontend-fix  policy     over-budget  -      2026-07-21T22:18:59.310Z</text>
-  <text x="18" y="290.3" fill="#c9d1d9" xml:space="preserve">local-3f9d2c                             local:side-project  tidy          failed     -            27     2026-07-21T20:02:17.845Z</text>
-  <text x="18" y="309.3" fill="#c9d1d9" xml:space="preserve"></text>
-  <text x="18" y="328.3" fill="#79c0ff" xml:space="preserve">Schedulers:</text>
-  <text x="18" y="347.3" fill="#c9d1d9" xml:space="preserve">  repeat:nightly-tidy  next 2026-07-23T03:00:00.000Z</text>
-  <text x="18" y="366.3" fill="#f0b72f" xml:space="preserve">  repeat:weekly-deps  next 2026-07-22T09:58:25.000Z  overdue by 95s</text>
-  <text x="18" y="385.3" fill="#c9d1d9" xml:space="preserve"></text>
-  <text x="18" y="404.3" fill="#79c0ff" xml:space="preserve">Settings (/tmp/pi-dispatch/settings.json):</text>
-  <text x="18" y="423.3" fill="#c9d1d9" xml:space="preserve">  model: claude-sonnet-4-5-20250929</text>
-  <text x="18" y="442.3" fill="#c9d1d9" xml:space="preserve">  provider: (unset)</text>
-  <text x="18" y="461.3" fill="#c9d1d9" xml:space="preserve">  maxTurns: (unset)</text>
-  <text x="18" y="480.3" fill="#c9d1d9" xml:space="preserve">  dailyCap: 25</text>
-  <text x="18" y="499.3" fill="#c9d1d9" xml:space="preserve">  concurrency: (unset)</text>
-  <text x="18" y="518.3" fill="#c9d1d9" xml:space="preserve"></text>
-  <text x="18" y="537.3" fill="#8b949e" xml:space="preserve">[p]ause  [r]esume  [q]uit</text>
-  </g>
+  <text x="324.5" y="21" text-anchor="middle" fill="#8b949e" font-size="12" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">pi — /dispatch dashboard (live overlay)</text>
+  <text x="16" y="46" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">┌─ pi-dispatch ──────────────────────────────────────────────────────────────┐</text>
+  <text x="16" y="65" xml:space="preserve" fill="#58a6ff" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ STATUS                                                                     │</text>
+  <text x="16" y="84" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ Queue: running                                                             │</text>
+  <text x="16" y="103" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   waiting 2  active 1  paused 0  delayed 0  failed 0                       │</text>
+  <text x="16" y="122" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   workers: 1                                                               │</text>
+  <text x="16" y="141" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">├────────────────────────────────────────────────────────────────────────────┤</text>
+  <text x="16" y="160" xml:space="preserve" fill="#58a6ff" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ SPEND                                                                      │</text>
+  <text x="16" y="179" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ Budget:                                                                    │</text>
+  <text x="16" y="198" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   day: reserved 6 / cap 25 (overlay)                                       │</text>
+  <text x="16" y="217" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   week: reserved 18 / cap 100 (overlay)                                    │</text>
+  <text x="16" y="236" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   month: reserved 40 / cap 300 (overlay)                                   │</text>
+  <text x="16" y="255" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   soft-hold band: 80%                                                      │</text>
+  <text x="16" y="274" xml:space="preserve" fill="#3fb950" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ [████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░] 6/25 │</text>
+  <text x="16" y="293" xml:space="preserve" fill="#3fb950" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ [████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░] 18/100 │</text>
+  <text x="16" y="312" xml:space="preserve" fill="#3fb950" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ [█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░] 40/300 │</text>
+  <text x="16" y="331" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">├────────────────────────────────────────────────────────────────────────────┤</text>
+  <text x="16" y="350" xml:space="preserve" fill="#58a6ff" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ TRIGGERS                                                                   │</text>
+  <text x="16" y="369" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ Schedulers:                                                                │</text>
+  <text x="16" y="388" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   repeat:nightly-tidy  next 2026-07-24T03:01:00.000Z                       │</text>
+  <text x="16" y="407" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│                                                                            │</text>
+  <text x="16" y="426" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ Triggers:                                                                  │</text>
+  <text x="16" y="445" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   cron  nightly-tidy  0 3 * * * → /srv/site/tidy                           │</text>
+  <text x="16" y="464" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   label  any[pi:frontend] → frontend-fix                                   │</text>
+  <text x="16" y="483" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   label  any[pi:backend] → backend-fix                                     │</text>
+  <text x="16" y="502" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   comment  "@pi" → fix                                                     │</text>
+  <text x="16" y="521" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   pull_request  action[labeled] any[pi:review] → review                    │</text>
+  <text x="16" y="540" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   pull_request  action[opened,synchronize] → review                        │</text>
+  <text x="16" y="559" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">├────────────────────────────────────────────────────────────────────────────┤</text>
+  <text x="16" y="578" xml:space="preserve" fill="#58a6ff" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ RUNS                                                                       │</text>
+  <text x="16" y="597" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   * ACTIVE gh-b3d7 running                                                 │</text>
+  <text x="16" y="616" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ › gh-a91f · acme/web#412 · frontend-fix · completed · 14 · 54330           │</text>
+  <text x="16" y="635" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   gh-7c02 · acme/web#409 · review · completed · 6 · 24020                  │</text>
+  <text x="16" y="654" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   local-4d8b · local:site · tidy · completed · 9 · 34900                   │</text>
+  <text x="16" y="673" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   gh-1e55 · acme/api#88 · backend-fix · no-fix · 21 · 80400                │</text>
+  <text x="16" y="692" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">├────────────────────────────────────────────────────────────────────────────┤</text>
+  <text x="16" y="711" xml:space="preserve" fill="#58a6ff" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ SETTINGS                                                                   │</text>
+  <text x="16" y="730" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ Settings (~/.pi-dispatch/settings.json):                                   │</text>
+  <text x="16" y="749" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   model: claude-sonnet-4-5-20250929                                        │</text>
+  <text x="16" y="768" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   provider: anthropic                                                      │</text>
+  <text x="16" y="787" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   maxTurns: 30                                                             │</text>
+  <text x="16" y="806" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   dailyCap: 25                                                             │</text>
+  <text x="16" y="825" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   weeklyCap: 100                                                           │</text>
+  <text x="16" y="844" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   monthlyCap: 300                                                          │</text>
+  <text x="16" y="863" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   maxTokens: (unset)                                                       │</text>
+  <text x="16" y="882" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   dailyTokenCap: (unset)                                                   │</text>
+  <text x="16" y="901" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   concurrency: 3                                                           │</text>
+  <text x="16" y="920" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│   softHoldPct: 80                                                          │</text>
+  <text x="16" y="939" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">├────────────────────────────────────────────────────────────────────────────┤</text>
+  <text x="16" y="958" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ [p]ause  [r]esume  [q]uit                                                  │</text>
+  <text x="16" y="977" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">└────────────────────────────────────────────────────────────────────────────┘</text>
 </svg>


### PR DESCRIPTION
Follows #30 (the unified `{ on, run }` triggers + `pull_request` triggers), which merged into `feat/25-token-accounting`. This carries only the docs commit; based on `feat/25` so the diff is docs-only.

## What

- **Rewrites the README lead as a real pitch** — pi-dispatch is the missing operational layer around pi (durable queue, per-job container boundary, turn budget, daily spend cap, triggers, admin panel) — with the redesigned admin dashboard as the hero image and a "Why pi-dispatch" value-prop section.
- **Regenerates the two admin-panel SVGs** (`docs/images/dispatch-dashboard.svg`, `dispatch-commands.svg`) from the **current** `admin/src/render.mjs` + `panel.mjs` output. The old images were hand-drawn mockups from #16 that predated the PR #24 dashboard redesign and the unified TRIGGERS pane, so they showed the old panel. The new ones show the framed panel, day/week/month spend meters, the `cron`/`label`/`comment`/`pull_request` trigger rows, the interactive runs list with per-job token+cost, and the settings overlay.
- **Restructures the triggers docs** around the unified `triggers.json` and documents the `pull_request` triggers (label / comment / auto-on-open, collaborator-gated).

## Note on the images

These are faithful SVGs generated from the real render output (the repo's existing screenshots were likewise hand-authored SVG terminal frames), not literal terminal captures. Frame alignment assumes the viewer's monospace font renders box-drawing/block glyphs full-cell (true on GitHub's Consolas/Menlo/ui-monospace). Swap in real PNG captures of a live `/dispatch` session anytime if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3npQvQXLWsW6qsrRMAmNL
