### PR TITLE
docs(readme): lead with the panels, cut filler, add the drill-in view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,27 @@
 # pi-dispatch
 
-**Run the [pi](https://github.com/earendil-works/pi) coding agent as a service: it opens a repo or folder
-in a locked-down container, does the work, and shuts the container down — triggered on demand, on a
-schedule, or by a GitHub issue or pull request, with a durable queue, a spend cap, and a live admin
-panel.**
-
-pi is an excellent agent. It has no job queue, no concurrency control, no spend limit, and — by its own
-README — no permission system. **pi-dispatch is exactly that missing operational layer, and nothing
-else.** Everything below the container is pi; everything above it is a few hundred reviewed lines.
-
-```
-npx pi-dispatch run ./my-project --task "dedupe the imports in src/" --flow tidy
-```
-
-> `pi-dispatch` above is `npx pi-dispatch` from this repo (a workspace bin); or `npm link` it onto your PATH.
+**Run the [pi](https://github.com/earendil-works/pi) coding agent as a service — triggered on demand, on a
+cron schedule, or by a GitHub issue or pull request — in a container you control, with a durable queue, a
+spend cap, and a live admin panel.**
 
 ![The /dispatch dashboard overlay — live queue state, day/week/month spend meters, the unified triggers pane (cron, label, comment, pull_request), and the interactive runs list, in one framed TUI](docs/images/dispatch-dashboard.svg)
 
-## Why pi-dispatch
+![Transcript of /dispatch status, runs, and triggers — queue counts, the run-history table with per-job token and cost accounting, and the unified {on,run} triggers list](docs/images/dispatch-commands.svg)
 
-- **The container is the security boundary, not a promise.** pi has no permission system, so every job
-  runs `--cap-drop=ALL`, non-root, ephemeral, `no-new-privileges`, with your instructions mounted
-  read-only — the agent cannot rewrite its own guardrails or reach your host.
-- **Spend is bounded before a container starts** — a per-job **turn budget** (pi has none of its own) and
-  a **daily cap** checked *before* any tokens are spent, so a runaway can't quietly drain your API budget.
-- **Nothing is dropped.** Fifty triggers at once become fifty durable queued jobs, drained at a fixed
-  concurrency (default 3) and surviving a reboot (Valkey with AOF).
-- **Three triggers, one job contract.** A CLI command, a **cron schedule**, or a GitHub issue/PR — each
-  produces the same job, runs through the same box, and shows up in the same panel. The scheduler is the
-  unattended one: recurring work on your own hardware — a nightly tidy, a weekly dependency bump, a docs
-  regen, a scheduled frontend visual check — the same autonomous-agent-on-a-timer idea as a hosted
-  routine, but the run happens in *your* container under *your* queue and spend caps.
-- **The container image is yours to shape.** Every job runs in your
-  [`image/Dockerfile`](image/Dockerfile) — bake in a project's exact toolchain and system libraries. It
-  already ships **Playwright + Chromium**, so a flow can build your frontend, screenshot it, and iterate
-  on the *rendered* result (before/after images attach to the PR). A hosted routine runs in a fixed
-  environment; here the box bends to the project.
-- **Your project steers the agent** using pi's native layout — `.pi/APPEND_SYSTEM.md` for the persona,
-  `.pi/skills/<name>/SKILL.md` for skills, read from your committed files. pi-dispatch ships no persona of
-  its own, only a small immutable safety floor baked into the image that your instructions add to and
-  cannot remove.
-- **A live admin panel that binds no network port** — a pi extension in your own session: watch the
-  queue, meter spend, browse every run's PII-free record, tail a running job, and pause/resume, all
-  locally with no model involvement.
+pi has no job queue, no concurrency control, no spend limit, and — by its own README — no permission
+system. **pi-dispatch is exactly that missing operational layer, and nothing else.**
 
-Drive it and read its output from the `/dispatch` overlay above, or the matching slash commands:
-
-![Transcript of /dispatch status, /dispatch runs, and /dispatch triggers in a pi session — queue counts, the run-history table with per-job token and cost accounting, and the unified {on,run} triggers list](docs/images/dispatch-commands.svg)
-
----
+- **The container is the boundary.** Every job runs `--cap-drop=ALL`, non-root, ephemeral, instructions
+  mounted read-only — pi's missing permission system, enforced by Docker.
+- **Spend is bounded before a container starts** — a per-job turn budget and a daily cap, checked before
+  a single token is spent.
+- **The image is yours to shape.** Bake a project's toolchain into [`image/Dockerfile`](image/Dockerfile);
+  it ships **Playwright + Chromium**, so a flow can build a frontend, screenshot it, and iterate on the
+  rendered result — the edge over a fixed hosted routine or `/loop`.
+- **Three triggers, one job.** A CLI command, a cron schedule, or a GitHub issue/PR — same job, same box,
+  same panel. Cron is the unattended one: recurring work on your own hardware, in an image you control.
+- **Your project steers it** — pi's native `.pi/skills` and persona, from your committed files, over a
+  small immutable safety floor the agent can't remove.
 
 ## Quickstart (local folders)
 
@@ -90,9 +63,9 @@ flowchart LR
   PI -->|"edits in place"| F[("your folder")]
 ```
 
-The three guarantees from **Why pi-dispatch** — a container boundary, spend bounded *before* a container
-starts, and nothing dropped — are exactly what this path enforces. Read [`SECURITY.md`](SECURITY.md)
-before you rely on it: it states plainly what is and is not defended.
+A container boundary, spend bounded *before* a container starts, nothing dropped — that is what this path
+enforces. Read [`SECURITY.md`](SECURITY.md) before you rely on it: it states plainly what is and is not
+defended.
 
 ## Run as a service
 
@@ -183,8 +156,12 @@ to the `"extensions"` array in `~/.pi/agent/settings.json`, or just run pi insid
 in-repo `.pi/extensions` shim auto-loads once you've trusted the project.
 
 Bare `/dispatch` opens the live dashboard overlay — one snapshot per second, `p`/`r` to pause/resume the
-queue in place, `↑`/`↓` and `Enter` to drill into a run or tail the active job. It adds `/dispatch`
-commands that run **locally, with no model involvement**:
+queue in place, `↑`/`↓` and `Enter` to drill into a run or tail the active job. `Enter` on a run opens its
+full PII-free record:
+
+![The RUN_DETAIL drill-in — a framed key/value dump of one run's record: target, flow, outcome, turns, tokens, cost, exit code, timings](docs/images/dispatch-run-detail.svg)
+
+It adds `/dispatch` commands that run **locally, with no model involvement**:
 
 - `status` — queue counts, paused state, budget; `budget` — today's spend against the daily cap
 - `pause` / `resume` — the queue on/off switch

--- a/docs/images/dispatch-run-detail.svg
+++ b/docs/images/dispatch-run-detail.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 506 447" width="506" height="447" role="img" aria-label="pi — /dispatch run detail (drill-in)">
+  <rect width="506" height="447" rx="10" fill="#0d1117" stroke="#30363d"/>
+  <rect width="506" height="34" rx="10" fill="#161b22"/>
+  <rect y="24" width="506" height="10" fill="#161b22"/>
+  <circle cx="20" cy="17" r="6" fill="#ff5f57"/>
+  <circle cx="42" cy="17" r="6" fill="#febc2e"/>
+  <circle cx="64" cy="17" r="6" fill="#28c840"/>
+  <text x="253" y="21" text-anchor="middle" fill="#8b949e" font-size="12" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">pi — /dispatch run detail (drill-in)</text>
+  <text x="16" y="46" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">┌─ run gh-a91f ────────────────────────────────────────────┐</text>
+  <text x="16" y="65" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ jobId: gh-a91f                                           │</text>
+  <text x="16" y="84" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ kind: github                                             │</text>
+  <text x="16" y="103" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ target: acme/web#412                                     │</text>
+  <text x="16" y="122" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ flow: frontend-fix                                       │</text>
+  <text x="16" y="141" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ outcome: completed                                       │</text>
+  <text x="16" y="160" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ reason: -                                                │</text>
+  <text x="16" y="179" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ turns: 14                                                │</text>
+  <text x="16" y="198" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ tokens: 54330                                            │</text>
+  <text x="16" y="217" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ cost: $0.2712                                            │</text>
+  <text x="16" y="236" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ exitCode: 0                                              │</text>
+  <text x="16" y="255" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ budgetReserved: 1                                        │</text>
+  <text x="16" y="274" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ attempt: 0                                               │</text>
+  <text x="16" y="293" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ chainDepth: -                                            │</text>
+  <text x="16" y="312" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ parentJobId: -                                           │</text>
+  <text x="16" y="331" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ chainRefused: -                                          │</text>
+  <text x="16" y="350" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ startedAt: 2026-07-23T09:23:11.004Z                      │</text>
+  <text x="16" y="369" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ endedAt: 2026-07-23T09:37:02.881Z                        │</text>
+  <text x="16" y="388" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">├──────────────────────────────────────────────────────────┤</text>
+  <text x="16" y="407" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">│ Esc back                                                 │</text>
+  <text x="16" y="426" xml:space="preserve" fill="#8b949e" font-size="13" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">└──────────────────────────────────────────────────────────┘</text>
+</svg>


### PR DESCRIPTION
Follow-up to the docs that landed via #31/#32. This commit was pushed to `feat/25` after #32 merged, so it needs its own PR to reach `main`. Docs-only, clean single-commit diff.

## What

- **Restructures the README top** so the redesigned admin panels lead: the dashboard and command-transcript images now sit directly under a one-line pitch (no code block or note in front of them), and the six verbose "Why" bullets collapse to five one-liners.
- **Adds the RUN_DETAIL drill-in screenshot** (`docs/images/dispatch-run-detail.svg`) to the Admin section, generated from the current `admin/src/render.mjs` + `panel.mjs` — so the redesigned panel's interactivity (Enter on a run → its full PII-free record) is shown, not just described.

All three panel images (dashboard, run-detail, command transcript) render from the current post-redesign code; the old pre-redesign mockups are fully replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3npQvQXLWsW6qsrRMAmNL
