### PR TITLE
chore(promo): publishable pi-package for the operator extension + launch kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ npx pi-dispatch worker       # (or: npm --workspace worker start)
 npx pi-dispatch run ./my-project --task "add type hints to utils.py" --flow tidy
 ```
 
+> **Heads-up on the CLI name.** `pi-dispatch` here is *this repo's* workspace CLI (`worker/src/cli.mjs`),
+> which `npx` resolves from the local `node_modules/.bin` after `npm ci` — run these from the repo root. It
+> is **not** the unrelated npm package `pi-dispatch` (see [License](#license)); this project isn't published
+> to npm. If a shell can't find the local bin, use the explicit form:
+> `node worker/src/cli.mjs run ./my-project --task "…" --flow tidy`.
+
 The worker picks up the job, mounts your folder into a container, and pi edits it **in place**. It
 refuses a dirty git working tree unless you pass `--force`, because there is no undo — point it at
 folders you can restore, and commit first.

--- a/admin/README.md
+++ b/admin/README.md
@@ -1,0 +1,33 @@
+# @edgehero/pi-dispatch-admin
+
+The **operator console** for [**pi-dispatch**](https://github.com/edgehero/pi-dispatch) — a
+[pi](https://github.com/earendil-works/pi) extension that adds a `/dispatch` command (a live TUI overlay +
+model-callable tools) for running the pi coding agent as a self-hosted service.
+
+> This is a **companion** to a running pi-dispatch deployment. It reads that deployment's Valkey queue and
+> run-history — install it in your own pi, alongside the pi-dispatch service. On its own it will show
+> "queue unreachable".
+
+## What it gives you
+
+- A `/dispatch` overlay: live queue state, day/week/month **spend meters** + a daily token counter, run
+  history with per-job token & cost, and a unified **triggers** pane (cron / label / comment / pull_request).
+- **Editable** triggers and **scheduled pause windows** ("quiet hours" per folder/repo), applied live.
+- **Confirm-gated** model tools so an agent can operate the deployment (change limits, manage triggers/pauses)
+  with **a human approving each change** — fail-closed when no operator is present.
+- The bundled `operate-pi-dispatch` **skill** documenting those human-in-the-loop gates.
+
+## Install
+
+```bash
+pi install npm:@edgehero/pi-dispatch-admin
+```
+
+Then run pi and use `/dispatch`. Point it at your deployment with `VALKEY_URL` / `PI_LOGS_DIR` /
+`PI_SETTINGS_FILE` / `PI_TRIGGERS_FILE` / `PI_PAUSE_WINDOWS_FILE` (the same values your pi-dispatch worker uses).
+
+## The service
+
+The queue, worker, container image, and GitHub receiver live in the main repo:
+**https://github.com/edgehero/pi-dispatch** — start there. MIT. Read
+[`SECURITY.md`](https://github.com/edgehero/pi-dispatch/blob/main/SECURITY.md) before you rely on it.

--- a/admin/build.mjs
+++ b/admin/build.mjs
@@ -1,0 +1,30 @@
+/**
+ * Bundle the operator extension into a single self-contained `dist/index.mjs` for publishing as a pi-package.
+ *
+ * The admin extension imports ~10 `@pi-dispatch/worker` subpaths (a private workspace); esbuild INLINES those
+ * local `.mjs` files so the published package has no `@pi-dispatch/*` dependency. The pi runtime is
+ * host-provided (a peerDependency) and `bullmq`/`ioredis` are heavy real deps kept EXTERNAL and declared in
+ * package.json; everything else — the admin's own files, the inlined worker internals, and `typebox` — is
+ * bundled in. `import.meta.url` is preserved (esm), so the extension's `../skills` resolution still points at
+ * the shipped `skills/` dir (dist/ and skills/ sit side by side in the published tarball).
+ */
+import { build } from "esbuild";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+await build({
+	entryPoints: [join(here, "src/index.ts")],
+	outfile: join(here, "dist/index.mjs"),
+	bundle: true,
+	format: "esm",
+	platform: "node",
+	target: "node22",
+	// Host-provided peer + heavy runtime deps stay external (declared in package.json). typebox is bundled.
+	external: ["@earendil-works/pi-coding-agent", "bullmq", "ioredis"],
+	banner: { js: "// pi-dispatch operator extension (bundled). Source: https://github.com/edgehero/pi-dispatch" },
+	logLevel: "info",
+});
+
+console.log("[built admin/dist/index.mjs]");

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,16 +1,53 @@
 {
-  "name": "@pi-dispatch/admin",
+  "name": "@edgehero/pi-dispatch-admin",
   "version": "0.1.0",
-  "private": true,
+  "description": "Operator console (a pi extension) + skill for the pi-dispatch self-hosted agent service: a /dispatch TUI for queue, spend, run history, triggers, and scheduled pause windows. Runs against a live pi-dispatch deployment.",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-coding-agent",
+    "coding-agent",
+    "extension"
+  ],
+  "license": "MIT",
+  "author": "Rob Boerman",
+  "homepage": "https://github.com/edgehero/pi-dispatch/tree/main/admin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/edgehero/pi-dispatch.git",
+    "directory": "admin"
+  },
+  "bugs": "https://github.com/edgehero/pi-dispatch/issues",
   "type": "module",
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "pi": {
+    "extensions": [
+      "./dist/index.mjs"
+    ],
+    "skills": [
+      "./skills"
+    ],
+    "image": "https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/dispatch-dashboard.svg"
+  },
   "scripts": {
+    "build": "node build.mjs",
+    "prepublishOnly": "node build.mjs",
     "test": "node --test \"test/*.test.mjs\""
   },
   "dependencies": {
-    "@pi-dispatch/worker": "*",
-    "typebox": "1.1.38"
+    "bullmq": "5.80.4",
+    "ioredis": "5.11.1"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "0.80.7"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.80.7"
+    "@earendil-works/pi-coding-agent": "0.80.7",
+    "@pi-dispatch/worker": "*",
+    "esbuild": "^0.28.1",
+    "typebox": "1.1.38"
   }
 }

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,67 @@
+# Recording the demo (GIF / video)
+
+The `/dispatch` panel is the hook — a short recording of it is worth more than any paragraph. This is the
+recipe; it needs a real terminal, so it's yours to run (the panel can't be driven headless). Two options:
+[`vhs`](https://github.com/charmbracelet/vhs) (scripted, reproducible, best for a clean GIF) or
+[`asciinema`](https://asciinema.org) + [`agg`](https://github.com/asciinema/agg) (records a real session).
+
+## What to show (≈ 20–30s)
+
+1. `pi -e admin/src/index.ts` then `/dispatch` — the live panel: status header, spend meters, triggers,
+   pause windows, runs.
+2. `↵` on a trigger → the MATCHES / RUNS / TRUST MODEL drill-in.
+3. `↵` on a run → the colored post-mortem.
+4. (optional) `w` → add a pause window; watch the PAUSES row flip to `● paused · resumes in …`.
+5. `q` to close.
+
+Run against a deployment with a little state (a couple of triggers, a finished run or two) so the panel isn't
+empty — start the stack (`docker compose -f deploy/docker-compose.yml up -d`), queue one local job, let it
+finish, then record.
+
+## Option A — vhs (recommended for a crisp GIF)
+
+`brew install vhs` (or see its README). Save as `docs/demo.tape`:
+
+```tape
+# docs/demo.tape
+Output docs/images/dispatch-demo.gif
+Set FontSize 15
+Set Width 1200
+Set Height 760
+Set Theme "Dracula"
+Set Padding 16
+
+Hide
+Type "pi -e admin/src/index.ts"  Enter
+Sleep 3s
+Show
+
+Type "/dispatch"  Enter
+Sleep 3s
+Down Sleep 500ms   Enter  Sleep 3s   Escape Sleep 1s   # a trigger drill-in
+Down Down Down Down Down Down  Enter  Sleep 3s  Escape Sleep 1s   # a run post-mortem
+Type "q"
+Sleep 1s
+```
+
+Then: `vhs docs/demo.tape` → produces `docs/images/dispatch-demo.gif`.
+
+## Option B — asciinema + agg (records a real session)
+
+```bash
+asciinema rec docs/dispatch-demo.cast --cols 120 --rows 40
+#   ... do the walkthrough above, then exit the shell (Ctrl-D) ...
+agg --font-size 15 --theme dracula docs/dispatch-demo.cast docs/images/dispatch-demo.gif
+```
+
+An `.cast` file can also be uploaded to asciinema.org and embedded (autoplaying) in the README.
+
+## Where the output goes
+
+- **README**: add the GIF near the top, under the existing SVG panel images.
+- **Social preview** (GitHub → Settings → General → Social preview): export a single crisp PNG frame of the
+  panel — reuse `docs/images/dispatch-dashboard.svg` rendered to PNG until the GIF exists.
+- **pi.dev gallery card**: set `pi.video` (a hosted `.mp4`/`.gif` URL) or `pi.image` in the extension package's
+  `package.json` (see the packaging steps) so the listing shows the panel.
+
+Keep the file small (< ~3 MB): trim to ~25s, cap width at ~1200px, and prefer the GIF for GitHub autoplay.

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -1,0 +1,205 @@
+<!--
+Launch copy for pi-dispatch. Drafts to copy-paste and post. Every claim here traces to the README /
+SECURITY.md / the code — keep it that way when you edit. Be honest about maturity (v0.x, solo-maintained,
+self-host, read SECURITY.md); overclaiming burns a launch faster than underclaiming.
+
+Repo: https://github.com/edgehero/pi-dispatch
+Not distributed via npm (the name `pi-dispatch` is an unrelated package). Link the GitHub repo everywhere.
+-->
+
+# pi-dispatch — launch kit
+
+## The one-liner
+
+> Run the [pi](https://github.com/earendil-works/pi) coding agent as a service — on demand, on a cron, or on
+> a GitHub issue/PR — in a container you control, with a durable queue and a spend cap.
+
+## The elevator pitch (3 sentences)
+
+pi is a minimal coding agent with no queue, no concurrency control, no spend limit, and — by its own README —
+no permission system. pi-dispatch is exactly that missing operational layer: every job runs in an ephemeral
+`--cap-drop=ALL` non-root container (pi's missing permissions, enforced by Docker), spend is bounded *before*
+a container starts (per-job turn budget + a daily cap), and the same job runs whether you trigger it from the
+CLI, a cron schedule, or a GitHub issue. You bake your own toolchain into the image (it ships Playwright +
+Chromium, so a flow can build a frontend, screenshot it, and iterate on the render), and a live `/dispatch`
+admin panel shows the queue, spend meters, run history, and triggers.
+
+---
+
+## Show HN
+
+**Title** (≤ 80 chars):
+`Show HN: pi-dispatch – run the pi coding agent as a self-hosted service`
+
+**Body:**
+```
+pi (github.com/earendil-works/pi) is a minimal coding-agent CLI. It has no job queue, no
+concurrency control, no spend limit, and — by its own README — no permission system. I kept
+wanting to run it *unattended* — on a cron, on GitHub issues, on my own hardware — and every
+one of those gaps is a reason you can't.
+
+pi-dispatch is the operational layer that closes them, and nothing else:
+
+- The container is the boundary. Every job runs in an ephemeral --cap-drop=ALL, non-root,
+  no-new-privileges container; the agent's instructions are mounted read-only. That's pi's
+  missing permission system, enforced by Docker.
+- Spend is bounded BEFORE a container starts — a per-job turn budget and a daily cap (plus
+  week/month ceilings and a soft-hold band) checked before a single token is spent.
+- Three triggers, one job: a CLI command, a cron schedule, or a GitHub issue/PR — same queue,
+  same box, same budget. Cron is the unattended one.
+- Your image, your tools. Bake a project's toolchain into the Dockerfile; it ships Playwright +
+  Chromium so a flow can build a frontend, screenshot it, and iterate on the rendered result.
+- A live admin panel (a pi extension): queue state, day/week/month spend meters, run history
+  with per-job token+cost accounting, and editable triggers — plus per-repo "quiet hours" that
+  defer runs between certain times and resume automatically.
+
+I've tried to be honest about the threat model rather than hand-wave it: the whole thing runs
+untrusted, adversarial input through an unrestricted agent on purpose, so SECURITY.md states
+plainly what is and isn't defended (short version: the trust model is the same as a GitHub
+Action — whoever can merge to your default branch can instruct the agent).
+
+It's MIT, solo-maintained, v0.x, self-hosted (needs Docker + Node 22.19 + a provider key).
+Feedback very welcome, especially on the security model.
+
+https://github.com/edgehero/pi-dispatch
+```
+
+*Posting tips: post Tue–Thu ~8–10am ET; reply to every comment for the first few hours; don't seed upvotes
+(HN detects it). Lead the top comment with the honest threat-model paragraph — it's your credibility.*
+
+---
+
+## pi community (Discord / GitHub Discussions) + showcase submission
+
+pi has a Discord, GitHub Discussions on earendil-works/pi, and a package/showcase directory at pi.dev. This
+is the warmest, highest-intent audience — start here, before the cold channels.
+
+**Discord / Discussions post:**
+```
+Built a thing on top of pi some of you might want: pi-dispatch — a harness to run pi as a
+*service* (on-demand / cron / GitHub issue) with the operational bits pi deliberately leaves
+out: a durable Valkey+BullMQ queue, a container-per-job boundary (--cap-drop=ALL, non-root),
+and a spend cap checked before any container starts.
+
+The admin side is itself a pi extension: a /dispatch command + overlay (queue, spend meters,
+run history, editable triggers) and confirm-gated tools so an agent can operate the deployment
+with a human approving each change. Newest bit: per-repo scheduled pause windows ("quiet hours")
+that defer runs between certain times via BullMQ moveToDelayed and auto-resume.
+
+Repo: https://github.com/edgehero/pi-dispatch — feedback and pokes at the security model welcome.
+```
+
+**pi.dev showcase / packages submission:** publish the operator extension as a scoped `pi-package` (see
+`docs/demo.md` + the packaging steps) so it appears in the gallery, and — if pi maintains a showcase list
+(OpenClaw, etc.) — open an issue/PR on earendil-works/pi proposing pi-dispatch as an integration entry.
+
+---
+
+## X / Twitter thread
+
+*(tag the pi / earendil accounts; attach the /dispatch panel image)*
+
+```
+1/ pi is a great minimal coding agent. But it has no queue, no spend limit, and no permission
+system — so you can't really run it *unattended*.
+
+pi-dispatch is the missing operational layer. Run pi as a service: on-demand, on a cron, or on a
+GitHub issue. 🧵
+
+2/ The container is the boundary.
+Every job → an ephemeral --cap-drop=ALL, non-root container, instructions mounted read-only.
+That's pi's missing permission system, enforced by Docker.
+
+3/ Spend is bounded BEFORE a container starts.
+A per-job turn budget + a daily cap (plus week/month + a soft-hold band), checked before a single
+token is spent. A runaway costs you a refusal, not a bill.
+
+4/ Your image, your tools.
+Bake the toolchain into the Dockerfile — it ships Playwright + Chromium, so a flow can build a
+frontend, screenshot it, and iterate on the render.
+
+5/ A live admin panel (itself a pi extension): queue, day/week/month spend meters, run history w/
+per-job token+cost, editable triggers, and per-repo "quiet hours" that pause runs between certain
+times and auto-resume. [image]
+
+6/ MIT, self-hosted, v0.x. Honest about the threat model (SECURITY.md). Built on @earendil pi.
+https://github.com/edgehero/pi-dispatch
+```
+
+---
+
+## Reddit (r/selfhosted, r/LocalLLaMA)
+
+**Title:** `pi-dispatch: run a coding agent unattended on your own hardware, with a spend cap and container isolation`
+
+**Body:**
+```
+I wanted to run a coding agent (pi) on a cron and on GitHub issues without (a) it running loose
+with my shell's permissions or (b) waking up to a surprise API bill. pi-dispatch is the harness
+that makes that safe-ish and boring:
+
+- One ephemeral container per job (--cap-drop=ALL, non-root); the agent can't reach the host
+  outside two declared mounts.
+- Spend capped before a container even starts (per-job + daily/weekly/monthly).
+- Durable queue (Valkey + BullMQ) so a burst or a reboot doesn't drop jobs.
+- Bring your own Docker image (Playwright/Chromium included for frontend work).
+- A TUI admin panel for queue/spend/runs/triggers, plus per-repo scheduled pause windows.
+
+Self-hosted, MIT, needs Docker + Node 22.19 + a provider key. Threat model is written down
+honestly in SECURITY.md (it's the GitHub-Actions trust model: whoever can merge can instruct it).
+
+https://github.com/edgehero/pi-dispatch
+```
+*r/selfhosted dislikes anything that smells like an ad — keep it first-person, lead with the self-host angle,
+and engage in comments.*
+
+---
+
+## Blog post outline (dev.to / personal blog)
+
+Working title: **"Giving a coding agent an off-switch: containers, spend caps, and quiet hours"**
+
+1. **The gap.** pi (and most agent CLIs) assume a human is watching. No queue, no spend limit, no permission
+   system. What breaks when you try to run one unattended.
+2. **The container is the boundary.** Why `--cap-drop=ALL` + non-root + ephemeral is the honest answer to "no
+   permission system," and why per-*job* (not per-session) isolation matters against mutually-untrusting issue
+   authors. (Screenshot: the security section.)
+3. **Spend before tokens.** The one ordering that makes a cap real: check-and-increment *before* the container,
+   not after the bill. Day/week/month windows + a soft-hold band.
+4. **Quiet hours without dropping work.** The scoped pause-window design: defer a repo's runs with BullMQ's
+   `moveToDelayed` *before* the budget reservation, so a paused job costs nothing and auto-resumes — vs.
+   dropping it (which loses a GitHub job that has no re-trigger). Timezone-correct via built-in `Intl`.
+5. **An agent that can operate itself, safely.** Confirm-gated tools: the model proposes a change (raise a cap,
+   add a trigger), a human approves a dialog it can't answer. Why "operator-approved" beats "no tool at all"
+   here, and why it's fail-closed without a human.
+6. **What I got wrong / what's not defended.** Link SECURITY.md's honest list. Invite scrutiny.
+
+---
+
+## GitHub Release notes (draft — for `gh release create vX.Y.Z`)
+
+**Title:** `v0.2.0 — admin panel, AI-operable controls, scoped pause windows`
+
+```
+The operational layer, filled in.
+
+Admin
+- A theme-colored /dispatch TUI panel (a pi extension): live queue, day/week/month spend meters +
+  a daily token counter, run history with per-job token & cost, and a unified triggers pane.
+- Trigger CRUD (cron / label / comment / pull_request) from the overlay, applied live (no restart).
+
+AI-operable, safely
+- Confirm-gated model tools: an agent can change limits and manage triggers/pause windows, but every
+  write pops an operator confirmation dialog it can't answer — fail-closed without a human.
+- Bundled `operate-pi-dispatch` skill documenting the human-in-the-loop gates.
+
+Scheduled pause windows (quiet hours)
+- Pause a folder's or repo's runs between certain times (recurring daily, with weekday + date-range
+  bounds and a per-window IANA timezone) and resume automatically. Deferred via BullMQ, never dropped,
+  at zero budget cost.
+
+Docs & safety
+- Expanded SECURITY.md threat model; specs/ (constitution/requirements/design/interfaces) kept in lockstep.
+
+Self-hosted, MIT. Needs Docker + Node ≥ 22.19 + a provider API key. See the README quickstart.
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,13 +19,20 @@
       }
     },
     "admin": {
-      "name": "@pi-dispatch/admin",
+      "name": "@edgehero/pi-dispatch-admin",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
-        "@pi-dispatch/worker": "*",
-        "typebox": "1.1.38"
+        "bullmq": "5.80.4",
+        "ioredis": "5.11.1"
       },
       "devDependencies": {
+        "@earendil-works/pi-coding-agent": "0.80.7",
+        "@pi-dispatch/worker": "*",
+        "esbuild": "^0.28.1",
+        "typebox": "1.1.38"
+      },
+      "peerDependencies": {
         "@earendil-works/pi-coding-agent": "0.80.7"
       }
     },
@@ -2360,6 +2367,452 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "node_modules/@edgehero/pi-dispatch-admin": {
+      "resolved": "admin",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
@@ -2780,10 +3233,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@pi-dispatch/admin": {
-      "resolved": "admin",
-      "link": true
-    },
     "node_modules/@pi-dispatch/receiver": {
       "resolved": "receiver",
       "link": true
@@ -3170,6 +3619,48 @@
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/extend": {


### PR DESCRIPTION
Promotion prep — the three deliverables agreed, plus a repo-hardening note.

## The honest reframe
pi-dispatch is a **service**, not a `pi install`-able extension — so it doesn't belong in pi.dev/packages as a whole. What *does*: the **admin panel** (a real pi extension) + the **operate-pi-dispatch skill**, packaged as an operator companion that funnels to this repo. Two verified facts drove the plan:
- The npm name `pi-dispatch` is **taken** (an unrelated, deprecated package) → any distribution needs a **scoped** name.
- pi.dev/packages lists npm packages tagged **`keywords:["pi-package"]`** with a `pi` manifest.

## 1 — pi.dev/packages listing (the bundle)
- `admin/build.mjs`: esbuild bundles the extension into a self-contained `dist/index.mjs`, **inlining the ~10 `@pi-dispatch/worker` internals** (bullmq/ioredis/pi kept external). Smoke-tested: the bundle loads natively and registers every tool + the `resources_discover` skill path resolves.
- `admin/package.json`: publishable **`@edgehero/pi-dispatch-admin`** — un-private, `keywords:["pi-package"]`, the `pi` manifest (extensions + skills + a gallery image), `files:["dist","skills"]`, `prepublishOnly` build, runtime deps + the pi peer. `npm publish --dry-run` packs exactly `dist/` + `skills/` + `README` (4 files, 60 KB).
- `admin/README.md`: the npm/gallery page (clearly a companion to a running deployment).

## 2 — Launch-blocker fix
- `README.md`: a heads-up that the quickstart `pi-dispatch` is this repo's **local workspace CLI** (resolved by `npx` after `npm ci`), **not** the unrelated npm package — removes the outside-the-repo footgun.

## 3 — Launch kit (copy) + demo recipe
- `docs/launch-kit.md`: ready-to-post drafts — Show HN, pi Discord/showcase, X thread, Reddit, a blog outline, and Release notes. Each honest about v0.x maturity.
- `docs/demo.md`: a `vhs`/`asciinema` recipe to record the `/dispatch` panel GIF.

## Also: `main` is now branch-protected
Applied per request (and per `SECURITY.md`, which flags an unprotected default branch as a full-compromise vector): PRs required with 1 approving review, stale-review dismissal, conversation-resolution, no force-push/deletion. `enforce_admins:false` so a solo admin can still bypass-merge, while the agent's per-job non-admin token cannot.

## Yours to do (not automatable)
- Own the `@edgehero` npm scope + `npm publish` (I've set it up + dry-run'd it).
- Record the demo GIF; set GitHub topics/About/social-preview; cut a Release (notes drafted in `docs/launch-kit.md`).
- Post the launch copy + submit to the pi showcase.

`dist/` stays gitignored; `prepublishOnly` builds it. Independent of #35 (pause windows) — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)