### PR TITLE
ci(release): add the auto-publish + AI-release workflow (stranded off #36)

### DIFF
--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -1,0 +1,45 @@
+/**
+ * AI-written GitHub Release notes for `@edgehero/pi-dispatch-admin`.
+ *
+ * Reads the commit list (COMMITS), the version (VERSION), and the key (ANTHROPIC_API_KEY) from the
+ * environment, asks Claude for concise, grouped Markdown notes, and prints them to stdout. Exits NON-ZERO on
+ * any failure so the release workflow falls back to a plain commit list — a missing key or a flaky API never
+ * blocks the release. Model is overridable via RELEASE_MODEL (default: a current Sonnet).
+ */
+const key = process.env.ANTHROPIC_API_KEY;
+const commits = (process.env.COMMITS || "").trim();
+const version = process.env.VERSION || "";
+const model = process.env.RELEASE_MODEL || "claude-sonnet-5";
+
+if (!key) { console.error("release-notes: ANTHROPIC_API_KEY not set"); process.exit(1); }
+if (!commits) { console.error("release-notes: no commits provided"); process.exit(1); }
+
+const prompt = [
+	`Write GitHub Release notes in Markdown for \`@edgehero/pi-dispatch-admin\` ${version} — the operator`,
+	`extension (a pi coding-agent extension) for the pi-dispatch self-hosted agent service.`,
+	`Group changes under short bold headings (e.g. **Features**, **Fixes**, **Docs**) where relevant, as terse`,
+	`user-facing bullet points — not a raw commit dump. Drop chore/CI-only noise. No title line, no preamble.`,
+	``,
+	`Commits since the last release:`,
+	commits,
+].join("\n");
+
+let res;
+try {
+	res = await fetch("https://api.anthropic.com/v1/messages", {
+		method: "POST",
+		headers: { "content-type": "application/json", "x-api-key": key, "anthropic-version": "2023-06-01" },
+		body: JSON.stringify({ model, max_tokens: 1200, messages: [{ role: "user", content: prompt }] }),
+	});
+} catch (err) {
+	console.error("release-notes: request failed:", err?.message ?? err);
+	process.exit(1);
+}
+if (!res.ok) {
+	console.error("release-notes: HTTP", res.status, (await res.text()).slice(0, 300));
+	process.exit(1);
+}
+const data = await res.json();
+const text = data?.content?.find?.((b) => b.type === "text")?.text;
+if (!text) { console.error("release-notes: no text in response"); process.exit(1); }
+process.stdout.write(`${text.trim()}\n`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+# Publish @edgehero/pi-dispatch-admin and cut a GitHub Release when its version changes on main.
+#
+# main is branch-protected (PR + 1 approving review required), so a push here is an already-approved merge —
+# the human gate is the merge, not this workflow (consistent with CONST-MERGE-NEVER-AUTOMATIC: nothing here
+# merges anything). Publishing is idempotent: it fires only when admin/package.json's version is not already
+# on npm, so re-runs, reverts, and unrelated pushes are no-ops. Bump the version in your PR to ship a release.
+#
+# Required repo secret: NPM_TOKEN — an npm *automation* (or granular, "bypass 2FA") token that can publish to
+#   the @edgehero scope. Interactive 2FA cannot run in CI; the token is how publishing works here.
+# Optional repo secret: ANTHROPIC_API_KEY — enables AI-written release notes; without it, the release falls
+#   back to a plain commit list. Optional repo variable: RELEASE_MODEL (default: claude-sonnet-5).
+
+name: release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "admin/**"
+      - ".github/workflows/release.yml"
+      - ".github/scripts/release-notes.mjs"
+  # Manual re-run (available once this file is on the default branch): re-runs are safe — publish/release
+  # skip when the version is already on npm / the tag exists.
+  workflow_dispatch: {}
+
+permissions:
+  contents: write # create tags + releases
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history for the release-notes commit range
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.19"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install
+        run: npm ci
+
+      - name: Test the package being shipped
+        run: npm run test --workspace admin
+
+      - name: Resolve version + decide publish/release
+        id: v
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          V=$(node -p "require('./admin/package.json').version")
+          NAME=$(node -p "require('./admin/package.json').name")
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          if npm view "$NAME@$V" version >/dev/null 2>&1; then
+            echo "publish=no" >> "$GITHUB_OUTPUT"; echo "$NAME@$V already on npm — skip publish"
+          else
+            echo "publish=yes" >> "$GITHUB_OUTPUT"
+          fi
+          if gh release view "v$V" >/dev/null 2>&1; then
+            echo "release=no" >> "$GITHUB_OUTPUT"; echo "release v$V already exists — skip release"
+          else
+            echo "release=yes" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.v.outputs.publish == 'yes'
+        run: npm publish --workspace admin --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build release notes
+        if: steps.v.outputs.release == 'yes'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RELEASE_MODEL: ${{ vars.RELEASE_MODEL }}
+        run: |
+          PREV=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          RANGE=${PREV:+$PREV..HEAD}
+          COMMITS=$(git log $RANGE --no-merges --pretty=format:'- %s' -- admin/ | head -n 60)
+          if [ -n "$ANTHROPIC_API_KEY" ] && COMMITS="$COMMITS" VERSION="v${{ steps.v.outputs.version }}" \
+               node .github/scripts/release-notes.mjs > /tmp/notes.md 2>/tmp/notes.err; then
+            echo "release notes: AI-written"
+          else
+            echo "release notes: AI unavailable ($(head -n1 /tmp/notes.err 2>/dev/null)) — using commit list"
+            { echo "### Changes"; echo; printf '%s\n' "$COMMITS"; } > /tmp/notes.md
+          fi
+
+      - name: Create GitHub Release
+        if: steps.v.outputs.release == 'yes'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.v.outputs.version }}" \
+            --title "v${{ steps.v.outputs.version }} — pi-dispatch operator extension" \
+            --notes-file /tmp/notes.md


### PR DESCRIPTION
## Why
#36 was merged at its **first** commit (`429e582`), *before* I'd pushed the release workflow — so `main` got the packaging (`@edgehero/pi-dispatch-admin`, the esbuild bundle, the `pi` manifest, docs) **but not the automation that publishes it**. That's why the package isn't on npm and no `release` run exists. This PR lands the two stranded files.

## What
- `.github/workflows/release.yml` — on a push to `main` (an approved merge; `main` is branch-protected), tests the admin package and, when `admin/package.json`'s version isn't on npm yet, **publishes `--access public`** and cuts a **GitHub Release with AI-written notes**. Idempotent (skips if the version/tag already exists); `workflow_dispatch` allows manual re-runs.
- `.github/scripts/release-notes.mjs` — asks Claude to summarize the commit range into grouped Markdown; falls back to a plain commit list if `ANTHROPIC_API_KEY` is unset.

## Merging this **is** the first publish
The workflow fires on its own merge and builds the bundle **from `main`** — which now has 13 tools including pause windows (#35) — so it publishes a **complete `0.1.0`**, not the 10-tool branch build. Watch the **Actions → release** run:
- ✅ green → live on npm (`pi install npm:@edgehero/pi-dispatch-admin`) + will surface on pi.dev/packages; a `v0.1.0` GitHub Release is cut.
- ❌ red at *Publish to npm* → the `NPM_TOKEN` secret isn't a valid **automation / bypass-2FA** token with write on `@edgehero`. Fix it and re-run via **Run workflow** — no dummy commit needed.

Both secrets (`NPM_TOKEN`, `ANTHROPIC_API_KEY`) are already set. Non-token mechanics are verified locally: bundle builds + loads + registers all tools, the notes script runs, the YAML parses.

After this: the release loop is **bump `admin/package.json` version in a PR → merge → auto-publish + auto-release**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)