### PR TITLE
docs(pause): document scoped pause windows (quiet hours) across the repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ PI_JOB_IMAGE=pi-job:latest          # the image you built:  docker build -f imag
 # PI_LOG_RETENTION_DAYS=            # default 30; boot-time prune of logs older than N days; 0 = keep forever
 # PI_TRIGGERS_FILE=                 # ABSOLUTE path to the unified triggers.json, read by BOTH worker and receiver (a relative path resolves against the service's WorkingDirectory).
                                     # Unset = cron disabled for the worker; the receiver REQUIRES it (it holds the label/comment/pull_request trigger config)
+# PI_PAUSE_WINDOWS_FILE=            # ABSOLUTE path to pause-windows.json — "quiet hours" per folder/repo (pause runs between certain times/days/dates, auto-resume). Unset = feature off. See docs/pause-windows.md
 # PI_SETTINGS_FILE=                 # ABSOLUTE path to the runtime settings overlay (default: OS temp /pi-dispatch/settings.json); edited by the admin extension, read by the worker per job
 PI_SCHEDULER_STALL_MAX=2            # tear down a scheduler after N consecutive stalls (money backstop)
 # PI_DISPATCH_RUN_ROOTS=            # OS-path-delimited allowlist (; on Windows, : elsewhere) of folders the model-callable dispatch_run may target; default empty = fail-closed (dispatch_run refuses every folder until you opt in)

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@ coverage/
 /triggers.json
 !triggers.example.json
 
+# Scoped pause windows ("quiet hours"). pause-windows.example.json is the template;
+# deploy/pause-windows.json is the deployed default (empty). See docs/pause-windows.md.
+/pause-windows.json
+!pause-windows.example.json
+
 # Python — bytecode and tool caches from the skill scripts under .claude/skills/
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -267,6 +267,30 @@ Copying `triggers.example.json` verbatim makes the worker **refuse to start** wi
 `configError: folder does not exist` until a cron trigger's `folder` names a real path — fail-loud on
 purpose, so a broken trigger never silently fails to fire.
 
+## Quiet hours — scoped pause windows
+
+Pause a **specific folder or repo's** runs *between certain times* — recurring daily, optionally restricted to
+certain weekdays or a date range, in a timezone of your choice — and resume automatically. Unlike
+`pi-dispatch pause` (which stops the **whole** queue, untimed), a pause window is per-scope and scheduled, and
+a paused job is **deferred, not dropped**: it waits in the queue and runs once the window ends. The check
+happens **before** the budget reservation, so a deferred job spends nothing and counts nothing against the cap.
+
+Copy `pause-windows.example.json` and point `PI_PAUSE_WINDOWS_FILE` at it (unset = off); the worker validates
+it at boot and live-reloads edits:
+
+```json
+{ "windows": [
+  { "scope": "acme/web",  "from": "22:00", "to": "06:00", "tz": "Europe/Amsterdam",
+    "days": ["mon","tue","wed","thu","fri"] },
+  { "scope": "/srv/site", "from": "09:00", "to": "17:00", "dateFrom": "2026-08-10", "dateTo": "2026-08-14" }
+] }
+```
+
+`scope` is a repo `"owner/name"`, a local folder path, or `"*"` for all; `from > to` is an overnight window;
+`days`/`dateFrom`/`dateTo` gate the day the window starts. Manage windows by editing the file, in the panel
+(`/dispatch` → `w`), or through the confirm-gated `dispatch_pause_add`/`_delete` tools. Full field reference
+and more examples: **[`docs/pause-windows.md`](docs/pause-windows.md)**.
+
 ## GitHub automation
 
 pi-dispatch can also be triggered by GitHub — label an issue, and a container works it on a fresh clone,

--- a/docs/pause-windows.md
+++ b/docs/pause-windows.md
@@ -1,0 +1,112 @@
+# Quiet hours — scoped pause windows
+
+Pause a **specific folder or repo's** runs *between certain times* — recurring daily, restricted to certain
+weekdays or a date range, in a timezone of your choice — and resume automatically after. A paused job is
+**deferred, never dropped**: it waits in the queue and runs once the window ends.
+
+This is distinct from the global pause (`pi-dispatch pause` / `/dispatch` `p`), which stops the **whole**
+queue with no schedule. Scoped pause windows are per-scope and timed, and the two compose — a scope can be
+inside a pause window while the rest of the queue keeps draining.
+
+## Enable it
+
+Point `PI_PAUSE_WINDOWS_FILE` at a JSON file. Unset = the feature is off.
+
+```bash
+# .env
+PI_PAUSE_WINDOWS_FILE=/absolute/path/to/pause-windows.json
+```
+
+```json
+{
+  "windows": [
+    { "scope": "acme/web", "from": "22:00", "to": "06:00", "tz": "Europe/Amsterdam" }
+  ]
+}
+```
+
+The worker validates the file at boot (a malformed file **refuses startup**, fail-loud) and **live-reloads**
+it on change — an edit takes effect on the next job without a restart, and a bad edit keeps the last-good
+windows. The `deploy/pause-windows.json` in this repo is an empty template (`{ "windows": [] }`).
+
+## The window schema
+
+| Field | Required | Meaning |
+|---|---|---|
+| `scope` | **yes** | What the window applies to: a **repo** `"owner/name"` (github jobs), a **folder** host path (local/cron jobs), or `"*"` for **all** scopes. Matched exactly. |
+| `from` | **yes** | Pause **start**, `"HH:MM"` 24-hour. |
+| `to` | **yes** | Resume time, `"HH:MM"` 24-hour. If `from > to` the window is **overnight** (spans midnight). `from == to` is rejected — a 24h pause isn't expressible; remove the trigger instead. |
+| `tz` | no (default `UTC`) | IANA timezone, e.g. `"Europe/Amsterdam"`, `"America/New_York"`. `from`/`to` are that zone's wall clock, DST-correct. |
+| `days` | no (default: every day) | Weekday allow-list, e.g. `["mon","tue","wed","thu","fri"]`. Gates the day the window **starts** — an overnight window that starts on an allowed day still runs into the next morning. |
+| `dateFrom` | no | Inclusive `"YYYY-MM-DD"`: the window applies only on/after this **start** date. |
+| `dateTo` | no | Inclusive `"YYYY-MM-DD"`: only on/before this start date. |
+
+## Examples
+
+**Daytime freeze (same-day window)** — pause a repo 09:00–17:00 UTC:
+```json
+{ "scope": "acme/web", "from": "09:00", "to": "17:00" }
+```
+
+**Overnight quiet hours** — pause a folder every night 22:00 → 06:00 in Amsterdam time (`from > to` = overnight):
+```json
+{ "scope": "/srv/site", "from": "22:00", "to": "06:00", "tz": "Europe/Amsterdam" }
+```
+
+**Weeknights only** — the overnight window, but only when it *starts* on a weekday:
+```json
+{ "scope": "acme/web", "from": "22:00", "to": "06:00", "tz": "Europe/Amsterdam",
+  "days": ["mon","tue","wed","thu","fri"] }
+```
+
+**A change-freeze between dates** — no runs for `acme/api`, all day, across a release window:
+```json
+{ "scope": "acme/api", "from": "00:00", "to": "23:59", "dateFrom": "2026-08-10", "dateTo": "2026-08-14" }
+```
+
+**Everything, on weekends** — pause all scopes on Saturday/Sunday nights:
+```json
+{ "scope": "*", "from": "20:00", "to": "08:00", "days": ["sat","sun"] }
+```
+
+**Multiple windows** — they're independent; a job is paused if it falls inside *any* matching window, and held until the latest one ends:
+```json
+{ "windows": [
+  { "scope": "acme/web", "from": "22:00", "to": "06:00", "tz": "Europe/Amsterdam" },
+  { "scope": "/srv/site", "from": "09:00", "to": "17:00" }
+] }
+```
+
+## How it works
+
+- **Deferred, not dropped.** When a job is picked up and its scope is inside an active window, the worker moves
+  it to the queue's **delayed** set until the window ends (via BullMQ's `moveToDelayed`), then it runs
+  automatically. It keeps its identity (so GitHub delivery-GUID dedup still holds) and survives a worker restart.
+- **Zero cost while paused.** The check runs **before** the budget reservation, so a deferred job reserves no
+  spend slot and counts nothing against your daily/weekly/monthly caps — a deferral is not a job start.
+- **Timezone-correct.** Wall-clock times are resolved in the window's `tz` using the runtime's built-in
+  timezone data (DST-correct), with no extra dependency.
+
+## Managing windows
+
+Three equivalent ways — all write the same validated file and take effect live:
+
+1. **Edit the file.** Change `pause-windows.json`; the worker hot-reloads it (keeps the last-good set on a bad edit).
+2. **In the panel.** Open `/dispatch`, press `w` → add or delete a window through operator dialogs. The
+   **PAUSES** section shows each window as `●` paused (with a resume countdown) or `○` open.
+3. **From an agent, human-gated.** The model tools `dispatch_pause_add` / `dispatch_pause_delete` (and the
+   read-only `dispatch_pauses`) let an agent manage windows — but each write **pops an operator confirmation
+   the model can't answer**, and is refused when no operator is present.
+
+## Caveats
+
+- A window edited or removed **while a job is already delayed** doesn't re-time that job — it wakes at its
+  original window-end and the gate re-checks then. (You can also promote delayed jobs manually via the queue.)
+- `from == to` is rejected on purpose. To pause a scope indefinitely, remove its trigger rather than express a
+  24-hour window.
+
+## Reference
+
+The internal specs: `REQ-SCOPED-PAUSE-WINDOWS` ([requirements](../specs/requirements.md)),
+`DES-SCOPED-PAUSE-VIA-MOVE-TO-DELAYED` ([design](../specs/design.md)),
+`INT-PAUSE-WINDOWS-FILE-CONTRACT` ([interfaces](../specs/interfaces.md)).

--- a/pause-windows.example.json
+++ b/pause-windows.example.json
@@ -1,0 +1,6 @@
+{
+  "windows": [
+    { "scope": "acme/web", "from": "22:00", "to": "06:00", "tz": "Europe/Amsterdam", "days": ["mon", "tue", "wed", "thu", "fri"] },
+    { "scope": "/srv/site", "from": "09:00", "to": "17:00" }
+  ]
+}


### PR DESCRIPTION
The scoped pause-windows feature (#35 — pause a **folder/repo between certain times, days, and dates**, and resume automatically) shipped with internal specs but almost no operator-facing docs (a single line in the admin README). This adds them.

## Added
- **`docs/pause-windows.md`** — the full guide: enable via `PI_PAUSE_WINDOWS_FILE`, the window **schema** (`scope`, `from`/`to`, `tz`, `days`, `dateFrom`/`dateTo`) with the exact rules, and worked **examples** for every shape — daytime freeze, overnight quiet hours (`from > to`), weeknights-only, a between-dates change-freeze, all-scopes (`*`), and multiple windows. Plus **how it works** (deferred not dropped, checked *before* budget so it costs nothing, timezone-correct), the **three ways to manage** windows (edit the file / `/dispatch` → `w` / the confirm-gated `dispatch_pause_add`/`_delete` tools), and the caveats.
- **README** — a *"Quiet hours — scoped pause windows"* section beside Triggers, with a quick example and a link to the guide.
- **`.env.example`** — `PI_PAUSE_WINDOWS_FILE`.
- **`pause-windows.example.json`** — a validated copy-paste template, mirroring `triggers.example.json`; `.gitignore` keeps the operator's real `pause-windows.json` out of git.

## Notes
- Every field/rule is sourced from `worker/src/pause-windows.mjs` (the shared validator), and the example template is verified to parse.
- **Docs only** — no code touched, nothing under `admin/**`, so it won't trigger a republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)