### PR TITLE
feat(admin): edit an existing pause window (dispatch_pause_edit + w dialog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ it at boot and live-reloads edits:
 
 `scope` is a repo `"owner/name"`, a local folder path, or `"*"` for all; `from > to` is an overnight window;
 `days`/`dateFrom`/`dateTo` gate the day the window starts. Manage windows by editing the file, in the panel
-(`/dispatch` → `w`), or through the confirm-gated `dispatch_pause_add`/`_delete` tools. Full field reference
+(`/dispatch` → `w` → add / edit / delete), or through the confirm-gated
+`dispatch_pause_add`/`_edit`/`_delete` tools. Full field reference
 and more examples: **[`docs/pause-windows.md`](docs/pause-windows.md)**.
 
 ## GitHub automation

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable triggers (cron/label/comment/PR), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/admin/skills/operate-pi-dispatch/SKILL.md
+++ b/admin/skills/operate-pi-dispatch/SKILL.md
@@ -30,9 +30,10 @@ dialog before it takes effect**:
 - `dispatch_set` — change a limit/setting (e.g. `dailyCap`, `weeklyCap`, `maxTurns`, `model`). Omit `value`
   to unset.
 - `dispatch_trigger_add` / `dispatch_trigger_edit` / `dispatch_trigger_delete` — manage triggers.
-- `dispatch_pause_add` / `dispatch_pause_delete` — manage scheduled pause windows (per folder/repo "quiet
-  hours": runs for a scope are deferred between certain times and auto-resume after; `dispatch_pauses` lists
-  them). Deferring never drops a job and costs no budget.
+- `dispatch_pause_add` / `dispatch_pause_edit` / `dispatch_pause_delete` — manage scheduled pause windows
+  (per folder/repo "quiet hours": runs for a scope are deferred between certain times and auto-resume after;
+  `dispatch_pauses` lists them with their index). `dispatch_pause_edit` is a partial change — pass the index
+  plus only the fields to alter. Deferring never drops a job and costs no budget.
 
 Use them like this:
 

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -446,6 +446,56 @@ function registerTools(pi: ExtensionAPI): void {
   });
 
   pi.registerTool({
+    name: "dispatch_pause_edit",
+    label: "pi-dispatch edit pause window",
+    description:
+      "Changes fields of an existing pause window (by array index from dispatch_pauses) and applies it live. " +
+      "Provide only the fields to change (scope/from/to/tz/days/dateFrom/dateTo); the rest keep their current " +
+      "value. The operator MUST approve a confirm dialog showing the before->after; refused with no interactive " +
+      "operator.",
+    executionMode: "sequential",
+    parameters: Type.Object({
+      index: Type.Integer({ minimum: 0 }),
+      scope: Type.Optional(Type.String()),
+      from: Type.Optional(Type.String()),
+      to: Type.Optional(Type.String()),
+      tz: Type.Optional(Type.String()),
+      days: Type.Optional(Type.Array(Type.String())),
+      dateFrom: Type.Optional(Type.String()),
+      dateTo: Type.Optional(Type.String()),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const paths = resolvePaths(process.env);
+      const p = readPauseWindows({ pauseWindowsPath: paths.pauseWindowsPath });
+      const list = Array.isArray(p?.windows) ? p.windows : [];
+      const cur = list[params.index];
+      if (!cur) throw new Error(`no pause window at index ${params.index} (have ${list.length})`);
+      // A provided field replaces; an omitted one keeps the current value (?? treats undefined as "keep").
+      // Rebuild through the shared builder so the result is validated the same way as an add.
+      const before = buildPauseWindow(cur);
+      const merged = buildPauseWindow({
+        scope: params.scope ?? cur.scope,
+        from: params.from ?? cur.from,
+        to: params.to ?? cur.to,
+        tz: params.tz ?? cur.tz,
+        days: params.days ?? cur.days,
+        dateFrom: params.dateFrom ?? cur.dateFrom,
+        dateTo: params.dateTo ?? cur.dateTo,
+      });
+      const result = await confirmedWrite(
+        ctx,
+        { title: `Edit pause window #${params.index + 1}`, message: `pause window #${params.index + 1}:\n${JSON.stringify(before)}\n→ ${JSON.stringify(merged)}` },
+        () => {
+          const res = writePauseWindows({ pauseWindowsPath: paths.pauseWindowsPath, mutate: (l: any[]) => l.map((w, i) => (i === params.index ? merged : w)) });
+          if (res.invalid) throw new Error(`rejected: ${res.invalid}`);
+          return { applied: true, index: params.index, window: merged };
+        },
+      );
+      return toolText(JSON.stringify(result));
+    },
+  });
+
+  pi.registerTool({
     name: "dispatch_trigger_delete",
     label: "pi-dispatch delete trigger",
     description:
@@ -742,11 +792,12 @@ export async function handleDashboardAction(result: any, paths: any, ctx: any): 
   }
 }
 
-/** Pause-window management: pick add or delete, then run the matching dialog. Keeps one overlay key (`w`). */
+/** Pause-window management: pick add / edit / delete, then run the matching dialog. One overlay key (`w`). */
 async function managePausesViaDialogs(paths: any, ui: any, notify: Notify): Promise<void> {
-  const action = await ui.select("Pause windows", ["Add a pause window", "Delete a pause window"]);
+  const action = await ui.select("Pause windows", ["Add a pause window", "Edit a pause window", "Delete a pause window"]);
   if (!action) return;
   if (action.startsWith("Add")) return addPauseWindowViaDialogs(paths, ui, notify);
+  if (action.startsWith("Edit")) return editPauseWindowViaDialogs(paths, ui, notify);
   return deletePauseWindowViaDialogs(paths, ui, notify);
 }
 
@@ -769,6 +820,48 @@ async function addPauseWindowViaDialogs(paths: any, ui: any, notify: Notify): Pr
   const w = buildPauseWindow({ scope, from, to, tz, days, dateFrom, dateTo });
   const res = writePauseWindows({ pauseWindowsPath: paths.pauseWindowsPath, mutate: (list: any[]) => [...list, w] });
   notify?.(res.ok ? `pause window added (live) — ${w.scope} ${w.from}-${w.to}` : `add rejected: ${res.invalid}`, res.ok ? "info" : "error");
+}
+
+/** Edit a pause window: select which, then re-prompt each field with its current value — a blank answer keeps
+ * it, so you only re-type what you change. Validated + live through the same `writePauseWindows`. */
+async function editPauseWindowViaDialogs(paths: any, ui: any, notify: Notify): Promise<void> {
+  const p = readPauseWindows({ pauseWindowsPath: paths.pauseWindowsPath });
+  const list: any[] = Array.isArray(p?.windows) ? p.windows : [];
+  if (list.length === 0) { notify?.("no pause windows to edit", "info"); return; }
+  const labels = list.map((w, i) => `#${i + 1}  ${w.scope}  ${w.from}-${w.to} ${w.tz}${w.days ? ` [${w.days.join(",")}]` : ""}`);
+  const picked = await ui.select("Edit which pause window", labels);
+  if (!picked) return;
+  const index = labels.indexOf(picked);
+  if (index < 0) return;
+  const cur = list[index];
+  // Each field's current value is the placeholder; a blank answer keeps it (undefined = the operator cancelled).
+  const ask = async (label: string, current: string) => ui.input(`${label} — blank keeps "${current}"`, current);
+  const keep = (v: string | undefined, current: any) => (v === undefined || v.trim() === "" ? current : v);
+  const scope = await ask("scope", cur.scope ?? "");
+  if (scope === undefined) return;
+  const from = await ask("from (HH:MM)", cur.from ?? "");
+  if (from === undefined) return;
+  const to = await ask("to (HH:MM)", cur.to ?? "");
+  if (to === undefined) return;
+  const tz = await ask("tz (IANA / UTC)", cur.tz ?? "UTC");
+  if (tz === undefined) return;
+  const days = await ask("days (space-separated)", (cur.days ?? []).join(" "));
+  if (days === undefined) return;
+  const dateFrom = await ask("dateFrom (YYYY-MM-DD)", cur.dateFrom ?? "");
+  if (dateFrom === undefined) return;
+  const dateTo = await ask("dateTo (YYYY-MM-DD)", cur.dateTo ?? "");
+  if (dateTo === undefined) return;
+  const merged = buildPauseWindow({
+    scope: keep(scope, cur.scope),
+    from: keep(from, cur.from),
+    to: keep(to, cur.to),
+    tz: keep(tz, cur.tz),
+    days: keep(days, cur.days),
+    dateFrom: keep(dateFrom, cur.dateFrom),
+    dateTo: keep(dateTo, cur.dateTo),
+  });
+  const res = writePauseWindows({ pauseWindowsPath: paths.pauseWindowsPath, mutate: (l: any[]) => l.map((w, i) => (i === index ? merged : w)) });
+  notify?.(res.ok ? `pause window #${index + 1} updated (live) — ${merged.scope} ${merged.from}-${merged.to}` : `edit rejected: ${res.invalid}`, res.ok ? "info" : "error");
 }
 
 /** Delete a pause window: select which (by a scope/time label), confirm, remove. */

--- a/admin/test/crud.test.mjs
+++ b/admin/test/crud.test.mjs
@@ -301,3 +301,43 @@ test("managePauses: Delete removes the picked window on confirm", async () => {
   await handleDashboardAction({ action: "managePauses" }, { pauseWindowsPath: path }, { ui });
   assert.deepEqual(read(path).windows.map((w) => w.scope), ["*"], "only the picked window is removed");
 });
+
+test("dispatch_pause_edit: an approved partial edit changes one field and keeps the rest", async () => {
+  const path = tmpPauses({ windows: [{ scope: "acme/web", from: "22:00", to: "06:00", tz: "Europe/Amsterdam", days: ["mon", "tue"] }] });
+  const { ctx, shown } = toolCtx({ answer: true });
+  const out = textOf(await toolByName("dispatch_pause_edit").execute("id", { index: 0, to: "07:00" }, undefined, undefined, ctx));
+  assert.equal(out.applied, true);
+  const w = read(path).windows[0];
+  assert.equal(w.to, "07:00", "the changed field");
+  assert.equal(w.from, "22:00", "unchanged field kept");
+  assert.equal(w.tz, "Europe/Amsterdam", "unchanged field kept");
+  assert.deepEqual(w.days, ["mon", "tue"], "unchanged field kept");
+  assert.match(shown[0].message, /06:00/);
+  assert.match(shown[0].message, /07:00/);
+});
+
+test("dispatch_pause_edit: out-of-range index throws and writes nothing", async () => {
+  const path = tmpPauses({ windows: [{ scope: "acme/web", from: "22:00", to: "06:00" }] });
+  const { ctx } = toolCtx({ answer: true });
+  await assert.rejects(() => toolByName("dispatch_pause_edit").execute("id", { index: 9, to: "07:00" }, undefined, undefined, ctx), /no pause window at index/);
+  assert.equal(read(path).windows[0].to, "06:00");
+});
+
+test("dispatch_pause_edit: refuses with no interactive operator and writes nothing", async () => {
+  const path = tmpPauses({ windows: [{ scope: "acme/web", from: "22:00", to: "06:00" }] });
+  const { ctx } = toolCtx({ hasUI: false });
+  await assert.rejects(() => toolByName("dispatch_pause_edit").execute("id", { index: 0, to: "07:00" }, undefined, undefined, ctx), /refused|interactive operator/);
+  assert.equal(read(path).windows[0].to, "06:00");
+});
+
+test("managePauses: Edit re-prompts fields (blank keeps) and updates the picked window", async () => {
+  const path = tmpPauses({ windows: [{ scope: "acme/web", from: "22:00", to: "06:00", tz: "Europe/Amsterdam" }] });
+  // pick the window, then blank-keep scope/from, change `to`, blank-keep tz/days/dateFrom/dateTo.
+  const ui = mockUi({ select: ["Edit a pause window", "#1  acme/web  22:00-06:00 Europe/Amsterdam"], input: ["", "", "07:00", "", "", "", ""] });
+  await handleDashboardAction({ action: "managePauses" }, { pauseWindowsPath: path }, { ui });
+  const w = read(path).windows[0];
+  assert.equal(w.to, "07:00", "the changed field");
+  assert.equal(w.from, "22:00", "kept");
+  assert.equal(w.tz, "Europe/Amsterdam", "kept");
+  assert.ok(ui.notes.some((n) => /updated \(live\)/.test(n.m)), "a live-updated notice is shown");
+});

--- a/admin/test/wiring.test.mjs
+++ b/admin/test/wiring.test.mjs
@@ -121,15 +121,16 @@ test("an unknown subcommand notifies and never touches the model channel", async
  * writes cannot interleave. This test is the deliberate record that model-callable writes were added on
  * purpose -- gated by an operator confirm (behaviour proven in crud.test.mjs), not tool absence.
  */
-const WRITE_TOOLS = ["dispatch_set", "dispatch_trigger_add", "dispatch_trigger_edit", "dispatch_trigger_delete", "dispatch_pause_add", "dispatch_pause_delete"];
+const WRITE_TOOLS = ["dispatch_set", "dispatch_trigger_add", "dispatch_trigger_edit", "dispatch_trigger_delete", "dispatch_pause_add", "dispatch_pause_edit", "dispatch_pause_delete"];
 test("registers exactly the read/control/enqueue/write tools, and never a raw-log tool", async () => {
   const { calls } = await loadRegistered();
   const names = calls.registerTool.map((t) => t.name).sort();
-  assert.equal(calls.registerTool.length, 13, "exactly thirteen tools");
+  assert.equal(calls.registerTool.length, 14, "exactly fourteen tools");
   assert.deepEqual(names, [
     "dispatch_pause",
     "dispatch_pause_add",
     "dispatch_pause_delete",
+    "dispatch_pause_edit",
     "dispatch_pauses",
     "dispatch_resume",
     "dispatch_run",

--- a/docs/pause-windows.md
+++ b/docs/pause-windows.md
@@ -92,11 +92,14 @@ windows. The `deploy/pause-windows.json` in this repo is an empty template (`{ "
 Three equivalent ways — all write the same validated file and take effect live:
 
 1. **Edit the file.** Change `pause-windows.json`; the worker hot-reloads it (keeps the last-good set on a bad edit).
-2. **In the panel.** Open `/dispatch`, press `w` → add or delete a window through operator dialogs. The
-   **PAUSES** section shows each window as `●` paused (with a resume countdown) or `○` open.
-3. **From an agent, human-gated.** The model tools `dispatch_pause_add` / `dispatch_pause_delete` (and the
-   read-only `dispatch_pauses`) let an agent manage windows — but each write **pops an operator confirmation
-   the model can't answer**, and is refused when no operator is present.
+2. **In the panel.** Open `/dispatch`, press `w` → **add, edit, or delete** a window through operator
+   dialogs. Editing re-prompts each field with its current value, so a blank answer keeps it and you only
+   re-type what changes. The **PAUSES** section shows each window as `●` paused (with a resume countdown)
+   or `○` open.
+3. **From an agent, human-gated.** The model tools `dispatch_pause_add` / `dispatch_pause_edit` /
+   `dispatch_pause_delete` (and the read-only `dispatch_pauses`) let an agent manage windows — edit is a
+   **partial** change (pass only the fields to alter; the rest keep their value) — but each write **pops an
+   operator confirmation the model can't answer**, and is refused when no operator is present.
 
 ## Caveats
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",


### PR DESCRIPTION
Quiet hours were fully panel-managed for **view / add / delete** but not **in-place edit** — triggers have edit (`e` / `dispatch_trigger_edit`), pause windows didn't, so changing a window's times/days meant delete + re-add. This closes that gap.

## What
- **`dispatch_pause_edit`** (confirm-gated, `sequential`) — a **partial** edit by array index: pass only the fields to change (`scope`/`from`/`to`/`tz`/`days`/`dateFrom`/`dateTo`), the rest keep their current value. The confirm shows `before → after`; refused with no interactive operator. Rebuilds through the shared `buildPauseWindow`, so the result is validated exactly like an add.
- **Overlay** — `/dispatch` → `w` now offers **Add / Edit / Delete**. "Edit" re-prompts each field with its current value; a blank answer keeps it, so you only re-type what changes.
- Same human-in-the-loop gate as every other write: the model can propose the edit, only a human approves it.

## Docs (you asked for README clarity)
- `docs/pause-windows.md` "Managing windows" and the main README quiet-hours line now say **add / edit / delete** and describe the partial-edit behaviour.
- The bundled `operate-pi-dispatch` skill lists `dispatch_pause_edit`.

## Tests
- wiring tripwire → **14 tools**; new crud tests cover partial-edit-keeps-the-rest, out-of-range throws, no-UI refuses, and the "Edit" dialog. **admin 171 pass.**

Bumped to **`0.1.3`** → the release workflow republishes on merge. `main` is clean at `0.1.2` (no other version PRs open), so no merge-order coordination needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)