### PR TITLE
feat: easier install — pi-dispatch init + doctor, prebuilt GHCR image, and clearer 'add the panel via pi' docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,15 @@
 # Copy to .env and fill in. Never commit a real .env (it is gitignored).
 
-# --- Provider credential (required) ---
+# --- Provider credential ---
 # pi supports ~30 providers; set the key for the one you use, under the variable name pi expects.
 # The worker forwards ONLY the configured provider's key into the job container -- nothing else.
 #   Anthropic: ANTHROPIC_API_KEY  (or ANTHROPIC_OAUTH_TOKEN, which takes precedence)
 #   OpenAI:    OPENAI_API_KEY     Google: GEMINI_API_KEY     Groq: GROQ_API_KEY   ... etc.
+# You can LEAVE THIS BLANK if you are already logged into pi: when the env has no key, the worker reads the
+# API key from ~/.pi/agent/auth.json (host-side) and env-injects it -- on by default, nothing to set.
+# API-key logins only; an OAuth/subscription login is refused (it expires; use an API key for a service).
 ANTHROPIC_API_KEY=
-# Already logged into pi and don't want to restate the key here? Set PI_AUTH_FROM_PI=1 and the worker
-# reads the API key from ~/.pi/agent/auth.json (host-side) and env-injects it. API-key logins only —
-# an OAuth/subscription login is refused (it expires; use an API key for an unattended service).
-# PI_AUTH_FROM_PI=
+# PI_AUTH_FROM_PI=0   # uncomment to force env-only (fail loudly on a missing env key instead of using your pi login)
 
 # --- Which provider/model to run by default (override per job with --provider / --model) ---
 PI_PROVIDER=anthropic

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@
 #   Anthropic: ANTHROPIC_API_KEY  (or ANTHROPIC_OAUTH_TOKEN, which takes precedence)
 #   OpenAI:    OPENAI_API_KEY     Google: GEMINI_API_KEY     Groq: GROQ_API_KEY   ... etc.
 ANTHROPIC_API_KEY=
+# Already logged into pi and don't want to restate the key here? Set PI_AUTH_FROM_PI=1 and the worker
+# reads the API key from ~/.pi/agent/auth.json (host-side) and env-injects it. API-key logins only —
+# an OAuth/subscription login is refused (it expires; use an API key for an unattended service).
+# PI_AUTH_FROM_PI=
 
 # --- Which provider/model to run by default (override per job with --provider / --model) ---
 PI_PROVIDER=anthropic

--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ PI_CONCURRENCY=3       # how many jobs run in parallel
 
 # --- Infrastructure ---
 VALKEY_URL=redis://127.0.0.1:6379
-PI_JOB_IMAGE=pi-job:latest          # the image you built:  docker build -f image/Dockerfile -t pi-job:latest .
+PI_JOB_IMAGE=pi-job:latest          # docker pull ghcr.io/edgehero/pi-job:latest && docker tag ghcr.io/edgehero/pi-job:latest pi-job:latest  (or build image/Dockerfile)
 # PI_JOBS_DIR=                      # where per-job /job inputs live (default: your OS temp dir)
 # PI_LOGS_DIR=                      # where per-job status records (and optional raw logs) land (default: OS temp /pi-dispatch/logs)
 # PI_CAPTURE_JOB_LOGS=              # default 0; set 1 to ALSO write raw container output to logs/<jobId>.log -- PII-bearing (issue/comment text), host-only (never mounted into the container), off by default (opt-in)

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,12 @@ PI_JOB_IMAGE=pi-job:latest          # docker pull ghcr.io/edgehero/pi-job:latest
                                     # Unset = cron disabled for the worker; the receiver REQUIRES it (it holds the label/comment/pull_request trigger config)
 # PI_PAUSE_WINDOWS_FILE=            # ABSOLUTE path to pause-windows.json — "quiet hours" per folder/repo (pause runs between certain times/days/dates, auto-resume). Unset = feature off. See docs/pause-windows.md
 # PI_SETTINGS_FILE=                 # ABSOLUTE path to the runtime settings overlay (default: OS temp /pi-dispatch/settings.json); edited by the admin extension, read by the worker per job
+
+# --- Reuse your existing pi setup in every job (see docs/global-pi-overlay.md) ---
+# PI_GLOBAL_PI_DIR=                  # dir with your host pi setup (models.json/skills/APPEND_SYSTEM.md), mounted /opt/pi-global:ro into every job, layered UNDER each repo's .pi/. Unset = off. Stage it with: pi-dispatch import-pi
+# PI_GLOBAL_ALLOW_EXTENSIONS=       # set 1 to LOAD the overlay's extensions (default off). They run code against adversarial input with open egress — vet each; never the admin extension.
+# PI_FORWARD_ENV=                   # comma-separated extra env var NAMES to forward into the container (e.g. a CUSTOM provider's key). Explicit allowlist, not a pass-through.
+
 PI_SCHEDULER_STALL_MAX=2            # tear down a scheduler after N consecutive stalls (money backstop)
 # PI_DISPATCH_RUN_ROOTS=            # OS-path-delimited allowlist (; on Windows, : elsewhere) of folders the model-callable dispatch_run may target; default empty = fail-closed (dispatch_run refuses every folder until you opt in)
 # PI_DISPATCH_RUN_PER_HOUR=3       # per-hour cap on model-invoked dispatch_run enqueues; 0 disables the tool

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,68 @@
+# Build and publish the pi-dispatch job image to GHCR so operators `docker pull` instead of the slow local
+# build (Chromium + Playwright + fonts, minutes). main is branch-protected (PR + 1 approving review), so a
+# push here is an already-approved merge — nothing in this workflow merges anything (CONST-MERGE-NEVER-AUTOMATIC).
+#
+# The pushed image is a snapshot of THIS repo's runner + guardrails at the built commit. Operators who bake
+# their own toolchain into image/Dockerfile still build locally; the pull is only the fast default path.
+#
+# No secret required: GHCR auth uses the built-in GITHUB_TOKEN (packages: write). One-time after the first
+# successful run: make the ghcr.io/edgehero/pi-job package Public in the org's package settings, otherwise
+# `docker pull` needs auth.
+
+name: image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "image/**"
+      - ".github/workflows/image.yml"
+  # Manual re-run (available once this file is on the default branch).
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write # push to ghcr.io/edgehero/*
+
+concurrency:
+  group: image
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/edgehero/pi-job
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3 # arm64 emulation for the multi-arch build
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest
+            type=sha
+
+      - name: Build + push (amd64 + arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: . # repo root — the Dockerfile copies image/runner + guardrails from here
+          file: image/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ docker compose -f deploy/docker-compose.yml up -d
 npm ci
 npx pi-dispatch init         # writes .env + triggers.json + pause-windows.json (never clobbers)
 #    edit .env — set ANTHROPIC_API_KEY (or your provider's key)
-#    already logged into pi? set PI_AUTH_FROM_PI=1 instead and it reuses the key from ~/.pi/agent/auth.json
+#    already logged into pi? leave it blank — the worker reuses the key from ~/.pi/agent/auth.json by default
 npx pi-dispatch doctor       # ✓/✗ preflight: Docker, Valkey, the image, and your provider key
 
 # 4. Run the worker in one terminal
@@ -104,12 +104,12 @@ the safety floor always first and unremovable. `import-pi` **refuses** a `models
 separately (`--with-extensions` + `PI_GLOBAL_ALLOW_EXTENSIONS=1`) because they run code against adversarial
 input; the admin extension is hard-blocked. Full reference: [`docs/global-pi-overlay.md`](docs/global-pi-overlay.md).
 
-**Already logged into pi and don't want to restate the key?** Set `PI_AUTH_FROM_PI=1`. When the provider key
-is absent from the worker's environment, the worker reads it **host-side** from `~/.pi/agent/auth.json` and
-env-injects it into the job — a host-side read of a host-held secret, never a file mounted into the container.
-**API-key logins only**: an OAuth/subscription login (`pi login`) is refused — those tokens expire and can't
-be refreshed in the container, and a subscription isn't the credential for an unattended service; use an API
-key with a spend limit.
+**Already logged into pi? The key just works — by default.** When the provider key is absent from the
+worker's environment, the worker reads it **host-side** from `~/.pi/agent/auth.json` and env-injects it into
+the job — a host-side read of a host-held secret, never a file mounted into the container. Nothing to set;
+`PI_AUTH_FROM_PI=0` forces env-only if you'd rather fail loudly on a missing env key. **API-key logins only**:
+an OAuth/subscription login (`pi login`) is refused — those tokens expire and can't be refreshed in the
+container, and a subscription isn't the credential for an unattended service; use an API key with a spend limit.
 
 ## Run as a service
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ A container boundary, spend bounded *before* a container starts, nothing dropped
 enforces. Read [`SECURITY.md`](SECURITY.md) before you rely on it: it states plainly what is and is not
 defended.
 
+## Reuse your existing pi setup
+
+Already run `pi`? Give every job your host setup — custom models, global skills, a global persona — **layered
+under each repo's own `.pi/`** (the repo still wins). Works with the pulled image; it's a read-only mount, not
+a rebuild.
+
+```bash
+pi-dispatch import-pi          # stage a credential-free copy of ~/.pi/agent into ./pi-global
+# then set PI_GLOBAL_PI_DIR=/abs/path/to/pi-global in .env, and:
+pi-dispatch doctor             # verifies the overlay carries no credential
+```
+
+The overlay is mounted `/opt/pi-global:ro` into every container. Skills merge with the repo's (a repo skill
+of the same name overrides the global one); the prompt layers `guardrails → global persona → repo persona`,
+the safety floor always first and unremovable. `import-pi` **refuses** a `models.json` with a literal key and
+**never** copies `auth.json` — your credential stays in the environment. Extensions are opt-in and armed
+separately (`--with-extensions` + `PI_GLOBAL_ALLOW_EXTENSIONS=1`) because they run code against adversarial
+input; the admin extension is hard-blocked. Full reference: [`docs/global-pi-overlay.md`](docs/global-pi-overlay.md).
+
 ## Run as a service
 
 `pi-dispatch worker` is a long-running process — run it in a terminal, or hand it to your OS's service

--- a/README.md
+++ b/README.md
@@ -32,15 +32,19 @@ system. **pi-dispatch is exactly that missing operational layer, and nothing els
 You need **Docker** and **Node ≥ 22.19**, and a provider API key (e.g. Anthropic).
 
 ```bash
-# 1. Build the job image (once)
-docker build -f image/Dockerfile -t pi-job:latest .
+# 1. Get the job image — pull the prebuilt one (fast)...
+docker pull ghcr.io/edgehero/pi-job:latest && docker tag ghcr.io/edgehero/pi-job:latest pi-job:latest
+#    ...or bake your own toolchain into it instead (slower, fully yours):
+#    docker build -f image/Dockerfile -t pi-job:latest .
 
 # 2. Start Valkey (the durable job queue)
 docker compose -f deploy/docker-compose.yml up -d
 
-# 3. Configure
-cp .env.example .env         # then set ANTHROPIC_API_KEY (or your provider's key)
+# 3. Install, scaffold, and check your setup
 npm ci
+npx pi-dispatch init         # writes .env + triggers.json + pause-windows.json (never clobbers)
+#    edit .env — set ANTHROPIC_API_KEY (or your provider's key)
+npx pi-dispatch doctor       # ✓/✗ preflight: Docker, Valkey, the image, and your provider key
 
 # 4. Run the worker in one terminal
 npx pi-dispatch worker       # (or: npm --workspace worker start)
@@ -48,6 +52,9 @@ npx pi-dispatch worker       # (or: npm --workspace worker start)
 # 5. Queue a job from another
 npx pi-dispatch run ./my-project --task "add type hints to utils.py" --flow tidy
 ```
+
+> **The prebuilt image is a snapshot** of this repo's runner + guardrails at its build. To bake a project's
+> toolchain in (the edge cron/visual flows rely on), build `image/Dockerfile` yourself — step 1's second form.
 
 > **Heads-up on the CLI name.** `pi-dispatch` here is *this repo's* workspace CLI (`worker/src/cli.mjs`),
 > which `npx` resolves from the local `node_modules/.bin` after `npm ci` — run these from the repo root. It
@@ -161,9 +168,20 @@ worker's **boot reaper** clears on the next start, rather than draining cleanly.
 
 The admin surface — the dashboard and command transcript shown at the top of this README — is a **pi
 extension** in [`admin/`](admin/) that loads into *your own* interactive pi session — no daemon, no web
-app, **no network port at all**. Load it with `pi -e admin/src/index.ts` from this checkout, add that path
-to the `"extensions"` array in `~/.pi/agent/settings.json`, or just run pi inside this checkout: the
-in-repo `.pi/extensions` shim auto-loads once you've trusted the project.
+app, **no network port at all**.
+
+**Install it through pi** — the published package, then open the panel:
+
+```bash
+pi install npm:@edgehero/pi-dispatch-admin   # then, in pi:  /dispatch
+```
+
+Two other ways to load it: from a clone, the in-repo `.pi/extensions` shim auto-loads once you've trusted
+the project; or point pi at the source with `pi -e admin/src/index.ts` (add that path to the `"extensions"`
+array in `~/.pi/agent/settings.json` to make it permanent). To operate a **live** deployment, give the pi
+session the same `VALKEY_URL`, `PI_SETTINGS_FILE`, `PI_TRIGGERS_FILE`, `PI_PAUSE_WINDOWS_FILE`, and
+`PI_LOGS_DIR` the worker uses — the panel reads and writes those same files and queue, so both act on one
+deployment.
 
 Bare `/dispatch` opens the live dashboard overlay — one snapshot per second, `p`/`r` to pause/resume the
 queue in place, `↑`/`↓` to move across the triggers and runs, `Enter` to drill into either. **Triggers are

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ docker compose -f deploy/docker-compose.yml up -d
 npm ci
 npx pi-dispatch init         # writes .env + triggers.json + pause-windows.json (never clobbers)
 #    edit .env — set ANTHROPIC_API_KEY (or your provider's key)
+#    already logged into pi? set PI_AUTH_FROM_PI=1 instead and it reuses the key from ~/.pi/agent/auth.json
 npx pi-dispatch doctor       # ✓/✗ preflight: Docker, Valkey, the image, and your provider key
 
 # 4. Run the worker in one terminal
@@ -102,6 +103,13 @@ the safety floor always first and unremovable. `import-pi` **refuses** a `models
 **never** copies `auth.json` — your credential stays in the environment. Extensions are opt-in and armed
 separately (`--with-extensions` + `PI_GLOBAL_ALLOW_EXTENSIONS=1`) because they run code against adversarial
 input; the admin extension is hard-blocked. Full reference: [`docs/global-pi-overlay.md`](docs/global-pi-overlay.md).
+
+**Already logged into pi and don't want to restate the key?** Set `PI_AUTH_FROM_PI=1`. When the provider key
+is absent from the worker's environment, the worker reads it **host-side** from `~/.pi/agent/auth.json` and
+env-injects it into the job — a host-side read of a host-held secret, never a file mounted into the container.
+**API-key logins only**: an OAuth/subscription login (`pi login`) is refused — those tokens expire and can't
+be refreshed in the container, and a subscription isn't the credential for an unattended service; use an API
+key with a spend limit.
 
 ## Run as a service
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -169,11 +169,12 @@ Stated openly rather than discovered later:
   provider needs. In particular `ANTHROPIC_OAUTH_TOKEN` silently takes precedence over
   `ANTHROPIC_API_KEY`, so a stray variable in the host environment can quietly redirect which credential
   a job spends.
-- **`PI_AUTH_FROM_PI` sources the provider key from pi's `~/.pi/agent/auth.json` when the env has none.**
+- **By default the worker sources the provider key from pi's `~/.pi/agent/auth.json` when the env has none.**
   It is a host-side read env-injected into the container — never a credential file mounted in — and accepts
-  **API-key** logins only; an OAuth/subscription login is refused. Prefer an API key with a provider-side
-  spend limit for an unattended service; a subscription token is neither refreshable in the container nor
-  intended for automation.
+  **API-key** logins only; an OAuth/subscription login is refused. The env always wins when set; set
+  `PI_AUTH_FROM_PI=0` to force env-only (fail loudly on a missing env key rather than fall back to a pi login).
+  Prefer an API key with a provider-side spend limit for an unattended service; a subscription token is
+  neither refreshable in the container nor intended for automation.
 - **Treat `.pi/` on your default branch as production code**, because it is: it goes into the agent's
   system prompt. Review changes to it with the same care as `.github/workflows/`.
 - **The global pi overlay (`PI_GLOBAL_PI_DIR`) is production code too**, and it must be credential-free. It

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -171,6 +171,14 @@ Stated openly rather than discovered later:
   a job spends.
 - **Treat `.pi/` on your default branch as production code**, because it is: it goes into the agent's
   system prompt. Review changes to it with the same care as `.github/workflows/`.
+- **The global pi overlay (`PI_GLOBAL_PI_DIR`) is production code too**, and it must be credential-free. It
+  is mounted `:ro` into every job — a container that runs adversarial input — so a secret in it is a secret
+  in the box. Stage it with `pi-dispatch import-pi` (it refuses a `models.json` with a literal key and never
+  copies `auth.json`) and let `pi-dispatch doctor` re-check it; the provider key belongs in the environment,
+  never a mounted file. Overlay **extensions run arbitrary code against adversarial input with open network
+  egress** and are not scanned for secrets: keep `PI_GLOBAL_ALLOW_EXTENSIONS` unset until you have vetted
+  every one, and never place the admin extension in the overlay (it can enqueue paid jobs — a recursion
+  vector; `import-pi` blocks it).
 - **The admin surface is not a network service.** It is a pi extension in your own terminal session plus
   a `settings.json` file — it binds no port. Whoever can run pi with the extension loaded, or write
   `PI_SETTINGS_FILE`, holds operator power: the same trust as shell access on the host. Treat it that way.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -169,6 +169,11 @@ Stated openly rather than discovered later:
   provider needs. In particular `ANTHROPIC_OAUTH_TOKEN` silently takes precedence over
   `ANTHROPIC_API_KEY`, so a stray variable in the host environment can quietly redirect which credential
   a job spends.
+- **`PI_AUTH_FROM_PI` sources the provider key from pi's `~/.pi/agent/auth.json` when the env has none.**
+  It is a host-side read env-injected into the container — never a credential file mounted in — and accepts
+  **API-key** logins only; an OAuth/subscription login is refused. Prefer an API key with a provider-side
+  spend limit for an unattended service; a subscription token is neither refreshable in the container nor
+  intended for automation.
 - **Treat `.pi/` on your default branch as production code**, because it is: it goes into the agent's
   system prompt. Review changes to it with the same care as `.github/workflows/`.
 - **The global pi overlay (`PI_GLOBAL_PI_DIR`) is production code too**, and it must be credential-free. It

--- a/docs/global-pi-overlay.md
+++ b/docs/global-pi-overlay.md
@@ -58,6 +58,18 @@ If your model uses a provider whose key variable pi's built-in table doesn't kno
 PI_FORWARD_ENV=MY_PROVIDER_KEY      # comma-separated NAMES; forwarded by exact -e NAME=VALUE, never a pass-through
 ```
 
+### The key is already in pi (`PI_AUTH_FROM_PI`)
+
+Logged into pi already and don't want to restate the key in `.env`? Set `PI_AUTH_FROM_PI=1`. When the
+provider key is absent from the worker's environment, the worker reads it **host-side** from
+`~/.pi/agent/auth.json` and env-injects it under the variable pi expects — a host-side read of a host-held
+secret, injected via env exactly like `.env`, **never a file mounted into the container**. The environment
+still wins when present; this is a fallback.
+
+**API-key logins only.** An OAuth/subscription login (`pi login`) is refused: those tokens expire and the
+container can't refresh them, and a subscription isn't the credential for an unattended paid service —
+configure an API key (with a spend limit) instead.
+
 ## Extensions (the sharp edge — opt-in and armed separately)
 
 Extensions run **code against adversarial input with open network egress**, and host extensions often carry

--- a/docs/global-pi-overlay.md
+++ b/docs/global-pi-overlay.md
@@ -1,0 +1,77 @@
+# Reuse your existing pi setup — the global overlay
+
+If you already run `pi`, you have a configured `~/.pi/agent`: custom models, global skills, a global persona.
+Point pi-dispatch at a **credential-free copy** of it and every job gets it — **layered under each repo's own
+`.pi/`**, so a repo can still override or add on top. It works with the **pulled** prebuilt image: this is a
+read-only mount, not an image rebuild.
+
+## Enable it
+
+```bash
+pi-dispatch import-pi          # stage the safe subset of ~/.pi/agent into ./pi-global
+# then in .env:
+PI_GLOBAL_PI_DIR=/absolute/path/to/pi-global
+pi-dispatch doctor             # verifies the overlay is credential-free
+```
+
+`import-pi` reads your host agent dir (`$PI_CODING_AGENT_DIR`, else `~/.pi/agent`) and copies a **curated,
+credential-free** subset into the overlay dir. Re-run it whenever you change your host setup. Flags:
+`--with-extensions` (see below), `--from <agentDir>`, `--to <overlayDir>`.
+
+## What layers, and who wins
+
+Four tiers, most-trusted first; each refines but never removes the one above:
+
+| Tier | Source | Trust | Mutable? |
+|---|---|---|---|
+| 1. Safety floor | baked `HARD_RULES.md` | image, root-owned | no (immutable) |
+| 2. **Global overlay** | `PI_GLOBAL_PI_DIR` → `/opt/pi-global:ro` | **operator, deploy-time** | re-run `import-pi` |
+| 3. Per-repo `.pi/` | repo's committed `.pi/` (default-branch SHA) | trusted-by-merge | per PR |
+| 4. Task/issue text | the webhook / CLI input | **adversarial — never instructions** | — |
+
+- **Skills**: repo skills are listed **first**, so a repo skill **overrides** a global one of the same name
+  (pi is first-path-wins); names that don't collide all load.
+- **Persona**: the assembled prompt is `guardrails → global persona → repo persona`. The floor is always
+  first and cannot be removed; global is your baseline; the repo's `.pi/APPEND_SYSTEM.md` is most specific.
+- **Models**: the overlay's `models.json` makes a **custom provider/model** resolvable. Definitions only —
+  the credential still comes from the environment, never the overlay.
+
+## What is copied — and what never is
+
+| Copied into the overlay | Never copied |
+|---|---|
+| `models.json` (definitions; **refused if it embeds a literal key**) | `auth.json` — your credential stays in env/auth.json |
+| `skills/<name>/` | `settings.json`, `sessions/`, `themes/`, `prompts/` |
+| `APPEND_SYSTEM.md` (global persona) | anything holding a secret |
+| `extensions/` — only with `--with-extensions` | the admin extension (hard-blocked) |
+
+The overlay is mounted **read-only** into a container that runs adversarial input, so it must hold **no
+secret**. `import-pi` refuses a `models.json` with a literal `apiKey` (move it to `auth.json`, or reference
+the environment as `"$MY_KEY"`), and `doctor` re-checks the overlay for `auth.json` and literal keys.
+
+### Custom providers
+
+If your model uses a provider whose key variable pi's built-in table doesn't know, forward it explicitly:
+
+```bash
+# .env
+PI_FORWARD_ENV=MY_PROVIDER_KEY      # comma-separated NAMES; forwarded by exact -e NAME=VALUE, never a pass-through
+```
+
+## Extensions (the sharp edge — opt-in and armed separately)
+
+Extensions run **code against adversarial input with open network egress**, and host extensions often carry
+MCP-server credentials. They are therefore **doubly gated**:
+
+1. `pi-dispatch import-pi --with-extensions` copies them (verbatim — they are **not** scanned for secrets;
+   the admin extension is refused).
+2. They load **only** when you set `PI_GLOBAL_ALLOW_EXTENSIONS=1`. Unset = present but dormant.
+
+Vet every extension before arming, and never place the admin extension in the overlay (it can enqueue paid
+jobs — a recursion vector; `import-pi` blocks it, but treat it as a rule).
+
+## Reference
+
+`REQ-GLOBAL-PI-OVERLAY` ([requirements](../specs/requirements.md)),
+`DES-OPERATOR-GLOBAL-OVERLAY` ([design](../specs/design.md)),
+`INT-CONTAINER-RUNTIME-CONTRACT` / `INT-SDK-SESSION-OPTIONS` ([interfaces](../specs/interfaces.md)).

--- a/docs/global-pi-overlay.md
+++ b/docs/global-pi-overlay.md
@@ -58,13 +58,13 @@ If your model uses a provider whose key variable pi's built-in table doesn't kno
 PI_FORWARD_ENV=MY_PROVIDER_KEY      # comma-separated NAMES; forwarded by exact -e NAME=VALUE, never a pass-through
 ```
 
-### The key is already in pi (`PI_AUTH_FROM_PI`)
+### The key is already in pi (on by default)
 
-Logged into pi already and don't want to restate the key in `.env`? Set `PI_AUTH_FROM_PI=1`. When the
-provider key is absent from the worker's environment, the worker reads it **host-side** from
-`~/.pi/agent/auth.json` and env-injects it under the variable pi expects — a host-side read of a host-held
-secret, injected via env exactly like `.env`, **never a file mounted into the container**. The environment
-still wins when present; this is a fallback.
+Logged into pi already? You don't have to restate the key in `.env`. When the provider key is absent from
+the worker's environment, the worker reads it **host-side** from `~/.pi/agent/auth.json` and env-injects it
+under the variable pi expects — a host-side read of a host-held secret, injected via env exactly like `.env`,
+**never a file mounted into the container**. This is **on by default**; the environment still wins when
+present. Set `PI_AUTH_FROM_PI=0` to force env-only (fail loudly on a missing env key instead of falling back).
 
 **API-key logins only.** An OAuth/subscription login (`pi login`) is refused: those tokens expire and the
 container can't refresh them, and a subscription isn't the credential for an unattended paid service —

--- a/image/runner/run-job.mjs
+++ b/image/runner/run-job.mjs
@@ -47,7 +47,12 @@ async function main() {
 	// ships, REQ-UPSTREAM-CONTRACT-TESTS fires on the pin bump and this is the code that changes.
 	// See OQ-005.
 	const authStorage = AuthStorage.create(`${agentDir}/auth.json`);
-	const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+	// Prefer the operator's global overlay models.json (REQ-GLOBAL-PI-OVERLAY) when the :ro overlay is
+	// mounted -- this is how a CUSTOM provider/model becomes resolvable. The credential still comes from
+	// env -> auth.json; the overlay models.json is definitions only (import-pi refuses a literal key).
+	const GLOBAL_MODELS = "/opt/pi-global/models.json";
+	const modelsPath = existsSync(GLOBAL_MODELS) ? GLOBAL_MODELS : `${agentDir}/models.json`;
+	const modelRegistry = ModelRegistry.create(authStorage, modelsPath);
 
 	// Pin the model explicitly. With `model` omitted, pi picks from settings and provider defaults
 	// -- nondeterministic across images, and it silently changes cost per job.
@@ -61,7 +66,7 @@ async function main() {
 	// project's .pi/settings.json cannot override our spend controls.
 	const settingsManager = SettingsManager.inMemory({ retry: { enabled: true, ...cfg.retry } });
 
-	const resourceLoader = await buildLoadedResourceLoader({ settingsManager });
+	const resourceLoader = await buildLoadedResourceLoader({ settingsManager, allowGlobalExtensions: cfg.allowGlobalExtensions });
 
 	const { session } = await createAgentSession({
 		cwd: WORKSPACE,

--- a/image/runner/src/config.mjs
+++ b/image/runner/src/config.mjs
@@ -20,6 +20,10 @@ export function parseRunnerEnv(env) {
 		model,
 		maxTurns,
 		maxTokens,
+		// REQ-GLOBAL-PI-OVERLAY: arm loading of the global overlay's extensions. Fail-closed -- anything
+		// but the exact string "1" leaves overlay extensions dormant. Not a configError: an unset flag is
+		// the normal, safe state, not a misconfiguration.
+		allowGlobalExtensions: env.PI_GLOBAL_ALLOW_EXTENSIONS === "1",
 		retry: {
 			maxRetries: parsePositiveInt(env, "PI_RETRY_MAX", 2),
 			baseDelayMs: parsePositiveInt(env, "PI_RETRY_BASE_MS", 2000),

--- a/image/runner/src/loader.mjs
+++ b/image/runner/src/loader.mjs
@@ -13,6 +13,13 @@ export const OUTBOX_MOUNT = "/outbox";
 /** Read-only mount the worker materialises the project's .pi/ into, from the default-branch SHA. */
 export const JOB_PI_DIR = "/job/pi";
 
+/**
+ * Read-only mount of the operator's global pi overlay (REQ-GLOBAL-PI-OVERLAY): custom models, global
+ * skills, and a global persona from the operator's own ~/.pi/agent, present only when configured. It is
+ * operator deploy-time config -- the same trust class as the baked floor -- layered UNDER each repo's .pi/.
+ */
+export const GLOBAL_PI_DIR = "/opt/pi-global";
+
 export const WORKSPACE = "/workspace";
 
 function readIfExists(path) {
@@ -47,12 +54,20 @@ export function buildResourceLoader({
 	cwd = WORKSPACE,
 	guardrailsPath = GUARDRAILS_PATH,
 	jobPiDir = JOB_PI_DIR,
+	globalPiDir = GLOBAL_PI_DIR,
 	outboxMount = OUTBOX_MOUNT,
 	outboxProtocolPath = OUTBOX_PROTOCOL_PATH,
+	allowGlobalExtensions = false,
 	settingsManager,
 } = {}) {
 	const guardrails = readFileSync(guardrailsPath, "utf8");
 	const projectPersona = readIfExists(`${jobPiDir}/APPEND_SYSTEM.md`);
+	// The operator's global overlay (REQ-GLOBAL-PI-OVERLAY), present only when the /opt/pi-global mount
+	// exists. Persona layers BETWEEN the immutable floor and the repo persona; skills layer UNDER the
+	// repo's (repo path first => repo wins a name collision, since pi's loadSkills is first-path-wins).
+	const globalPersona = readIfExists(`${globalPiDir}/APPEND_SYSTEM.md`);
+	const globalSkills = `${globalPiDir}/skills`;
+	const globalExtensions = `${globalPiDir}/extensions`;
 	// Only a local job carries an /outbox mount; a github job has none, so its prompt never
 	// pays for the protocol. Evaluated ONCE here at loader build, not per message, so the
 	// assembled prompt is byte-identical across turns (CONST-PERSONA-IN-CACHED-PREFIX).
@@ -65,9 +80,16 @@ export function buildResourceLoader({
 		noContextFiles: true,
 		noSkills: true,
 		noExtensions: true,
-		additionalSkillPaths: [`${jobPiDir}/skills`],
-		additionalExtensionPaths: [`${jobPiDir}/extensions`],
-		appendSystemPromptOverride: () => [guardrails, outboxProtocol, projectPersona].filter(Boolean),
+		// Repo path FIRST so a repo skill overrides a global one of the same name (first-path-wins).
+		additionalSkillPaths: [`${jobPiDir}/skills`, ...(existsSync(globalSkills) ? [globalSkills] : [])],
+		// Global overlay extensions are fail-closed: loaded ONLY when the operator armed them
+		// (PI_GLOBAL_ALLOW_EXTENSIONS=1) AND the dir is present. They run code against adversarial input
+		// with open egress, so arming is a second, explicit decision beyond mounting the overlay.
+		additionalExtensionPaths: [
+			`${jobPiDir}/extensions`,
+			...(allowGlobalExtensions && existsSync(globalExtensions) ? [globalExtensions] : []),
+		],
+		appendSystemPromptOverride: () => [guardrails, outboxProtocol, globalPersona, projectPersona].filter(Boolean),
 	});
 }
 

--- a/image/runner/test/loader.test.mjs
+++ b/image/runner/test/loader.test.mjs
@@ -203,3 +203,50 @@ test("guardrails precede outbox precede persona when all three are present", { s
 		"the outbox protocol must precede the project persona",
 	);
 });
+
+// --- REQ-GLOBAL-PI-OVERLAY: the operator global overlay, layered UNDER the per-repo .pi/ ---
+const GLOBAL_PERSONA_SENTINEL = "GLOBAL-PERSONA-SENTINEL-d15e";
+const GLOBAL_SKILL_SENTINEL = "GLOBAL-ONLY-SKILL-SENTINEL-e26f";
+const GLOBAL_BUGFIX_SENTINEL = "GLOBAL-BUGFIX-SENTINEL-f37a"; // a global "bug-fix" the repo's must shadow
+
+/** A /opt/pi-global overlay: a global-only skill, a colliding "bug-fix" skill, and a global persona. */
+function globalOverlay() {
+	const dir = mkdtempSync(join(tmpdir(), "pi-global-"));
+	mkdirSync(join(dir, "skills", "global-only"), { recursive: true });
+	writeFileSync(join(dir, "skills", "global-only", "SKILL.md"), `---\nname: global-only\ndescription: ${GLOBAL_SKILL_SENTINEL} a house rule\n---\n\nApply everywhere.\n`);
+	mkdirSync(join(dir, "skills", "bug-fix"), { recursive: true });
+	writeFileSync(join(dir, "skills", "bug-fix", "SKILL.md"), `---\nname: bug-fix\ndescription: ${GLOBAL_BUGFIX_SENTINEL} the GLOBAL bug-fix\n---\n\nGlobal steps.\n`);
+	writeFileSync(join(dir, "APPEND_SYSTEM.md"), `# House persona\n${GLOBAL_PERSONA_SENTINEL}\nHouse style.\n`);
+	return dir;
+}
+
+test("a global overlay skill loads, and a repo skill of the same name overrides it (repo first)", { skip }, async () => {
+	const { loader } = await load({ globalPiDir: globalOverlay() });
+	const { skills } = loader.getSkills();
+	assert.ok(skills.find((s) => s.name === "global-only")?.description.includes(GLOBAL_SKILL_SENTINEL), "a global-only skill must load");
+	const bugFix = skills.find((s) => s.name === "bug-fix");
+	assert.ok(bugFix.description.includes(SKILL_SENTINEL), "the REPO bug-fix must win the name collision (repo path is first)");
+	assert.ok(!bugFix.description.includes(GLOBAL_BUGFIX_SENTINEL), "the global bug-fix must be shadowed, not merged");
+});
+
+test("the global persona layers between the guardrails floor and the repo persona", { skip }, async () => {
+	const { loader } = await load({ globalPiDir: globalOverlay() });
+	const appended = loader.getAppendSystemPrompt().join("\n\n");
+	assert.ok(appended.includes(GLOBAL_PERSONA_SENTINEL), "the global persona must reach the prompt");
+	assert.ok(
+		appended.indexOf(GUARDRAIL_SENTINEL) < appended.indexOf(GLOBAL_PERSONA_SENTINEL),
+		"the immutable floor must precede the global persona",
+	);
+	assert.ok(
+		appended.indexOf(GLOBAL_PERSONA_SENTINEL) < appended.indexOf(PERSONA_SENTINEL),
+		"the global persona must precede the repo persona (repo is most specific)",
+	);
+});
+
+test("no overlay mounted -> the loader behaves exactly as before (guardrails + repo persona only)", { skip }, async () => {
+	// globalPiDir points at a path that does not exist -> existsSync gates every overlay read to a no-op.
+	const { loader } = await load({ globalPiDir: join(tmpdir(), "pi-global-absent-xyz") });
+	const appended = loader.getAppendSystemPrompt().join("\n\n");
+	assert.ok(appended.includes(GUARDRAIL_SENTINEL) && appended.includes(PERSONA_SENTINEL));
+	assert.ok(!appended.includes(GLOBAL_PERSONA_SENTINEL), "an absent overlay contributes nothing");
+});

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -74,8 +74,11 @@ that always fires is one nobody reads.
   permissions of the user and process that launched it."* … *"If you need stronger boundaries,
   containerize or sandbox Pi."*
 - **Traces to**: `INT-CONTAINER-RUNTIME-CONTRACT`, `CONST-TOKEN-SCOPED-PER-JOB`
-- **Acceptance**: Given any job, the agent has no filesystem path to the host outside the two declared
-  mounts, and the container is gone after the run.
+- **Acceptance**: Given any job, the agent has no filesystem path to the host outside the declared mounts
+  in `INT-CONTAINER-RUNTIME-CONTRACT` — `/job:ro`, `/workspace:rw`, `/outbox:rw` (local only), and
+  `/opt/pi-global:ro` (the operator global overlay, only when configured; `REQ-GLOBAL-PI-OVERLAY`) — every
+  one operator- or worker-supplied, none host-wide, and only `/workspace`/`/outbox` writable; and the
+  container is gone after the run.
 
 ## CONST-NO-CONTEXT-FILES-MANDATORY
 

--- a/specs/design.md
+++ b/specs/design.md
@@ -618,7 +618,10 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   - **The overlay may never carry persona or hard rules.** It tunes task/config knobs only; the immutable
     rules stay baked. This is the `DES-FLOWS-ARE-DATA-PERSONA-IS-CODE` boundary applied to settings:
     mutable = task/config tuning, immutable = hard rules, and the split falls on the risk, not on the
-    filesystem.
+    filesystem. This bar is on **this admin-editable runtime channel** — the one an admin-surface compromise
+    can bend. It does not constrain deploy-time operator config: the global pi overlay
+    (`DES-OPERATOR-GLOBAL-OVERLAY`) *may* carry a persona layer, because it is operator-authored `:ro` config
+    at the same trust level as baking, not a runtime-mutable knob.
   - **A file, not Redis**, so the live configuration is inspectable, hand-editable with an editor,
     survives a Valkey flush, and does not become a second opaque state store. The shared-filesystem
     assumption it relies on is true by construction: `DES-WORKER-ON-HOST` puts the worker and the admin
@@ -768,8 +771,41 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   - *Everything admin-editable including hard rules* — makes `CONST-MERGE-NEVER-AUTOMATIC` and
     `CONST-ISSUE-TEXT-IS-DATA` runtime-mutable state. They are constitutional precisely because they are
     not negotiable at runtime.
+- **Clarification (operator deploy-time overlay)**: "The admin surface may never touch the persona" governs
+  the **admin-editable runtime channel** — the settings overlay (`DES-RUNTIME-SETTINGS-FILE-OVERLAY`) — which
+  an attacker who reaches the admin surface could bend. It does **not** bar the operator from supplying a
+  persona at deploy time. The global pi overlay (`DES-OPERATOR-GLOBAL-OVERLAY`) is operator-authored,
+  `:ro`-mounted deploy-time config — the **same trust class as baking `~/.pi/agent/APPEND_SYSTEM.md` into the
+  image** — and may carry a persona layer *under* the immutable floor. Mutability, not the persona/flow label,
+  is the boundary: the baked `HARD_RULES.md` stays first and unremovable regardless.
 - **Traces to**: `CONST-ISSUE-TEXT-IS-DATA`, `CONST-MERGE-NEVER-AUTOMATIC`, `INT-CONTAINER-JOB-INPUTS`,
-  `DES-PERSONA-VIA-APPEND-SYSTEM-MD`, `DES-PANEL-SEPARATE-FROM-RECEIVER`
+  `DES-PERSONA-VIA-APPEND-SYSTEM-MD`, `DES-OPERATOR-GLOBAL-OVERLAY`, `DES-PANEL-SEPARATE-FROM-RECEIVER`
+
+## DES-OPERATOR-GLOBAL-OVERLAY
+
+- **Decision**: Reuse an operator's existing host `pi` setup across every job through a single **global
+  overlay dir** (`PI_GLOBAL_PI_DIR`), bind-mounted `/opt/pi-global:ro` into each container and layered as a
+  new trust **tier 2** between the baked floor and the per-repo `.pi/`. It supplies custom models
+  (`models.json`), global skills, and a global persona; the runner reads them (models path selection,
+  `additionalSkillPaths` with the repo path first, a global persona entry in `appendSystemPromptOverride`).
+  A host-side `pi-dispatch import-pi` stages the **credential-free** subset of `~/.pi/agent` and `doctor`
+  re-verifies it. Extensions are a separate, armed opt-in (`--with-extensions` + `PI_GLOBAL_ALLOW_EXTENSIONS`),
+  with the admin extension hard-blocked. A runtime **mount**, not a rebuild, so it works with the pulled image.
+- **Why**: Four trust tiers, each refining but never removing the one above — baked floor (immutable) →
+  operator overlay (deploy-time, operator-authored) → per-repo `.pi/` (trusted-by-merge) → adversarial input.
+  The overlay sits at the operator's own trust level, which is why it may carry a persona (unlike the
+  admin-editable settings overlay) yet must stay `:ro` and credential-free (it rides into an adversarial-input
+  container: `CONST-TOKEN-SCOPED-PER-JOB`). Skills are **first-path-wins** in pi, so listing the repo path
+  first makes repo skills override global ones — the "project refines global" semantics operators expect.
+- **Rejected**:
+  - *Copy `~/.pi` wholesale* — drags `auth.json` and MCP-credentialed extensions into the box; and pi's
+    `noSkills/noExtensions/noContextFiles` mean host-global *discovery* is off anyway, so most of it is inert.
+  - *Bake the overlay into the image* — a per-operator image defeats the pulled prebuilt image; the mount
+    delivers the same content without a rebuild.
+  - *Load overlay extensions by default* — arbitrary code against adversarial input with open egress; arming
+    it must be a second, explicit decision, and the admin extension must never be among them.
+- **Traces to**: `REQ-GLOBAL-PI-OVERLAY`, `INT-CONTAINER-RUNTIME-CONTRACT`, `INT-SDK-SESSION-OPTIONS`,
+  `CONST-ISOLATION-CONTAINER-PER-JOB`, `CONST-TOKEN-SCOPED-PER-JOB`, `DES-FLOWS-ARE-DATA-PERSONA-IS-CODE`
 
 ## DES-PLAYWRIGHT-CLI-NOT-CHROME-DEVTOOLS
 

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -400,14 +400,15 @@ Evidence convention as in `constitution.md`.
     hand-maintained copy is exactly the reinvention `no-reimplementing-pi` forbids. For `anthropic` the
     call returns `["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]` — **the array order *is* the
     precedence**, which is precisely the trap this rule exists for.
-  - **`PI_AUTH_FROM_PI=1` is an optional credential *source*, not a new injection path.** When set and the
-    provider key is absent from the worker env, the worker reads it **host-side** from `~/.pi/agent/auth.json`
-    (honoring `PI_CODING_AGENT_DIR`) and injects it under the variable name pi expects — the name resolved by
-    the same `findEnvKeys` oracle, so no hand table. It stays a HOST-SIDE read of a host-held secret,
-    env-injected exactly like the env path, **never a credential file mounted into the container**
-    (`CONST-TOKEN-SCOPED-PER-JOB`). **API-key credentials only**: an OAuth/subscription login is refused
-    pre-spend (it expires, the container cannot refresh it, and it is not the credential for an unattended
-    service). The env, when present, always wins — this is a fallback, not an override.
+  - **Sourcing the key from pi's `auth.json` is a credential *source*, not a new injection path, and is ON by
+    default.** When the provider key is absent from the worker env, the worker reads it **host-side** from
+    `~/.pi/agent/auth.json` (honoring `PI_CODING_AGENT_DIR`) and injects it under the variable name pi expects
+    — the name resolved by the same `findEnvKeys` oracle, so no hand table. It stays a HOST-SIDE read of a
+    host-held secret, env-injected exactly like the env path, **never a credential file mounted into the
+    container** (`CONST-TOKEN-SCOPED-PER-JOB`). **API-key credentials only**: an OAuth/subscription login is
+    refused pre-spend (it expires, the container cannot refresh it, and it is not the credential for an
+    unattended service). The env, when present, always wins — this is a fallback, not an override.
+    `PI_AUTH_FROM_PI=0` disables it (env-only, fail-loud on a missing env key).
   - Mounts: `/job:ro`, `/workspace:rw`, — **local jobs only** — `/outbox:rw`, and — **only when
     `PI_GLOBAL_PI_DIR` is configured** — `/opt/pi-global:ro` — delivered by host bind mounts
     (`-v <hostPath>:<containerPath>`, per `DES-WORKER-ON-HOST` and `worker/src/docker-run.mjs`): the worker

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -400,6 +400,14 @@ Evidence convention as in `constitution.md`.
     hand-maintained copy is exactly the reinvention `no-reimplementing-pi` forbids. For `anthropic` the
     call returns `["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]` — **the array order *is* the
     precedence**, which is precisely the trap this rule exists for.
+  - **`PI_AUTH_FROM_PI=1` is an optional credential *source*, not a new injection path.** When set and the
+    provider key is absent from the worker env, the worker reads it **host-side** from `~/.pi/agent/auth.json`
+    (honoring `PI_CODING_AGENT_DIR`) and injects it under the variable name pi expects — the name resolved by
+    the same `findEnvKeys` oracle, so no hand table. It stays a HOST-SIDE read of a host-held secret,
+    env-injected exactly like the env path, **never a credential file mounted into the container**
+    (`CONST-TOKEN-SCOPED-PER-JOB`). **API-key credentials only**: an OAuth/subscription login is refused
+    pre-spend (it expires, the container cannot refresh it, and it is not the credential for an unattended
+    service). The env, when present, always wins — this is a fallback, not an override.
   - Mounts: `/job:ro`, `/workspace:rw`, — **local jobs only** — `/outbox:rw`, and — **only when
     `PI_GLOBAL_PI_DIR` is configured** — `/opt/pi-global:ro` — delivered by host bind mounts
     (`-v <hostPath>:<containerPath>`, per `DES-WORKER-ON-HOST` and `worker/src/docker-run.mjs`): the worker

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -28,14 +28,18 @@ Evidence convention as in `constitution.md`.
 
   ```typescript
   const authStorage   = AuthStorage.create(`${agentDir}/auth.json`);
-  const modelRegistry = ModelRegistry.create(authStorage, `${agentDir}/models.json`);
+  // Prefer the operator overlay's models.json when the :ro overlay is mounted (REQ-GLOBAL-PI-OVERLAY) —
+  // how a CUSTOM provider/model becomes resolvable. Definitions only; the key still flows env -> auth.json.
+  const modelsPath = existsSync("/opt/pi-global/models.json") ? "/opt/pi-global/models.json" : `${agentDir}/models.json`;
+  const modelRegistry = ModelRegistry.create(authStorage, modelsPath);
   const model = modelRegistry.find(process.env.PI_PROVIDER, process.env.PI_MODEL);  // NOT getModel
   if (!model) throw configError(`unknown model`);   // configError tags exit 2 — see below
   if (!modelRegistry.hasConfiguredAuth(model)) throw configError(`no configured auth`);
 
   // Guardrails read EXPLICITLY from a path we own — never via discovery. See (e).
-  const guardrails    = readFileSync("/opt/pi-dispatch/HARD_RULES.md", "utf8");
-  const projectPersona = readIfExists("/job/pi/APPEND_SYSTEM.md");   // :ro, default-branch SHA
+  const guardrails     = readFileSync("/opt/pi-dispatch/HARD_RULES.md", "utf8");
+  const globalPersona  = readIfExists("/opt/pi-global/APPEND_SYSTEM.md"); // operator overlay, :ro (REQ-GLOBAL-PI-OVERLAY)
+  const projectPersona = readIfExists("/job/pi/APPEND_SYSTEM.md");        // :ro, default-branch SHA
 
   const resourceLoader = new DefaultResourceLoader({
     cwd: "/workspace",
@@ -43,9 +47,14 @@ Evidence convention as in `constitution.md`.
     noContextFiles: true,                              // CONST-NO-CONTEXT-FILES-MANDATORY
     noSkills: true,                                    // exclude cwd/package discovery …
     noExtensions: true,                                // … we supply ours explicitly instead
-    additionalSkillPaths:     ["/job/pi/skills"],      // native pi skills, :ro, default-branch
-    additionalExtensionPaths: ["/job/pi/extensions"],
-    appendSystemPromptOverride: () => [guardrails, projectPersona].filter(Boolean),
+    // Repo path FIRST so a repo skill overrides a global one of the same name (pi is first-path-wins).
+    additionalSkillPaths:     ["/job/pi/skills", ...(existsSync("/opt/pi-global/skills") ? ["/opt/pi-global/skills"] : [])],
+    // Overlay extensions are fail-closed: only when PI_GLOBAL_ALLOW_EXTENSIONS=1 AND the dir is present.
+    additionalExtensionPaths: ["/job/pi/extensions", ...(allowGlobalExtensions && existsSync("/opt/pi-global/extensions") ? ["/opt/pi-global/extensions"] : [])],
+    // Floor first (unremovable), then operator-global, then repo (most specific). Deploy-time overlay
+    // persona is the SAME trust class as baking (DES-OPERATOR-GLOBAL-OVERLAY), distinct from the
+    // admin-editable runtime settings overlay, which still may never carry persona.
+    appendSystemPromptOverride: () => [guardrails, globalPersona, projectPersona].filter(Boolean),
   });
   await resourceLoader.reload();        // MANDATORY — createAgentSession will NOT do this for you
   // NOTE: reload() is NOT called with `resolveProjectTrust`. Project trust is never granted.
@@ -369,8 +378,11 @@ Evidence convention as in `constitution.md`.
     (see below); `GITHUB_TOKEN` (scoped, short-lived — GitHub-backed jobs only); `PI_JOB_ID`; `PI_PROVIDER`;
     `PI_MODEL`; `PI_MAX_TURNS`; `PI_MAX_TOKENS` (the per-job token budget — forwarded ONLY when set, omitted
     otherwise so the runner meters usage without a cap; `REQ-TOKEN-ACCOUNTING-AND-CAPS`); `PI_CODING_AGENT_DIR`
-    (if not `$HOME/.pi/agent`). Note `PI_DAILY_TOKEN_CAP` is **worker-only and is NOT forwarded** — the daily
-    token counter is enforced host-side, and the container stays queue/budget-blind (`no-broad-env-into-container`).
+    (if not `$HOME/.pi/agent`); `PI_GLOBAL_ALLOW_EXTENSIONS=1` (forwarded ONLY when the operator armed overlay
+    extensions — fail-closed; `REQ-GLOBAL-PI-OVERLAY`); and each name in `PI_FORWARD_ENV` (an explicit operator
+    allowlist of extra host vars — e.g. a custom provider's key — forwarded by exact `-e NAME=VALUE`, never a
+    pass-through, so it satisfies `no-broad-env-into-container`). Note `PI_DAILY_TOKEN_CAP` is **worker-only and is
+    NOT forwarded** — the daily token counter is enforced host-side, and the container stays queue/budget-blind.
   - Env **baked into the image**, because they are facts about the image and not choices a job makes:
     `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`, `PLAYWRIGHT_MCP_BROWSER=chromium`,
     `PLAYWRIGHT_MCP_SANDBOX=false`. **`PLAYWRIGHT_MCP_BROWSER` is load-bearing**: `playwright-cli`
@@ -388,10 +400,15 @@ Evidence convention as in `constitution.md`.
     hand-maintained copy is exactly the reinvention `no-reimplementing-pi` forbids. For `anthropic` the
     call returns `["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]` — **the array order *is* the
     precedence**, which is precisely the trap this rule exists for.
-  - Mounts: `/job:ro`, `/workspace:rw`, and — **local jobs only** — `/outbox:rw` — delivered by host bind
-    mounts (`-v <hostPath>:<containerPath>`, per `DES-WORKER-ON-HOST` and `worker/src/docker-run.mjs`): the
-    worker runs on the host and binds the per-job inputs dir, the workspace folder, and the outbox dir
-    directly. No credential is ever written to `/outbox` (same rule as `/workspace`).
+  - Mounts: `/job:ro`, `/workspace:rw`, — **local jobs only** — `/outbox:rw`, and — **only when
+    `PI_GLOBAL_PI_DIR` is configured** — `/opt/pi-global:ro` — delivered by host bind mounts
+    (`-v <hostPath>:<containerPath>`, per `DES-WORKER-ON-HOST` and `worker/src/docker-run.mjs`): the worker
+    runs on the host and binds the per-job inputs dir, the workspace folder, the outbox dir, and the operator's
+    global pi overlay directly. `/opt/pi-global` is the operator's own `~/.pi/agent` subset — custom models, global
+    skills, a global persona — layered UNDER each repo's `.pi/` (`REQ-GLOBAL-PI-OVERLAY`, `DES-OPERATOR-GLOBAL-OVERLAY`);
+    it is `:ro` and **credential-free by construction** (`import-pi` refuses a literal-key `models.json` and never
+    copies `auth.json`; `CONST-TOKEN-SCOPED-PER-JOB`). No credential is ever written to `/outbox` or `/opt/pi-global`
+    (same rule as `/workspace`).
   - No TTY (`-it` absent)
   - **The agent dir must be writable by the non-root runtime user.** pi lazily creates
     `~/.pi/agent/` (mode `0700`) and `auth.json` (mode `0600`, contents `{}`) on the **first credential

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -495,6 +495,40 @@ local), the credential (a short-lived scoped token for GitHub jobs vs none for l
 
 ---
 
+## REQ-GLOBAL-PI-OVERLAY
+
+- **Statement**: An operator shall be able to reuse their existing host `pi` setup in every job. A single
+  **global overlay dir** (`PI_GLOBAL_PI_DIR`) is bind-mounted `/opt/pi-global:ro` into each container (both
+  job kinds) and layered **UNDER** each repo's own `.pi/`: custom models (`models.json`) become resolvable,
+  global skills (`skills/`) and a global persona (`APPEND_SYSTEM.md`) apply to every job. **Repo wins on
+  conflict** — the repo skill path is listed first (pi is first-path-wins) and the repo persona is appended
+  last; the baked `HARD_RULES.md` floor stays first and unremovable. The overlay is **credential-free by
+  construction**: `pi-dispatch import-pi` stages the safe subset of `~/.pi/agent` (honoring
+  `PI_CODING_AGENT_DIR`), **refusing** a `models.json` with a literal key and **never** copying `auth.json`
+  or `settings.json`; `pi-dispatch doctor` re-verifies. Overlay **extensions are fail-closed**: copied only
+  under `import-pi --with-extensions` (the admin extension hard-blocked), and loaded only when the operator
+  arms `PI_GLOBAL_ALLOW_EXTENSIONS=1`. A custom provider's key reaches the container through the explicit
+  `PI_FORWARD_ENV` name allowlist, never a host pass-through.
+- **Scope**: The container mount + env contract and the runner's resource loader; a new host-side CLI
+  (`import-pi`) and `doctor` checks. Works with the **pulled** prebuilt image — a runtime mount, not a
+  rebuild. Distinct from the per-repo `.pi/` (trusted-by-merge, materialized from a git SHA) and from the
+  admin-editable runtime settings overlay (which still may never carry persona).
+- **Why**: Anyone who already runs pi has a configured `~/.pi/agent`; re-expressing it per-repo is friction
+  the missing-layer pitch should remove. The overlay is **operator deploy-time config — the same trust class
+  as baking the image** — so it may carry a persona layer, but it is mounted `:ro` into an adversarial-input
+  container, so it must hold no secret (`CONST-TOKEN-SCOPED-PER-JOB`) and extensions (arbitrary code, open
+  egress) stay opt-in and armed separately.
+- **Traces to**: `DES-OPERATOR-GLOBAL-OVERLAY`, `INT-CONTAINER-RUNTIME-CONTRACT`, `INT-SDK-SESSION-OPTIONS`,
+  `CONST-ISOLATION-CONTAINER-PER-JOB`, `CONST-TOKEN-SCOPED-PER-JOB`, `DES-PERSONA-VIA-APPEND-SYSTEM-MD`
+- **Acceptance**: Given a configured overlay, a global skill is available to a job and a repo skill of the
+  same name overrides it; the assembled prompt shows guardrails before the global persona before the repo
+  persona; given a custom model in the overlay `models.json`, the runner resolves it; given `import-pi`
+  against a `models.json` with a literal key, it refuses and writes nothing; given `auth.json` in the
+  overlay, `doctor` fails; given overlay extensions with `PI_GLOBAL_ALLOW_EXTENSIONS` unset, they do not
+  load; given `import-pi --with-extensions` over the admin extension, it is not copied.
+
+---
+
 ## Notes (not requirements)
 
 **Capacity and cost.** ~1.5–2.5 GB RAM per job (pi + dev server + headless Chromium) and roughly

--- a/worker/src/cli.mjs
+++ b/worker/src/cli.mjs
@@ -8,6 +8,9 @@ import { gitDirty } from "./git-dirty.mjs";
 
 const USAGE = `pi-dispatch — run pi coding-agent flows on your own folders
 
+  pi-dispatch init         scaffold .env + triggers.json + pause-windows.json in this folder
+  pi-dispatch doctor       preflight Docker, Valkey, the job image, and your provider key
+
   pi-dispatch run <folder> --task "<what to do>" [--flow <name>]
                            [--provider <p>] [--model <m>] [--max-turns <n>] [--force]
   pi-dispatch worker       drain the queue (run this in another terminal, or as a service)
@@ -19,6 +22,16 @@ Config comes from the environment (see .env.example); flags override it per run.
 
 export async function main(argv = process.argv.slice(2), env = process.env) {
 	const cmd = argv[0];
+
+	if (cmd === "init") {
+		const { runInit } = await import("./init.mjs");
+		return runInit(process.cwd());
+	}
+
+	if (cmd === "doctor") {
+		const { runDoctor } = await import("./doctor.mjs");
+		return runDoctor(env);
+	}
 
 	if (cmd === "worker") {
 		const { startWorker } = await import("./start.mjs");

--- a/worker/src/cli.mjs
+++ b/worker/src/cli.mjs
@@ -10,6 +10,8 @@ const USAGE = `pi-dispatch — run pi coding-agent flows on your own folders
 
   pi-dispatch init         scaffold .env + triggers.json + pause-windows.json in this folder
   pi-dispatch doctor       preflight Docker, Valkey, the job image, and your provider key
+  pi-dispatch import-pi    stage your host pi setup (models/skills/persona) into a global overlay
+                           [--with-extensions] [--from <agentDir>] [--to <overlayDir>]
 
   pi-dispatch run <folder> --task "<what to do>" [--flow <name>]
                            [--provider <p>] [--model <m>] [--max-turns <n>] [--force]
@@ -31,6 +33,11 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
 	if (cmd === "doctor") {
 		const { runDoctor } = await import("./doctor.mjs");
 		return runDoctor(env);
+	}
+
+	if (cmd === "import-pi") {
+		const { runImportPi } = await import("./import-pi.mjs");
+		return runImportPi(argv.slice(1), { env });
 	}
 
 	if (cmd === "worker") {

--- a/worker/src/config.mjs
+++ b/worker/src/config.mjs
@@ -62,6 +62,25 @@ function delimitedList(raw) {
 		.filter((s) => s.length > 0);
 }
 
+// A comma-separated list of NAMES (env var names cannot contain commas, so unlike a path list this
+// splits on ",", not the OS path delimiter). Used by PI_FORWARD_ENV.
+function commaList(raw) {
+	return (raw ?? "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+}
+
+// The operator's global pi overlay dir (REQ-GLOBAL-PI-OVERLAY). Unset/empty = feature off. When set it
+// must EXIST at boot -- a typo pointing at nothing would silently drop the operator's whole setup on
+// every job, so fail loud like every other config error rather than degrade to nothing.
+function resolveGlobalPiDir(env, fileExists) {
+	const dir = env.PI_GLOBAL_PI_DIR;
+	if (dir === undefined || dir === "") return null;
+	if (!fileExists(dir)) throw configError(`PI_GLOBAL_PI_DIR does not exist: ${dir}`);
+	return dir;
+}
+
 /**
  * Parse the worker's config from `env` (default process.env). All defaults are conservative:
  * spend controls (`PI_DAILY_CAP`, `PI_MAX_TURNS`) exist to bound money, so they default low, and a
@@ -84,6 +103,9 @@ export function loadConfig(env = process.env, { fileExists = existsSync } = {}) 
 		maxTokens: optionalBoundedInt(env, "PI_MAX_TOKENS", 1), // issue #25; null = per-job token budget disabled (lagging in-run backstop)
 		dailyTokenCap: optionalBoundedInt(env, "PI_DAILY_TOKEN_CAP", 1), // issue #25; null = daily token counter disabled (check-AFTER, host-side)
 		jobImage: env.PI_JOB_IMAGE ?? "pi-job:latest",
+		globalPiDir: resolveGlobalPiDir(env, fileExists), // REQ-GLOBAL-PI-OVERLAY: operator's ~/.pi/agent subset, :ro-mounted; null = off
+		allowGlobalExtensions: env.PI_GLOBAL_ALLOW_EXTENSIONS === "1", // fail-closed: overlay extensions load only when armed
+		forwardEnv: commaList(env.PI_FORWARD_ENV), // extra host var NAMES to forward (e.g. a custom provider's key); explicit allowlist
 		jobsDir: env.PI_JOBS_DIR ?? defaultJobsDir(),
 		triggersFile: env.PI_TRIGGERS_FILE ?? null, // DES-CRON-VIA-BULLMQ-SCHEDULER: unified triggers file; null = cron disabled for the worker (it selects on.type:"cron")
 		pauseWindowsFile: env.PI_PAUSE_WINDOWS_FILE ?? null, // REQ-SCOPED-PAUSE-WINDOWS: per-folder/repo timed pause; null = no scoped pauses

--- a/worker/src/config.mjs
+++ b/worker/src/config.mjs
@@ -106,6 +106,7 @@ export function loadConfig(env = process.env, { fileExists = existsSync } = {}) 
 		globalPiDir: resolveGlobalPiDir(env, fileExists), // REQ-GLOBAL-PI-OVERLAY: operator's ~/.pi/agent subset, :ro-mounted; null = off
 		allowGlobalExtensions: env.PI_GLOBAL_ALLOW_EXTENSIONS === "1", // fail-closed: overlay extensions load only when armed
 		forwardEnv: commaList(env.PI_FORWARD_ENV), // extra host var NAMES to forward (e.g. a custom provider's key); explicit allowlist
+		authFromPi: env.PI_AUTH_FROM_PI === "1", // fall back to the provider key in ~/.pi/agent/auth.json when the env has none (api-key only)
 		jobsDir: env.PI_JOBS_DIR ?? defaultJobsDir(),
 		triggersFile: env.PI_TRIGGERS_FILE ?? null, // DES-CRON-VIA-BULLMQ-SCHEDULER: unified triggers file; null = cron disabled for the worker (it selects on.type:"cron")
 		pauseWindowsFile: env.PI_PAUSE_WINDOWS_FILE ?? null, // REQ-SCOPED-PAUSE-WINDOWS: per-folder/repo timed pause; null = no scoped pauses

--- a/worker/src/config.mjs
+++ b/worker/src/config.mjs
@@ -106,7 +106,7 @@ export function loadConfig(env = process.env, { fileExists = existsSync } = {}) 
 		globalPiDir: resolveGlobalPiDir(env, fileExists), // REQ-GLOBAL-PI-OVERLAY: operator's ~/.pi/agent subset, :ro-mounted; null = off
 		allowGlobalExtensions: env.PI_GLOBAL_ALLOW_EXTENSIONS === "1", // fail-closed: overlay extensions load only when armed
 		forwardEnv: commaList(env.PI_FORWARD_ENV), // extra host var NAMES to forward (e.g. a custom provider's key); explicit allowlist
-		authFromPi: env.PI_AUTH_FROM_PI === "1", // fall back to the provider key in ~/.pi/agent/auth.json when the env has none (api-key only)
+		authFromPi: env.PI_AUTH_FROM_PI !== "0", // ON by default: use the key in ~/.pi/agent/auth.json when the env has none (api-key only). PI_AUTH_FROM_PI=0 forces env-only.
 		jobsDir: env.PI_JOBS_DIR ?? defaultJobsDir(),
 		triggersFile: env.PI_TRIGGERS_FILE ?? null, // DES-CRON-VIA-BULLMQ-SCHEDULER: unified triggers file; null = cron disabled for the worker (it selects on.type:"cron")
 		pauseWindowsFile: env.PI_PAUSE_WINDOWS_FILE ?? null, // REQ-SCOPED-PAUSE-WINDOWS: per-folder/repo timed pause; null = no scoped pauses

--- a/worker/src/docker-run.mjs
+++ b/worker/src/docker-run.mjs
@@ -27,6 +27,7 @@ export const ISOLATION_FLAGS = [
  * @param jobDir     host path to the /job inputs dir (contains prompt.md and pi/); mounted /job:ro
  * @param workspace  host path to the fresh clone / local folder (mounted /workspace:rw)
  * @param outboxDir  host path to the /outbox chain-request dir (local jobs only); mounted /outbox:rw
+ * @param globalPiDir host path to the operator's global pi overlay (REQ-GLOBAL-PI-OVERLAY); mounted /opt/pi-global:ro
  * @param name       container name (for `docker stop` at the timeout)
  * @param memory     e.g. "4g"; cpus e.g. "2"
  * @param extraFlags escape hatch for a Linux-only --user uid:gid on a bind-mounted local folder
@@ -37,6 +38,7 @@ export function buildDockerRunArgs({
 	jobDir,
 	workspace,
 	outboxDir,
+	globalPiDir,
 	name,
 	memory = "4g",
 	cpus = "2",
@@ -64,6 +66,11 @@ export function buildDockerRunArgs({
 	// (DES-WORKER-ON-HOST). github jobs pass no outboxDir, so the request channel does not exist for
 	// them -- an untrusted issue author cannot chain (INT-OUTBOX-CONTRACT).
 	if (outboxDir) args.push("-v", `${outboxDir}:/outbox`);
+
+	// The operator's global pi overlay (REQ-GLOBAL-PI-OVERLAY): custom models, global skills, a global
+	// persona, layered UNDER each repo's own .pi/. Read-only -- it is operator-authored deploy-time config,
+	// the same trust class as the baked floor, but the agent still must not rewrite it. Both job kinds.
+	if (globalPiDir) args.push("-v", `${globalPiDir}:/opt/pi-global:ro`);
 
 	args.push(image);
 	return args;

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -7,9 +7,10 @@
  * switch in cli.mjs, which reads only VALKEY_URL for the same reason (it must work when GitHub is
  * misconfigured). The provider key is checked for presence only and never printed (secrets-and-pii).
  */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawn as nodeSpawn } from "node:child_process";
+import { findLiteralSecret } from "./import-pi.mjs";
 
 const NODE_FLOOR = [22, 19]; // pi's engine floor (22.19.0)
 
@@ -73,6 +74,49 @@ export async function runDoctor(env = process.env, deps = {}) {
 		label: `Provider key set (${provider}: ${keys.join(" or ")})`,
 		fix: `set ${keys[0]} in .env`,
 	});
+
+	// Global pi overlay (REQ-GLOBAL-PI-OVERLAY), only when configured. The overlay is mounted :ro into an
+	// adversarial-input container, so the load-bearing checks are that it holds NO credential.
+	const overlay = env.PI_GLOBAL_PI_DIR;
+	if (overlay) {
+		const dirOk = fileExists(overlay);
+		checks.push({ ok: dirOk, label: `Global overlay dir exists (${overlay})`, fix: "run `pi-dispatch import-pi`, or fix PI_GLOBAL_PI_DIR" });
+		if (dirOk) {
+			checks.push({
+				ok: !fileExists(join(overlay, "auth.json")),
+				label: "Overlay is credential-free (no auth.json)",
+				fix: "delete auth.json from the overlay — the provider key belongs in env, never a mounted file",
+			});
+			const modelsPath = join(overlay, "models.json");
+			let modelsOk = true;
+			let modelsFix = "";
+			if (fileExists(modelsPath)) {
+				try {
+					const leak = findLiteralSecret(JSON.parse(readFileSync(modelsPath, "utf8")));
+					if (leak) {
+						modelsOk = false;
+						modelsFix = `literal secret at ${leak} — move it to env/auth.json or a "$VAR" reference`;
+					}
+				} catch {
+					modelsOk = false;
+					modelsFix = "overlay models.json is not valid JSON";
+				}
+			}
+			checks.push({ ok: modelsOk, label: "Overlay models.json is credential-free", fix: modelsFix });
+			if (fileExists(join(overlay, "extensions"))) {
+				if (env.PI_GLOBAL_ALLOW_EXTENSIONS === "1") {
+					checks.push({
+						ok: false,
+						warn: true,
+						label: "Overlay extensions present and ARMED (PI_GLOBAL_ALLOW_EXTENSIONS=1)",
+						fix: "they run code against adversarial input with open egress — vet each; never the admin extension",
+					});
+				} else {
+					checks.push({ ok: true, label: "Overlay extensions present but dormant (PI_GLOBAL_ALLOW_EXTENSIONS unset)" });
+				}
+			}
+		}
+	}
 
 	let failed = false;
 	for (const c of checks) {

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -8,6 +8,7 @@
  * misconfigured). The provider key is checked for presence only and never printed (secrets-and-pii).
  */
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawn as nodeSpawn } from "node:child_process";
 import { findLiteralSecret } from "./import-pi.mjs";
@@ -69,10 +70,25 @@ export async function runDoctor(env = process.env, deps = {}) {
 	});
 
 	const keys = PROVIDER_KEYS[provider] ?? [`${provider.toUpperCase()}_API_KEY`];
+	let keyOk = keys.some((k) => (env[k] ?? "").trim().length > 0);
+	let keyNote = "";
+	// PI_AUTH_FROM_PI: the key may come from pi's auth.json instead of the env, so don't falsely report it missing.
+	if (!keyOk && env.PI_AUTH_FROM_PI === "1") {
+		const agentDir = env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+		try {
+			const cred = JSON.parse(readFileSync(join(agentDir, "auth.json"), "utf8"))?.[provider];
+			if (cred?.type === "api_key" && cred.key) {
+				keyOk = true;
+				keyNote = " — from pi auth.json (PI_AUTH_FROM_PI)";
+			} else if (cred?.type === "oauth") {
+				keyNote = " — pi login is OAuth/subscription: not usable for an unattended service, configure an API key";
+			}
+		} catch {}
+	}
 	checks.push({
-		ok: keys.some((k) => (env[k] ?? "").trim().length > 0),
-		label: `Provider key set (${provider}: ${keys.join(" or ")})`,
-		fix: `set ${keys[0]} in .env`,
+		ok: keyOk,
+		label: `Provider key set (${provider}: ${keys.join(" or ")})${keyNote}`,
+		fix: env.PI_AUTH_FROM_PI === "1" ? `run \`pi login\` with an API key for ${provider}, or set ${keys[0]} in .env` : `set ${keys[0]} in .env`,
 	});
 
 	// Global pi overlay (REQ-GLOBAL-PI-OVERLAY), only when configured. The overlay is mounted :ro into an

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -1,0 +1,133 @@
+/**
+ * `pi-dispatch doctor` — preflight the host before the first job. Prints a ✓/⚠/✗ line per prerequisite
+ * with a one-line fix, and exits non-zero if any hard check fails, so it is usable in a setup script.
+ *
+ * Reads the handful of values it needs with config.mjs's own defaults rather than loadConfig, so it
+ * runs even when GitHub auth is unset — a local-folder deployment needs none of it. Mirrors the kill
+ * switch in cli.mjs, which reads only VALKEY_URL for the same reason (it must work when GitHub is
+ * misconfigured). The provider key is checked for presence only and never printed (secrets-and-pii).
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawn as nodeSpawn } from "node:child_process";
+
+const NODE_FLOOR = [22, 19]; // pi's engine floor (22.19.0)
+
+// Which env var holds the credential for each provider. Presence is checked, value never read out.
+// anthropic lists the OAuth token too because it silently takes precedence over the API key upstream.
+const PROVIDER_KEYS = {
+	anthropic: ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"],
+	openai: ["OPENAI_API_KEY"],
+	google: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+	gemini: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+};
+
+export async function runDoctor(env = process.env, deps = {}) {
+	const {
+		cwd = process.cwd(),
+		out = (s) => process.stdout.write(s),
+		spawn = nodeSpawn,
+		probeValkey = defaultProbeValkey,
+		fileExists = existsSync,
+		nodeVersion = process.versions.node,
+	} = deps;
+
+	const jobImage = env.PI_JOB_IMAGE ?? "pi-job:latest";
+	const valkeyUrl = env.VALKEY_URL ?? "redis://127.0.0.1:6379";
+	const provider = env.PI_PROVIDER ?? "anthropic";
+
+	const checks = [];
+	checks.push(nodeCheck(nodeVersion));
+
+	checks.push({
+		ok: fileExists(join(cwd, ".env")),
+		warn: true, // advisory: env may be supplied by a service manager instead of a file
+		label: ".env present",
+		fix: "run `pi-dispatch init` to scaffold one (or supply env via your service manager)",
+	});
+
+	const dockerCode = await runCmd(spawn, "docker", ["info"]);
+	checks.push({
+		ok: dockerCode === 0,
+		label: "Docker daemon reachable",
+		fix: dockerCode === null ? "install Docker — `docker` was not found on PATH" : "start Docker (the daemon is not responding)",
+	});
+
+	// Only meaningful if docker itself responds; otherwise the image check is noise on top of a down daemon.
+	const imageCode = dockerCode === 0 ? await runCmd(spawn, "docker", ["image", "inspect", jobImage]) : null;
+	checks.push({
+		ok: imageCode === 0,
+		label: `Job image present (${jobImage})`,
+		fix: "docker pull ghcr.io/edgehero/pi-job:latest && docker tag ghcr.io/edgehero/pi-job:latest pi-job:latest  (or build image/Dockerfile)",
+	});
+
+	checks.push({
+		ok: await probeValkey(valkeyUrl),
+		label: `Valkey reachable (${valkeyUrl})`,
+		fix: "docker compose -f deploy/docker-compose.yml up -d",
+	});
+
+	const keys = PROVIDER_KEYS[provider] ?? [`${provider.toUpperCase()}_API_KEY`];
+	checks.push({
+		ok: keys.some((k) => (env[k] ?? "").trim().length > 0),
+		label: `Provider key set (${provider}: ${keys.join(" or ")})`,
+		fix: `set ${keys[0]} in .env`,
+	});
+
+	let failed = false;
+	for (const c of checks) {
+		out(`${c.ok ? "✓" : c.warn ? "⚠" : "✗"} ${c.label}\n`);
+		if (!c.ok) {
+			out(`    → ${c.fix}\n`);
+			if (!c.warn) failed = true;
+		}
+	}
+	out(failed ? "\ndoctor: some checks failed — fix the above, then re-run.\n" : "\ndoctor: ready. Start the worker with `pi-dispatch worker`.\n");
+	return failed ? 1 : 0;
+}
+
+function nodeCheck(version) {
+	const [maj, min] = version.split(".").map((n) => Number.parseInt(n, 10));
+	const ok = maj > NODE_FLOOR[0] || (maj === NODE_FLOOR[0] && min >= NODE_FLOOR[1]);
+	return {
+		ok,
+		label: `Node ≥ ${NODE_FLOOR[0]}.${NODE_FLOOR[1]} (have ${version})`,
+		fix: `upgrade Node to ${NODE_FLOOR[0]}.${NODE_FLOOR[1]} or newer`,
+	};
+}
+
+/** Resolve a spawned command's exit code; null means it could not be launched (e.g. not on PATH). */
+function runCmd(spawn, cmd, args) {
+	return new Promise((resolve) => {
+		let child;
+		try {
+			child = spawn(cmd, args, { stdio: "ignore" });
+		} catch {
+			resolve(null);
+			return;
+		}
+		child.on("error", () => resolve(null)); // ENOENT etc. — the binary is not available
+		child.on("close", (code) => resolve(code));
+	});
+}
+
+/**
+ * Reachability probe with a raw, fail-fast ioredis client. `lazyConnect` holds the connect until the
+ * error handler is attached, so a down Valkey is reported as one ✗ line — not the ioredis stack traces
+ * a BullMQ Queue's internal client would dump. Reuses `parseConnection`'s fail-fast options (cli.mjs:88).
+ */
+async function defaultProbeValkey(url) {
+	const { Redis } = await import("ioredis");
+	const { parseConnection } = await import("./connection.mjs");
+	const client = new Redis({ ...parseConnection(url, { failFast: true }), lazyConnect: true });
+	client.on("error", () => {}); // swallow connect errors + retries; reachability is the ✓/✗, not a trace
+	try {
+		await client.connect();
+		await client.ping();
+		return true;
+	} catch {
+		return false;
+	} finally {
+		client.disconnect();
+	}
+}

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -72,14 +72,16 @@ export async function runDoctor(env = process.env, deps = {}) {
 	const keys = PROVIDER_KEYS[provider] ?? [`${provider.toUpperCase()}_API_KEY`];
 	let keyOk = keys.some((k) => (env[k] ?? "").trim().length > 0);
 	let keyNote = "";
-	// PI_AUTH_FROM_PI: the key may come from pi's auth.json instead of the env, so don't falsely report it missing.
-	if (!keyOk && env.PI_AUTH_FROM_PI === "1") {
+	// The key may come from pi's auth.json when the env has none (ON by default; PI_AUTH_FROM_PI=0 forces
+	// env-only) — so don't falsely report it missing.
+	const authFromPi = env.PI_AUTH_FROM_PI !== "0";
+	if (!keyOk && authFromPi) {
 		const agentDir = env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
 		try {
 			const cred = JSON.parse(readFileSync(join(agentDir, "auth.json"), "utf8"))?.[provider];
 			if (cred?.type === "api_key" && cred.key) {
 				keyOk = true;
-				keyNote = " — from pi auth.json (PI_AUTH_FROM_PI)";
+				keyNote = " — from pi auth.json";
 			} else if (cred?.type === "oauth") {
 				keyNote = " — pi login is OAuth/subscription: not usable for an unattended service, configure an API key";
 			}
@@ -88,7 +90,7 @@ export async function runDoctor(env = process.env, deps = {}) {
 	checks.push({
 		ok: keyOk,
 		label: `Provider key set (${provider}: ${keys.join(" or ")})${keyNote}`,
-		fix: env.PI_AUTH_FROM_PI === "1" ? `run \`pi login\` with an API key for ${provider}, or set ${keys[0]} in .env` : `set ${keys[0]} in .env`,
+		fix: authFromPi ? `run \`pi login\` with an API key for ${provider}, or set ${keys[0]} in .env` : `set ${keys[0]} in .env`,
 	});
 
 	// Global pi overlay (REQ-GLOBAL-PI-OVERLAY), only when configured. The overlay is mounted :ro into an

--- a/worker/src/env-allowlist.mjs
+++ b/worker/src/env-allowlist.mjs
@@ -29,7 +29,7 @@ export function providerKeyVars(provider, hostEnv) {
  * Throws if the provider is not configured -- a deterministic misconfiguration the caller maps to
  * a pre-spend refusal, never a launched-then-failed container.
  */
-export function buildContainerEnv({ provider, model, maxTurns, maxTokens, jobId, githubToken, hostEnv }) {
+export function buildContainerEnv({ provider, model, maxTurns, maxTokens, jobId, githubToken, hostEnv, allowGlobalExtensions = false, forwardEnv = [] }) {
 	const keyVars = providerKeyVars(provider, hostEnv);
 	if (!keyVars || keyVars.length === 0) {
 		const error = new Error(`provider ${provider} has no configured credential in the worker environment`);
@@ -50,12 +50,23 @@ export function buildContainerEnv({ provider, model, maxTurns, maxTokens, jobId,
 		PLAYWRIGHT_BROWSERS_PATH: "/ms-playwright",
 		PLAYWRIGHT_MCP_BROWSER: "chromium",
 		PLAYWRIGHT_MCP_SANDBOX: "false",
+		// Arms loading of the global overlay's extensions in the runner (REQ-GLOBAL-PI-OVERLAY). Fail-closed:
+		// only set when the operator opted in, so an unset value keeps overlay extensions dormant.
+		PI_GLOBAL_ALLOW_EXTENSIONS: allowGlobalExtensions ? "1" : undefined,
 	};
 
 	// The provider credential(s), by their real names, copied from the host by EXACT name. Passing
 	// the value under pi's expected variable name is what lets pi's own auth resolution find it.
 	for (const name of keyVars) {
 		env[name] = hostEnv[name];
+	}
+
+	// Operator-declared extra vars (PI_FORWARD_ENV), forwarded by EXACT name -- the allowlist
+	// no-broad-env-into-container prescribes, not a host pass-through. This is how a CUSTOM provider's
+	// key (one pi's findEnvKeys table does not know) reaches the container. A name whose value is unset
+	// on the host is skipped, never forwarded as empty.
+	for (const name of forwardEnv) {
+		if (hostEnv[name] !== undefined) env[name] = hostEnv[name];
 	}
 
 	// GitHub-backed jobs only. Local-folder jobs have no token (CONST-TOKEN-SCOPED-PER-JOB is

--- a/worker/src/env-allowlist.mjs
+++ b/worker/src/env-allowlist.mjs
@@ -1,4 +1,13 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { findEnvKeys } from "@earendil-works/pi-ai/compat";
+
+function configError(message) {
+	const error = new Error(message);
+	error.piDispatchConfig = true;
+	return error;
+}
 
 /**
  * Build the EXACT environment a job container receives. Never a pass-through.
@@ -23,19 +32,81 @@ export function providerKeyVars(provider, hostEnv) {
 }
 
 /**
+ * Resolve the provider credential(s) to inject, as `{ VAR_NAME: value }`.
+ *
+ * Primary source: the worker's own environment, by pi's expected variable name(s) (`findEnvKeys`).
+ * Fallback (only when `PI_AUTH_FROM_PI` is set and the env has none): read the credential from the host's
+ * pi `auth.json`. This is a HOST-SIDE read of a host-held secret, injected via env exactly like the env
+ * path — never a credential file mounted into the container (`CONST-TOKEN-SCOPED-PER-JOB`). API-key
+ * credentials only; an OAuth/subscription login is refused (it expires, the container cannot refresh it,
+ * and it is not the credential for an unattended service). Throws a config-tagged error (pre-spend refusal)
+ * when neither source yields a credential.
+ */
+export function resolveProviderCredential({ provider, hostEnv, authFromPi = false, agentDir, readFile = readFileSync }) {
+	const envNames = providerKeyVars(provider, hostEnv);
+	if (envNames && envNames.length > 0) {
+		return Object.fromEntries(envNames.map((name) => [name, hostEnv[name]]));
+	}
+	if (authFromPi) {
+		const { name, value } = credentialFromPiAuth(provider, agentDir ?? defaultAgentDir(hostEnv), readFile);
+		return { [name]: value };
+	}
+	throw configError(`provider ${provider} has no configured credential in the worker environment`);
+}
+
+function defaultAgentDir(hostEnv) {
+	// pi's getAgentDir() default, resolved without importing the whole pi SDK into the worker.
+	return hostEnv.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+}
+
+function credentialFromPiAuth(provider, agentDir, readFile) {
+	const path = join(agentDir, "auth.json");
+	let auth;
+	try {
+		auth = JSON.parse(readFile(path, "utf8"));
+	} catch {
+		throw configError(`PI_AUTH_FROM_PI is set but ${path} is missing or unreadable — run \`pi login\`, or set the provider key in the worker environment`);
+	}
+	const cred = auth?.[provider];
+	if (!cred) throw configError(`PI_AUTH_FROM_PI: ${path} has no credential for provider "${provider}"`);
+	if (cred.type === "oauth") {
+		throw configError(
+			`PI_AUTH_FROM_PI: the pi login for "${provider}" is an OAuth/subscription token, which cannot power an unattended service (it expires and the container cannot refresh it). Configure an API key — with a provider-side spend limit — instead.`,
+		);
+	}
+	if (cred.type !== "api_key" || !cred.key) throw configError(`PI_AUTH_FROM_PI: unsupported credential for "${provider}" in ${path}`);
+	const name = resolveEnvName(provider, cred);
+	if (!name) {
+		throw configError(`PI_AUTH_FROM_PI: could not determine the environment variable pi expects for provider "${provider}" — set it in the worker environment manually`);
+	}
+	return { name, value: cred.key };
+}
+
+/**
+ * The env var name pi reads this provider's key from. Discovered through pi's OWN `findEnvKeys` (the
+ * oracle) rather than a hand-maintained provider→var table that would drift: try the credential's own
+ * `env` hint plus the conventional `<PROVIDER>_API_KEY`/`_KEY`, and forward the one pi recognizes.
+ */
+function resolveEnvName(provider, cred) {
+	const upper = provider.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+	const candidates = [cred.env, `${upper}_API_KEY`, `${upper}_KEY`].filter((s) => typeof s === "string" && s.length > 0);
+	const synthetic = Object.fromEntries(candidates.map((name) => [name, cred.key]));
+	const recognized = findEnvKeys(provider, synthetic);
+	return recognized?.[0] ?? null;
+}
+
+/**
  * Assemble the container env. `hostEnv` is the worker's process.env; `job` carries the resolved
  * config and the per-job scoped token (GitHub-backed jobs only).
  *
  * Throws if the provider is not configured -- a deterministic misconfiguration the caller maps to
  * a pre-spend refusal, never a launched-then-failed container.
  */
-export function buildContainerEnv({ provider, model, maxTurns, maxTokens, jobId, githubToken, hostEnv, allowGlobalExtensions = false, forwardEnv = [] }) {
-	const keyVars = providerKeyVars(provider, hostEnv);
-	if (!keyVars || keyVars.length === 0) {
-		const error = new Error(`provider ${provider} has no configured credential in the worker environment`);
-		error.piDispatchConfig = true;
-		throw error;
-	}
+export function buildContainerEnv({ provider, model, maxTurns, maxTokens, jobId, githubToken, hostEnv, allowGlobalExtensions = false, forwardEnv = [], authFromPi = false, agentDir, readFile = readFileSync }) {
+	// The provider credential(s), by pi's expected variable name(s) -- from the worker env, or (when
+	// PI_AUTH_FROM_PI is set and the env has none) host-side from pi's auth.json. Throws (config) if
+	// neither source yields one, which the processor turns into a pre-spend refusal.
+	const credEnv = resolveProviderCredential({ provider, hostEnv, authFromPi, agentDir, readFile });
 
 	const env = {
 		PI_PROVIDER: provider,
@@ -55,11 +126,8 @@ export function buildContainerEnv({ provider, model, maxTurns, maxTokens, jobId,
 		PI_GLOBAL_ALLOW_EXTENSIONS: allowGlobalExtensions ? "1" : undefined,
 	};
 
-	// The provider credential(s), by their real names, copied from the host by EXACT name. Passing
-	// the value under pi's expected variable name is what lets pi's own auth resolution find it.
-	for (const name of keyVars) {
-		env[name] = hostEnv[name];
-	}
+	// The provider credential(s), under pi's expected variable name(s), so pi's own auth resolution finds them.
+	Object.assign(env, credEnv);
 
 	// Operator-declared extra vars (PI_FORWARD_ENV), forwarded by EXACT name -- the allowlist
 	// no-broad-env-into-container prescribes, not a host pass-through. This is how a CUSTOM provider's

--- a/worker/src/env-allowlist.mjs
+++ b/worker/src/env-allowlist.mjs
@@ -35,12 +35,12 @@ export function providerKeyVars(provider, hostEnv) {
  * Resolve the provider credential(s) to inject, as `{ VAR_NAME: value }`.
  *
  * Primary source: the worker's own environment, by pi's expected variable name(s) (`findEnvKeys`).
- * Fallback (only when `PI_AUTH_FROM_PI` is set and the env has none): read the credential from the host's
- * pi `auth.json`. This is a HOST-SIDE read of a host-held secret, injected via env exactly like the env
- * path — never a credential file mounted into the container (`CONST-TOKEN-SCOPED-PER-JOB`). API-key
- * credentials only; an OAuth/subscription login is refused (it expires, the container cannot refresh it,
- * and it is not the credential for an unattended service). Throws a config-tagged error (pre-spend refusal)
- * when neither source yields a credential.
+ * Fallback (ON by default; `PI_AUTH_FROM_PI=0` forces env-only): when the env has none, read the credential
+ * from the host's pi `auth.json`. This is a HOST-SIDE read of a host-held secret, injected via env exactly
+ * like the env path — never a credential file mounted into the container (`CONST-TOKEN-SCOPED-PER-JOB`).
+ * API-key credentials only; an OAuth/subscription login is refused (it expires, the container cannot refresh
+ * it, and it is not the credential for an unattended service). Throws a config-tagged error (pre-spend
+ * refusal) when neither source yields a credential.
  */
 export function resolveProviderCredential({ provider, hostEnv, authFromPi = false, agentDir, readFile = readFileSync }) {
 	const envNames = providerKeyVars(provider, hostEnv);
@@ -65,19 +65,19 @@ function credentialFromPiAuth(provider, agentDir, readFile) {
 	try {
 		auth = JSON.parse(readFile(path, "utf8"));
 	} catch {
-		throw configError(`PI_AUTH_FROM_PI is set but ${path} is missing or unreadable — run \`pi login\`, or set the provider key in the worker environment`);
+		throw configError(`no credential for provider "${provider}": not in the worker environment, and no pi login at ${path} — set the key in .env, or run \`pi login\``);
 	}
 	const cred = auth?.[provider];
-	if (!cred) throw configError(`PI_AUTH_FROM_PI: ${path} has no credential for provider "${provider}"`);
+	if (!cred) throw configError(`no credential for provider "${provider}": not in the worker environment, and ${path} has no "${provider}" login — set the key in .env, or run \`pi login\``);
 	if (cred.type === "oauth") {
 		throw configError(
-			`PI_AUTH_FROM_PI: the pi login for "${provider}" is an OAuth/subscription token, which cannot power an unattended service (it expires and the container cannot refresh it). Configure an API key — with a provider-side spend limit — instead.`,
+			`the pi login for "${provider}" is an OAuth/subscription token, which cannot power an unattended service (it expires and the container cannot refresh it). Configure an API key — with a provider-side spend limit — instead.`,
 		);
 	}
-	if (cred.type !== "api_key" || !cred.key) throw configError(`PI_AUTH_FROM_PI: unsupported credential for "${provider}" in ${path}`);
+	if (cred.type !== "api_key" || !cred.key) throw configError(`unsupported pi credential for "${provider}" in ${path} — set an API key in .env`);
 	const name = resolveEnvName(provider, cred);
 	if (!name) {
-		throw configError(`PI_AUTH_FROM_PI: could not determine the environment variable pi expects for provider "${provider}" — set it in the worker environment manually`);
+		throw configError(`could not determine the environment variable pi expects for provider "${provider}" — set it in the worker environment manually`);
 	}
 	return { name, value: cred.key };
 }

--- a/worker/src/import-pi.mjs
+++ b/worker/src/import-pi.mjs
@@ -1,0 +1,206 @@
+/**
+ * `pi-dispatch import-pi` — stage a CREDENTIAL-FREE copy of the host's `pi` setup into a global overlay
+ * dir, so every job can reuse it (REQ-GLOBAL-PI-OVERLAY). Point `PI_GLOBAL_PI_DIR` at the result and the
+ * worker mounts it `:ro` into each container, layered UNDER each repo's own `.pi/`.
+ *
+ * The overlay must never carry a secret (CONST-TOKEN-SCOPED-PER-JOB): the provider key stays in the host's
+ * `auth.json` / env and reaches the container through the env allowlist, never a mounted file. So this
+ * command copies only the safe subset and REFUSES a `models.json` that embeds a literal key.
+ *
+ * Copied:   models.json (definitions only, sanitized), skills/, APPEND_SYSTEM.md, and — only under
+ *           --with-extensions — extensions/ (verbatim; the admin extension is hard-blocked).
+ * Never:    auth.json, settings.json, sessions/, themes/, prompts/, tools/.
+ */
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, statSync, copyFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** A valid skill/extension entry name: lowercase kebab/underscore, no dots (no "..") and no slashes. */
+const ENTRY_NAME_RE = /^[a-z0-9](?:[a-z0-9_.-]{0,62}[a-z0-9])?$/i;
+/** The admin extension — never duplicated into a job overlay (it can enqueue paid jobs: a recursion vector). */
+const ADMIN_RE = /pi-dispatch|dispatch-admin/i;
+
+// Resolve the host's pi agent dir the way pi's getAgentDir() does (env override, else ~/.pi/agent).
+// Custom: the worker CLI depends on @earendil-works/pi-ai/compat, not the whole pi-coding-agent SDK;
+// importing the SDK just to read one well-known path is not worth the weight.
+function defaultFrom(env) {
+	return env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+}
+
+/** A config value that defers to the environment/a command rather than embedding a literal secret. */
+function isIndirection(v) {
+	return typeof v === "string" && (v.startsWith("$") || v.startsWith("!"));
+}
+
+/**
+ * Find a literal secret in a parsed models.json. Returns a human-readable location, or null if clean.
+ * A provider `apiKey`, or an auth-ish header, that is a plain string (not `$ENV` / `!cmd`) is a literal.
+ */
+export function findLiteralSecret(models) {
+	const providers = models?.providers;
+	if (!providers || typeof providers !== "object") return null;
+	for (const [name, cfg] of Object.entries(providers)) {
+		if (typeof cfg?.apiKey === "string" && !isIndirection(cfg.apiKey)) return `providers.${name}.apiKey`;
+		const headers = cfg?.headers;
+		if (headers && typeof headers === "object") {
+			for (const [h, val] of Object.entries(headers)) {
+				if (/auth|api[-_]?key|token|secret|bearer/i.test(h) && typeof val === "string" && !isIndirection(val)) {
+					return `providers.${name}.headers.${h}`;
+				}
+			}
+		}
+	}
+	return null;
+}
+
+export function runImportPi(argv = [], deps = {}) {
+	const {
+		env = process.env,
+		cwd = process.cwd(),
+		out = (s) => process.stdout.write(s),
+		fs = { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, statSync, copyFileSync },
+	} = deps;
+
+	const withExtensions = argv.includes("--with-extensions");
+	const from = flagValue(argv, "--from") ?? defaultFrom(env);
+	const to = flagValue(argv, "--to") ?? join(cwd, "pi-global");
+
+	if (!fs.existsSync(from)) {
+		out(`error: no pi setup found at ${from}\n  Is pi installed and configured? Set PI_CODING_AGENT_DIR or pass --from <dir>.\n`);
+		return 1;
+	}
+
+	// Pre-flight the one hard security gate BEFORE writing anything: a literal key in models.json aborts the
+	// whole import so no half-overlay is produced and no secret is ever written to the overlay.
+	const modelsSrc = join(from, "models.json");
+	let modelsText;
+	if (fs.existsSync(modelsSrc)) {
+		modelsText = fs.readFileSync(modelsSrc, "utf8");
+		let parsed;
+		try {
+			parsed = JSON.parse(modelsText);
+		} catch {
+			modelsText = null; // malformed: skip it with a warning rather than abort the whole import
+		}
+		if (parsed) {
+			const leak = findLiteralSecret(parsed);
+			if (leak) {
+				out(
+					`error: ${modelsSrc} embeds a literal secret at ${leak}.\n` +
+						`  The overlay is mounted into an adversarial-input container, so it must be credential-free.\n` +
+						`  Move the key to auth.json (\`pi\` login) or reference the environment (e.g. "$MY_KEY"), then re-run.\n`,
+				);
+				return 1;
+			}
+		}
+	}
+
+	const results = [];
+	fs.mkdirSync(to, { recursive: true });
+
+	// models.json — definitions only, already proven literal-secret-free above.
+	if (modelsText) {
+		fs.writeFileSync(join(to, "models.json"), modelsText);
+		results.push(["models.json", "custom model/provider definitions (credential-free)"]);
+	} else if (fs.existsSync(modelsSrc)) {
+		results.push(["models.json", "SKIPPED — not valid JSON"]);
+	}
+
+	// skills/ — copy each named skill dir (SKILL.md + its files), skipping symlinks and odd names.
+	const skillsCount = copyNamedDirs(fs, join(from, "skills"), join(to, "skills"), out);
+	if (skillsCount > 0) results.push(["skills/", `${skillsCount} skill${skillsCount === 1 ? "" : "s"}`]);
+
+	// APPEND_SYSTEM.md — the operator's global persona.
+	if (fs.existsSync(join(from, "APPEND_SYSTEM.md"))) {
+		fs.copyFileSync(join(from, "APPEND_SYSTEM.md"), join(to, "APPEND_SYSTEM.md"));
+		results.push(["APPEND_SYSTEM.md", "global persona (layers under each repo's persona)"]);
+	}
+
+	// extensions/ — the sharp edge. Off unless --with-extensions; the admin extension is always blocked.
+	const extSrc = join(from, "extensions");
+	if (withExtensions && fs.existsSync(extSrc)) {
+		const { copied, blocked } = copyExtensions(fs, extSrc, join(to, "extensions"), out);
+		if (copied > 0) results.push(["extensions/", `${copied} extension${copied === 1 ? "" : "s"} — VET THESE`]);
+		for (const name of blocked) out(`  blocked extension "${name}" — the admin extension must never run inside a job.\n`);
+		out(
+			"\n⚠ Extensions run code against adversarial input with open network egress and are NOT scanned for\n" +
+				"  secrets. Review every one, then arm them with PI_GLOBAL_ALLOW_EXTENSIONS=1 (they stay dormant otherwise).\n",
+		);
+	} else if (fs.existsSync(extSrc)) {
+		results.push(["extensions/", "skipped — re-run with --with-extensions to include (the risky part)"]);
+	}
+
+	out(`Imported the credential-free subset of ${from} → ${to}\n\n`);
+	for (const [name, note] of results) out(`  ${name.padEnd(18)} ${note}\n`);
+	out(`\n  (auth.json, settings.json, sessions/ are never copied — your credential stays in env/auth.json.)\n`);
+	out(nextSteps(to, withExtensions));
+	return 0;
+}
+
+/** Copy `<src>/<name>/**` for each valid, non-symlink child dir. Returns the count copied. */
+function copyNamedDirs(fs, src, dst, out) {
+	if (!fs.existsSync(src)) return 0;
+	let n = 0;
+	for (const name of fs.readdirSync(src)) {
+		if (!ENTRY_NAME_RE.test(name)) {
+			out(`  skipped "${name}" — unexpected name\n`);
+			continue;
+		}
+		const childSrc = join(src, name);
+		if (fs.statSync(childSrc).isSymbolicLink?.() || !fs.statSync(childSrc).isDirectory()) continue;
+		copyTree(fs, childSrc, join(dst, name));
+		n++;
+	}
+	return n;
+}
+
+/** Like copyNamedDirs but reports the admin extension it refuses to copy. */
+function copyExtensions(fs, src, dst, out) {
+	let copied = 0;
+	const blocked = [];
+	for (const name of fs.readdirSync(src)) {
+		if (ADMIN_RE.test(name)) {
+			blocked.push(name);
+			continue;
+		}
+		if (!ENTRY_NAME_RE.test(name)) {
+			out(`  skipped "${name}" — unexpected name\n`);
+			continue;
+		}
+		const childSrc = join(src, name);
+		const st = fs.statSync(childSrc);
+		if (st.isSymbolicLink?.()) continue;
+		if (st.isDirectory()) copyTree(fs, childSrc, join(dst, name));
+		else fs.copyFileSync(childSrc, join(dst, name));
+		copied++;
+	}
+	return { copied, blocked };
+}
+
+/** Recursively copy a directory tree, skipping symlinks (a symlink could point outside the source). */
+function copyTree(fs, src, dst) {
+	fs.mkdirSync(dst, { recursive: true });
+	for (const entry of fs.readdirSync(src)) {
+		const s = join(src, entry);
+		const st = fs.statSync(s);
+		if (st.isSymbolicLink?.()) continue;
+		if (st.isDirectory()) copyTree(fs, s, join(dst, entry));
+		else fs.copyFileSync(s, join(dst, entry));
+	}
+}
+
+function flagValue(argv, flag) {
+	const i = argv.indexOf(flag);
+	return i >= 0 && i + 1 < argv.length ? argv[i + 1] : undefined;
+}
+
+function nextSteps(to, withExtensions) {
+	const ext = withExtensions
+		? "  3. After vetting, set PI_GLOBAL_ALLOW_EXTENSIONS=1 in .env to load the overlay's extensions\n"
+		: "";
+	return `
+Next:
+  1. Set PI_GLOBAL_PI_DIR=${to} in .env
+  2. pi-dispatch doctor        # verifies the overlay is credential-free
+${ext}`;
+}

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -27,7 +27,7 @@ export const JOB_TIMEOUT_MS = 30 * 60 * 1000; // REQ-JOB-TIMEOUT-30M
  * The overlay changes which values the spend caps take, never when they are checked -- reserveBudget still
  * runs inside runJob against the freshly passed caps (CONST-BUDGET-BEFORE-TOKENS).
  */
-export function makeProcessor({ cancelJob, stopContainer, redis, getSettings, applyConcurrency = () => {}, pauseUntil = () => null, deps, recordRun = () => {}, timeoutMs = JOB_TIMEOUT_MS }) {
+export function makeProcessor({ cancelJob, stopContainer, redis, getSettings, applyConcurrency = () => {}, pauseUntil = () => null, deps, recordRun = () => {}, timeoutMs = JOB_TIMEOUT_MS, now = () => Date.now() }) {
 	return async function processor(job, token, signal) {
 		// Scoped pause windows (REQ-SCOPED-PAUSE-WINDOWS): if this job's folder/repo is inside an active pause
 		// window, DEFER it to the window end via BullMQ's delayed set -- the job keeps its identity/dedup and
@@ -36,8 +36,11 @@ export function makeProcessor({ cancelJob, stopContainer, redis, getSettings, ap
 		// (CONST-BUDGET-BEFORE-TOKENS). `moveToDelayed` needs the worker's `token`; the `> now + 1s` guard keeps
 		// a boundary tick from busy-deferring. A thrown `DelayedError` is how BullMQ learns the job was deferred
 		// (worker.js recognises it) rather than completed or failed.
-		const until = pauseUntil(job.data, Date.now());
-		if (until && until > Date.now() + 1000) {
+		// One clock snapshot for both the window lookup and the guard, so they cannot disagree across the
+		// call (and a test can inject a fixed clock). `now` defaults to the real wall clock in production.
+		const nowMs = now();
+		const until = pauseUntil(job.data, nowMs);
+		if (until && until > nowMs + 1000) {
 			await job.moveToDelayed(until, token);
 			throw new DelayedError();
 		}

--- a/worker/src/init.mjs
+++ b/worker/src/init.mjs
@@ -1,0 +1,66 @@
+/**
+ * `pi-dispatch init` — scaffold a deployment's config files in the current folder.
+ *
+ * Idempotent and non-destructive: an existing file is reported and left as-is, so re-running init
+ * never overwrites operator edits. The scaffolds mirror the empty templates the worker validates
+ * against — an empty triggers list disables cron/label/comment/PR, an empty windows list means no
+ * scoped pauses — so a fresh deployment starts inert and is opted into feature by feature.
+ */
+import { existsSync, copyFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+const EMPTY_TRIGGERS = `${JSON.stringify({ triggers: [] }, null, 2)}\n`;
+const EMPTY_PAUSE_WINDOWS = `${JSON.stringify({ windows: [] }, null, 2)}\n`;
+
+export function runInit(cwd = process.cwd(), deps = {}) {
+	const { fs = { existsSync, copyFileSync, writeFileSync }, out = (s) => process.stdout.write(s) } = deps;
+	const results = [];
+
+	// .env from the example. Prefer the copy in cwd (the clone's repo root); fall back to the one
+	// packaged next to the worker so init still works when run from elsewhere in the checkout.
+	const envPath = join(cwd, ".env");
+	if (fs.existsSync(envPath)) {
+		results.push(["kept", ".env", "already exists — left untouched"]);
+	} else {
+		const cwdExample = join(cwd, ".env.example");
+		const source = fs.existsSync(cwdExample)
+			? cwdExample
+			: fileURLToPath(new URL("../../.env.example", import.meta.url));
+		fs.copyFileSync(source, envPath);
+		results.push(["created", ".env", "from .env.example — set your provider key next"]);
+	}
+
+	scaffold(fs, results, join(cwd, "triggers.json"), EMPTY_TRIGGERS, "empty triggers list");
+	scaffold(fs, results, join(cwd, "pause-windows.json"), EMPTY_PAUSE_WINDOWS, "empty pause-windows list");
+
+	for (const [verb, name, note] of results) {
+		out(`${verb.padEnd(7)} ${name.padEnd(20)} ${note}\n`);
+	}
+	out(nextSteps());
+	return 0;
+}
+
+function scaffold(fs, results, path, content, note) {
+	const name = path.split(/[\\/]/).pop();
+	if (fs.existsSync(path)) {
+		results.push(["kept", name, "already exists — left untouched"]);
+	} else {
+		fs.writeFileSync(path, content);
+		results.push(["created", name, note]);
+	}
+}
+
+function nextSteps() {
+	return `
+Next:
+  1. docker pull ghcr.io/edgehero/pi-job:latest && docker tag ghcr.io/edgehero/pi-job:latest pi-job:latest
+                                                        # the prebuilt job image (or build image/Dockerfile)
+  2. docker compose -f deploy/docker-compose.yml up -d  # the durable queue (Valkey)
+  3. edit .env                                          # set ANTHROPIC_API_KEY (or your provider's key)
+  4. pi-dispatch doctor                                 # verify Docker, Valkey, image, and key
+  5. pi-dispatch worker                                 # drain the queue
+
+Operator panel (optional): pi install npm:@edgehero/pi-dispatch-admin   then   /dispatch
+`;
+}

--- a/worker/src/run-container.mjs
+++ b/worker/src/run-container.mjs
@@ -33,6 +33,7 @@ export function makeRunContainer({
 	globalPiDir = null, // REQ-GLOBAL-PI-OVERLAY: operator's global pi overlay dir, mounted :ro; null = off
 	allowGlobalExtensions = false,
 	forwardEnv = [],
+	authFromPi = false, // fall back to ~/.pi/agent/auth.json for the provider key when the env has none
 }) {
 	// async so a synchronous throw (e.g. buildContainerEnv on an unconfigured provider) surfaces as
 	// a rejection, uniformly awaitable by the processor and by tests.
@@ -51,6 +52,7 @@ export function makeRunContainer({
 			hostEnv,
 			allowGlobalExtensions, // arms overlay extensions in the runner (fail-closed)
 			forwardEnv, // extra host var names to forward (e.g. a custom provider's key)
+			authFromPi, // source the provider key from pi's auth.json when the env has none
 		});
 
 		const args = buildDockerRunArgs({

--- a/worker/src/run-container.mjs
+++ b/worker/src/run-container.mjs
@@ -30,6 +30,9 @@ export function makeRunContainer({
 	onOutput = (c) => process.stdout.write(c),
 	openJobLog = () => ({ write() {}, close: async () => ({ turns: null, tokens: null }) }),
 	spawnFn = spawn,
+	globalPiDir = null, // REQ-GLOBAL-PI-OVERLAY: operator's global pi overlay dir, mounted :ro; null = off
+	allowGlobalExtensions = false,
+	forwardEnv = [],
 }) {
 	// async so a synchronous throw (e.g. buildContainerEnv on an unconfigured provider) surfaces as
 	// a rejection, uniformly awaitable by the processor and by tests.
@@ -46,6 +49,8 @@ export function makeRunContainer({
 			jobId: name,
 			githubToken: token ?? undefined,
 			hostEnv,
+			allowGlobalExtensions, // arms overlay extensions in the runner (fail-closed)
+			forwardEnv, // extra host var names to forward (e.g. a custom provider's key)
 		});
 
 		const args = buildDockerRunArgs({
@@ -54,6 +59,7 @@ export function makeRunContainer({
 			jobDir: prepared.jobDir,
 			workspace: prepared.workspace,
 			outboxDir: prepared.outboxDir, // undefined for github jobs -> docker-run's guard skips the /outbox mount
+			globalPiDir, // undefined/null -> docker-run's guard skips the /opt/pi-global mount
 			name,
 		});
 

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -226,7 +226,14 @@ export async function startWorker(
 		pauseUntil: (job, now) => pauseUntilMs(pauseWindows.current, job, now),
 		deps: {
 			collectChain,
-			runContainer: makeRunContainer({ image: config.jobImage, hostEnv: env, openJobLog }),
+			runContainer: makeRunContainer({
+				image: config.jobImage,
+				hostEnv: env,
+				openJobLog,
+				globalPiDir: config.globalPiDir, // REQ-GLOBAL-PI-OVERLAY: :ro overlay mount when configured
+				allowGlobalExtensions: config.allowGlobalExtensions,
+				forwardEnv: config.forwardEnv,
+			}),
 			prepareWorkspace: makePrepareWorkspace({
 				jobsDir: config.jobsDir,
 				resolveDefaultBranchSha: host.resolveDefaultBranchSha,

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -233,6 +233,7 @@ export async function startWorker(
 				globalPiDir: config.globalPiDir, // REQ-GLOBAL-PI-OVERLAY: :ro overlay mount when configured
 				allowGlobalExtensions: config.allowGlobalExtensions,
 				forwardEnv: config.forwardEnv,
+				authFromPi: config.authFromPi, // source the provider key from ~/.pi/agent/auth.json when env has none
 			}),
 			prepareWorkspace: makePrepareWorkspace({
 				jobsDir: config.jobsDir,

--- a/worker/test/config.test.mjs
+++ b/worker/test/config.test.mjs
@@ -91,10 +91,11 @@ test("forwardEnv is a comma list of names -- trimmed, empties dropped, default [
 	assert.deepEqual(loadConfig({ PI_FORWARD_ENV: "MY_KEY, OTHER ,,THIRD" }).forwardEnv, ["MY_KEY", "OTHER", "THIRD"]);
 });
 
-test("authFromPi is armed only by PI_AUTH_FROM_PI=1", () => {
-	assert.equal(loadConfig({}).authFromPi, false);
+test("authFromPi defaults ON; only PI_AUTH_FROM_PI=0 forces env-only", () => {
+	assert.equal(loadConfig({}).authFromPi, true, "reusing the pi login is the default — no flag needed");
 	assert.equal(loadConfig({ PI_AUTH_FROM_PI: "1" }).authFromPi, true);
-	assert.equal(loadConfig({ PI_AUTH_FROM_PI: "yes" }).authFromPi, false);
+	assert.equal(loadConfig({ PI_AUTH_FROM_PI: "0" }).authFromPi, false, "explicit 0 forces env-only (fail-loud on a missing env key)");
+	assert.equal(loadConfig({ PI_AUTH_FROM_PI: "yes" }).authFromPi, true, "any non-0 value keeps the default on");
 });
 
 test("run-history env overrides logsDir, captureJobLogs, and logRetentionDays", () => {

--- a/worker/test/config.test.mjs
+++ b/worker/test/config.test.mjs
@@ -69,6 +69,28 @@ test("dispatchRunRoots defaults to [] and empty/whitespace yields [] (fail-close
 	assert.deepEqual(loadConfig({ PI_DISPATCH_RUN_ROOTS: `   ${delimiter}  ` }).dispatchRunRoots, []);
 });
 
+test("globalPiDir: unset is null; set-but-missing fails loud; set-and-existing returns the path", () => {
+	assert.equal(loadConfig({}).globalPiDir, null);
+	assert.throws(
+		() => loadConfig({ PI_GLOBAL_PI_DIR: "/no/such/dir" }, { fileExists: () => false }),
+		(e) => e.piDispatchConfig === true,
+		"a PI_GLOBAL_PI_DIR that does not exist must refuse boot, not silently drop the operator's setup",
+	);
+	assert.equal(loadConfig({ PI_GLOBAL_PI_DIR: "/opt/pi-global" }, { fileExists: () => true }).globalPiDir, "/opt/pi-global");
+});
+
+test("allowGlobalExtensions is fail-closed: only the exact string '1' arms it", () => {
+	assert.equal(loadConfig({}).allowGlobalExtensions, false);
+	assert.equal(loadConfig({ PI_GLOBAL_ALLOW_EXTENSIONS: "1" }).allowGlobalExtensions, true);
+	assert.equal(loadConfig({ PI_GLOBAL_ALLOW_EXTENSIONS: "true" }).allowGlobalExtensions, false);
+	assert.equal(loadConfig({ PI_GLOBAL_ALLOW_EXTENSIONS: "0" }).allowGlobalExtensions, false);
+});
+
+test("forwardEnv is a comma list of names -- trimmed, empties dropped, default []", () => {
+	assert.deepEqual(loadConfig({}).forwardEnv, []);
+	assert.deepEqual(loadConfig({ PI_FORWARD_ENV: "MY_KEY, OTHER ,,THIRD" }).forwardEnv, ["MY_KEY", "OTHER", "THIRD"]);
+});
+
 test("run-history env overrides logsDir, captureJobLogs, and logRetentionDays", () => {
 	const c = loadConfig({ PI_LOGS_DIR: "/x", PI_CAPTURE_JOB_LOGS: "1", PI_LOG_RETENTION_DAYS: "7" });
 	assert.equal(c.logsDir, "/x");

--- a/worker/test/config.test.mjs
+++ b/worker/test/config.test.mjs
@@ -91,6 +91,12 @@ test("forwardEnv is a comma list of names -- trimmed, empties dropped, default [
 	assert.deepEqual(loadConfig({ PI_FORWARD_ENV: "MY_KEY, OTHER ,,THIRD" }).forwardEnv, ["MY_KEY", "OTHER", "THIRD"]);
 });
 
+test("authFromPi is armed only by PI_AUTH_FROM_PI=1", () => {
+	assert.equal(loadConfig({}).authFromPi, false);
+	assert.equal(loadConfig({ PI_AUTH_FROM_PI: "1" }).authFromPi, true);
+	assert.equal(loadConfig({ PI_AUTH_FROM_PI: "yes" }).authFromPi, false);
+});
+
 test("run-history env overrides logsDir, captureJobLogs, and logRetentionDays", () => {
 	const c = loadConfig({ PI_LOGS_DIR: "/x", PI_CAPTURE_JOB_LOGS: "1", PI_LOG_RETENTION_DAYS: "7" });
 	assert.equal(c.logsDir, "/x");

--- a/worker/test/docker-run.test.mjs
+++ b/worker/test/docker-run.test.mjs
@@ -40,6 +40,14 @@ test("a github job (no outboxDir) emits no /outbox mount -- the request channel 
 	assert.ok(!args.some((a) => a.includes(":/outbox")), "a github job must have no /outbox mount");
 });
 
+test("the operator global overlay mounts /opt/pi-global:ro only when configured", () => {
+	const on = buildDockerRunArgs({ ...base, globalPiDir: "/srv/pi-global" });
+	assert.ok(on.includes("/srv/pi-global:/opt/pi-global:ro"), "overlay must mount at /opt/pi-global, read-only");
+	assert.ok(!on.some((a) => a.includes("/opt/pi-global") && !a.endsWith(":ro")), "the overlay mount must be :ro");
+	const off = buildDockerRunArgs({ ...base, globalPiDir: undefined });
+	assert.ok(!off.some((a) => a.includes("/opt/pi-global")), "no overlay mount when PI_GLOBAL_PI_DIR is unset");
+});
+
 test("env is an explicit -e NAME=VALUE allowlist, never a pass-through or --env-file", () => {
 	const args = buildDockerRunArgs(base);
 	assert.ok(args.includes("-e") && args.includes("ANTHROPIC_API_KEY=sk-real"));

--- a/worker/test/doctor.test.mjs
+++ b/worker/test/doctor.test.mjs
@@ -137,3 +137,32 @@ test("doctor: a clean overlay passes; armed extensions are a warning, not a fail
 	assert.equal(code, 0, "armed extensions warn (⚠) but do not fail doctor");
 	assert.match(t2(), /⚠ Overlay extensions present and ARMED/);
 });
+
+// PI_AUTH_FROM_PI: the provider key may live in pi's auth.json, not the env — doctor reads it (real fs).
+function agentDirWith(cred) {
+	const dir = mkdtempSync(join(tmpdir(), "pi-agent-"));
+	writeFileSync(join(dir, "auth.json"), JSON.stringify({ anthropic: cred }));
+	return dir;
+}
+
+test("doctor: PI_AUTH_FROM_PI with an api_key in auth.json passes the provider-key check", async () => {
+	const dir = agentDirWith({ type: "api_key", key: "sk-x" });
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", PI_AUTH_FROM_PI: "1", PI_CODING_AGENT_DIR: dir }, // no ANTHROPIC_API_KEY in env
+		{ out, cwd: tmpdir(), spawn: fakeSpawn(green), probeValkey: async () => true, nodeVersion: "22.19.0" },
+	);
+	assert.equal(code, 0, "the key comes from pi, so doctor is green");
+	assert.match(text(), /from pi auth\.json/);
+});
+
+test("doctor: PI_AUTH_FROM_PI over an OAuth login flags it as not usable for a service", async () => {
+	const dir = agentDirWith({ type: "oauth", access_token: "x" });
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", PI_AUTH_FROM_PI: "1", PI_CODING_AGENT_DIR: dir },
+		{ out, cwd: tmpdir(), spawn: fakeSpawn(green), probeValkey: async () => true, nodeVersion: "22.19.0" },
+	);
+	assert.equal(code, 1, "an OAuth/subscription login is not a usable service credential");
+	assert.match(text(), /OAuth\/subscription/);
+});

--- a/worker/test/doctor.test.mjs
+++ b/worker/test/doctor.test.mjs
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runDoctor } from "../src/doctor.mjs";
+
+// A fake `spawn`: resolves each `docker <sub>` to a canned exit code, or an "enoent" launch failure.
+function fakeSpawn(plan) {
+	return (_cmd, args) => {
+		const sub = args[0]; // "info" | "image"
+		const outcome = plan[sub];
+		const handlers = {};
+		queueMicrotask(() => {
+			if (outcome === "enoent") handlers.error?.(new Error("spawn docker ENOENT"));
+			else handlers.close?.(outcome);
+		});
+		return {
+			on(ev, cb) {
+				handlers[ev] = cb;
+				return this;
+			},
+		};
+	};
+}
+function capture() {
+	const buf = [];
+	return { out: (s) => buf.push(s), text: () => buf.join("") };
+}
+const green = { info: 0, image: 0 };
+
+test("doctor: all prerequisites present passes and exits 0", async () => {
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x" },
+		{ out, spawn: fakeSpawn(green), probeValkey: async () => true, fileExists: () => true, nodeVersion: "22.19.0" },
+	);
+	assert.equal(code, 0);
+	assert.match(text(), /Docker daemon reachable/);
+	assert.doesNotMatch(text(), /✗/, "no hard failures are marked");
+});
+
+test("doctor: docker down, valkey down, no key exits 1 with fixes", async () => {
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic" }, // no credential
+		{ out, spawn: fakeSpawn({ info: 1 }), probeValkey: async () => false, fileExists: () => true, nodeVersion: "22.19.0" },
+	);
+	assert.equal(code, 1);
+	assert.match(text(), /start Docker/, "a down daemon (exit != 0) is distinguished from a missing binary");
+	assert.match(text(), /docker compose .* up -d/, "the Valkey fix is shown");
+	assert.match(text(), /set ANTHROPIC_API_KEY in \.env/, "the provider-key fix names the right var");
+});
+
+test("doctor: a missing docker binary reads as 'install', not 'start'", async () => {
+	const { out, text } = capture();
+	await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x" },
+		{ out, spawn: fakeSpawn({ info: "enoent" }), probeValkey: async () => true, fileExists: () => true, nodeVersion: "22.19.0" },
+	);
+	assert.match(text(), /install Docker/, "an unlaunchable docker is an install problem");
+});
+
+test("doctor: the provider key value is never printed", async () => {
+	const { out, text } = capture();
+	await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-secret-value" },
+		{ out, spawn: fakeSpawn(green), probeValkey: async () => true, fileExists: () => true, nodeVersion: "22.19.0" },
+	);
+	assert.doesNotMatch(text(), /sk-secret-value/, "the credential must never reach output");
+});
+
+test("doctor: an outdated Node is flagged and fails", async () => {
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x" },
+		{ out, spawn: fakeSpawn(green), probeValkey: async () => true, fileExists: () => true, nodeVersion: "20.10.0" },
+	);
+	assert.equal(code, 1);
+	assert.match(text(), /Node ≥ 22\.19 \(have 20\.10\.0\)/);
+});
+
+test("doctor: a missing .env is a warning, not a hard failure", async () => {
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x" },
+		{ out, spawn: fakeSpawn(green), probeValkey: async () => true, fileExists: () => false, nodeVersion: "22.19.0" },
+	);
+	assert.equal(code, 0, "an absent .env alone does not fail doctor — env can come from a service manager");
+	assert.match(text(), /⚠ \.env present/);
+});

--- a/worker/test/doctor.test.mjs
+++ b/worker/test/doctor.test.mjs
@@ -145,22 +145,32 @@ function agentDirWith(cred) {
 	return dir;
 }
 
-test("doctor: PI_AUTH_FROM_PI with an api_key in auth.json passes the provider-key check", async () => {
+test("doctor: an api_key in pi auth.json passes the provider-key check BY DEFAULT (no flag set)", async () => {
 	const dir = agentDirWith({ type: "api_key", key: "sk-x" });
 	const { out, text } = capture();
 	const code = await runDoctor(
-		{ PI_PROVIDER: "anthropic", PI_AUTH_FROM_PI: "1", PI_CODING_AGENT_DIR: dir }, // no ANTHROPIC_API_KEY in env
+		{ PI_PROVIDER: "anthropic", PI_CODING_AGENT_DIR: dir }, // no ANTHROPIC_API_KEY, no PI_AUTH_FROM_PI — default on
 		{ out, cwd: tmpdir(), spawn: fakeSpawn(green), probeValkey: async () => true, nodeVersion: "22.19.0" },
 	);
-	assert.equal(code, 0, "the key comes from pi, so doctor is green");
+	assert.equal(code, 0, "the key comes from pi by default, so doctor is green");
 	assert.match(text(), /from pi auth\.json/);
 });
 
-test("doctor: PI_AUTH_FROM_PI over an OAuth login flags it as not usable for a service", async () => {
+test("doctor: PI_AUTH_FROM_PI=0 forces env-only — the pi login is ignored", async () => {
+	const dir = agentDirWith({ type: "api_key", key: "sk-x" });
+	const { out } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", PI_CODING_AGENT_DIR: dir, PI_AUTH_FROM_PI: "0" }, // opt out
+		{ out, cwd: tmpdir(), spawn: fakeSpawn(green), probeValkey: async () => true, nodeVersion: "22.19.0" },
+	);
+	assert.equal(code, 1, "with the fallback disabled, a missing env key fails the check");
+});
+
+test("doctor: an OAuth login in pi auth.json is flagged as not usable for a service", async () => {
 	const dir = agentDirWith({ type: "oauth", access_token: "x" });
 	const { out, text } = capture();
 	const code = await runDoctor(
-		{ PI_PROVIDER: "anthropic", PI_AUTH_FROM_PI: "1", PI_CODING_AGENT_DIR: dir },
+		{ PI_PROVIDER: "anthropic", PI_CODING_AGENT_DIR: dir },
 		{ out, cwd: tmpdir(), spawn: fakeSpawn(green), probeValkey: async () => true, nodeVersion: "22.19.0" },
 	);
 	assert.equal(code, 1, "an OAuth/subscription login is not a usable service credential");

--- a/worker/test/doctor.test.mjs
+++ b/worker/test/doctor.test.mjs
@@ -1,5 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runDoctor } from "../src/doctor.mjs";
 
 // A fake `spawn`: resolves each `docker <sub>` to a canned exit code, or an "enoent" launch failure.
@@ -85,4 +88,52 @@ test("doctor: a missing .env is a warning, not a hard failure", async () => {
 	);
 	assert.equal(code, 0, "an absent .env alone does not fail doctor — env can come from a service manager");
 	assert.match(text(), /⚠ \.env present/);
+});
+
+// The overlay checks read real files (doctor uses real readFileSync for models.json), so use temp dirs and
+// doctor's default fileExists; the docker/valkey checks stay faked green so ONLY the overlay drives the outcome.
+function overlay({ auth = false, models, extensions = false } = {}) {
+	const dir = mkdtempSync(join(tmpdir(), "pi-overlay-"));
+	if (auth) writeFileSync(join(dir, "auth.json"), "{}");
+	if (models !== undefined) writeFileSync(join(dir, "models.json"), models);
+	if (extensions) mkdirSync(join(dir, "extensions", "x"), { recursive: true });
+	return dir;
+}
+const overlayEnv = (dir, extra = {}) => ({ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x", PI_GLOBAL_PI_DIR: dir, ...extra });
+const overlayDeps = (out) => ({ out, cwd: tmpdir(), spawn: fakeSpawn(green), probeValkey: async () => true, nodeVersion: "22.19.0" });
+
+test("doctor: a set-but-missing overlay dir fails", async () => {
+	const { out, text } = capture();
+	const code = await runDoctor(overlayEnv("/no/such/overlay"), overlayDeps(out));
+	assert.equal(code, 1);
+	assert.match(text(), /Global overlay dir exists/);
+});
+
+test("doctor: auth.json in the overlay is a hard failure (credential leak)", async () => {
+	const { out, text } = capture();
+	const code = await runDoctor(overlayEnv(overlay({ auth: true })), overlayDeps(out));
+	assert.equal(code, 1);
+	assert.match(text(), /credential-free \(no auth\.json\)/);
+	assert.match(text(), /belongs in env/);
+});
+
+test("doctor: a literal key in the overlay models.json is a hard failure", async () => {
+	const dir = overlay({ models: JSON.stringify({ providers: { c: { apiKey: "sk-literal" } } }) });
+	const { out, text } = capture();
+	const code = await runDoctor(overlayEnv(dir), overlayDeps(out));
+	assert.equal(code, 1);
+	assert.match(text(), /Overlay models\.json is credential-free/);
+});
+
+test("doctor: a clean overlay passes; armed extensions are a warning, not a failure", async () => {
+	const clean = overlay({ models: JSON.stringify({ providers: { anthropic: { name: "Anthropic" } } }) });
+	const { out: o1, text: t1 } = capture();
+	assert.equal(await runDoctor(overlayEnv(clean), overlayDeps(o1)), 0, "a clean overlay does not fail doctor");
+	assert.doesNotMatch(t1(), /✗/);
+
+	const armed = overlay({ extensions: true });
+	const { out: o2, text: t2 } = capture();
+	const code = await runDoctor(overlayEnv(armed, { PI_GLOBAL_ALLOW_EXTENSIONS: "1" }), overlayDeps(o2));
+	assert.equal(code, 0, "armed extensions warn (⚠) but do not fail doctor");
+	assert.match(t2(), /⚠ Overlay extensions present and ARMED/);
 });

--- a/worker/test/env-allowlist.test.mjs
+++ b/worker/test/env-allowlist.test.mjs
@@ -101,3 +101,52 @@ test("PI_FORWARD_ENV forwards ONLY the named vars that are present, never a pass
 	assert.equal(env.UNLISTED, undefined, "an unlisted host var is never forwarded");
 	assert.equal(env.AWS_SECRET_ACCESS_KEY, undefined, "the stray host secret still does not ride along");
 });
+
+// --- PI_AUTH_FROM_PI: source the provider key from pi's auth.json when the env has none ---
+const authBase = { provider: "anthropic", model: "m", maxTurns: 5, jobId: "j", agentDir: "/home/u/.pi/agent" };
+const authReader = (json) => (p) => {
+	assert.match(p, /auth\.json$/, "reads auth.json under the agent dir");
+	if (json === null) throw new Error("ENOENT");
+	return typeof json === "string" ? json : JSON.stringify(json);
+};
+
+test("PI_AUTH_FROM_PI injects the api key from auth.json under pi's expected var name", { skip }, () => {
+	const env = buildContainerEnv({
+		...authBase,
+		hostEnv: { HOME: "/root" }, // no ANTHROPIC_API_KEY on the host
+		authFromPi: true,
+		readFile: authReader({ anthropic: { type: "api_key", key: "sk-from-pi" } }),
+	});
+	assert.equal(env.ANTHROPIC_API_KEY, "sk-from-pi", "pi's own findEnvKeys resolves the var name -- no hand table");
+});
+
+test("PI_AUTH_FROM_PI: the env wins when the key is present (fallback only, auth.json never read)", { skip }, () => {
+	const env = buildContainerEnv({
+		...authBase,
+		hostEnv: { ANTHROPIC_API_KEY: "sk-env" },
+		authFromPi: true,
+		readFile: () => assert.fail("auth.json must not be read when the env already has the key"),
+	});
+	assert.equal(env.ANTHROPIC_API_KEY, "sk-env");
+});
+
+test("PI_AUTH_FROM_PI refuses an OAuth/subscription login (pre-spend)", { skip }, () => {
+	assert.throws(
+		() => buildContainerEnv({ ...authBase, hostEnv: {}, authFromPi: true, readFile: authReader({ anthropic: { type: "oauth", access_token: "x" } }) }),
+		(e) => e.piDispatchConfig === true && /OAuth|subscription/i.test(e.message),
+	);
+});
+
+test("PI_AUTH_FROM_PI refuses when auth.json is missing/unreadable, with guidance", { skip }, () => {
+	assert.throws(
+		() => buildContainerEnv({ ...authBase, hostEnv: {}, authFromPi: true, readFile: authReader(null) }),
+		(e) => e.piDispatchConfig === true && /pi login|environment/i.test(e.message),
+	);
+});
+
+test("without PI_AUTH_FROM_PI, a missing env key still refuses and auth.json is never consulted", { skip }, () => {
+	assert.throws(
+		() => buildContainerEnv({ ...authBase, hostEnv: {}, authFromPi: false, readFile: () => assert.fail("must not read auth.json when PI_AUTH_FROM_PI is off") }),
+		(e) => e.piDispatchConfig === true,
+	);
+});

--- a/worker/test/env-allowlist.test.mjs
+++ b/worker/test/env-allowlist.test.mjs
@@ -86,3 +86,18 @@ test("an unconfigured provider throws a config-tagged error (=> pre-spend refusa
 		(e) => e.piDispatchConfig === true,
 	);
 });
+
+test("PI_GLOBAL_ALLOW_EXTENSIONS is forwarded only when armed (fail-closed)", { skip }, () => {
+	const base = { provider: "anthropic", model: "m", maxTurns: 5, jobId: "j", hostEnv: HOST };
+	assert.equal(buildContainerEnv({ ...base, allowGlobalExtensions: true }).PI_GLOBAL_ALLOW_EXTENSIONS, "1");
+	assert.equal(buildContainerEnv(base).PI_GLOBAL_ALLOW_EXTENSIONS, undefined, "unset by default -> overlay extensions stay dormant");
+});
+
+test("PI_FORWARD_ENV forwards ONLY the named vars that are present, never a pass-through", { skip }, () => {
+	const host = { ...HOST, MY_PROVIDER_KEY: "sk-custom", UNLISTED: "nope" };
+	const env = buildContainerEnv({ provider: "anthropic", model: "m", maxTurns: 5, jobId: "j", hostEnv: host, forwardEnv: ["MY_PROVIDER_KEY", "ABSENT_VAR"] });
+	assert.equal(env.MY_PROVIDER_KEY, "sk-custom", "a listed, present var is forwarded (a custom provider's key)");
+	assert.equal(env.ABSENT_VAR, undefined, "a listed but unset var is skipped, never forwarded as empty");
+	assert.equal(env.UNLISTED, undefined, "an unlisted host var is never forwarded");
+	assert.equal(env.AWS_SECRET_ACCESS_KEY, undefined, "the stray host secret still does not ride along");
+});

--- a/worker/test/import-pi.test.mjs
+++ b/worker/test/import-pi.test.mjs
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runImportPi, findLiteralSecret } from "../src/import-pi.mjs";
+
+function capture() {
+	const buf = [];
+	return { out: (s) => buf.push(s), text: () => buf.join("") };
+}
+
+/** A host ~/.pi/agent fixture with the full surface: safe + secret-bearing + extensions. */
+function hostAgent({ models, withAuth = true, withExtensions = false } = {}) {
+	const dir = mkdtempSync(join(tmpdir(), "pi-agent-"));
+	if (models !== null) writeFileSync(join(dir, "models.json"), models ?? JSON.stringify({ providers: { anthropic: { name: "Anthropic" } } }));
+	mkdirSync(join(dir, "skills", "tidy"), { recursive: true });
+	writeFileSync(join(dir, "skills", "tidy", "SKILL.md"), "---\nname: tidy\n---\nTidy up.\n");
+	writeFileSync(join(dir, "APPEND_SYSTEM.md"), "Be terse.\n");
+	if (withAuth) writeFileSync(join(dir, "auth.json"), JSON.stringify({ anthropic: { type: "api_key", key: "sk-secret" } }));
+	if (withExtensions) {
+		mkdirSync(join(dir, "extensions", "my-tool"), { recursive: true });
+		writeFileSync(join(dir, "extensions", "my-tool", "index.mjs"), "export default () => {};\n");
+		mkdirSync(join(dir, "extensions", "pi-dispatch-admin"), { recursive: true });
+		writeFileSync(join(dir, "extensions", "pi-dispatch-admin", "index.mjs"), "export default () => {};\n");
+	}
+	return dir;
+}
+const overlayDir = () => mkdtempSync(join(tmpdir(), "pi-overlay-"));
+const run = (from, to, extra = [], out) => runImportPi(["--from", from, "--to", to, ...extra], { out });
+
+test("import-pi copies models/skills/persona and NEVER auth.json", () => {
+	const from = hostAgent();
+	const to = overlayDir();
+	const { out } = capture();
+
+	const code = run(from, to, [], out);
+
+	assert.equal(code, 0);
+	assert.ok(existsSync(join(to, "models.json")), "models.json copied");
+	assert.ok(existsSync(join(to, "skills", "tidy", "SKILL.md")), "skill copied");
+	assert.ok(existsSync(join(to, "APPEND_SYSTEM.md")), "persona copied");
+	assert.equal(existsSync(join(to, "auth.json")), false, "auth.json must NEVER be copied — the credential stays in env");
+});
+
+test("import-pi refuses a models.json with a literal key and writes nothing", () => {
+	const from = hostAgent({ models: JSON.stringify({ providers: { custom: { name: "Custom", apiKey: "sk-live-literal" } } }) });
+	const to = join(mkdtempSync(join(tmpdir(), "pi-overlay-")), "out"); // does not exist yet
+	const { out, text } = capture();
+
+	const code = run(from, to, [], out);
+
+	assert.equal(code, 1);
+	assert.match(text(), /literal secret at providers\.custom\.apiKey/);
+	assert.equal(existsSync(join(to, "models.json")), false, "a refused import writes no overlay at all");
+});
+
+test("import-pi skips extensions by default, and blocks the admin extension under --with-extensions", () => {
+	const from = hostAgent({ withExtensions: true });
+
+	const noExt = overlayDir();
+	run(from, noExt, [], () => {});
+	assert.equal(existsSync(join(noExt, "extensions")), false, "extensions are not copied without --with-extensions");
+
+	const withExt = overlayDir();
+	const { out, text } = capture();
+	run(from, withExt, ["--with-extensions"], out);
+	assert.ok(existsSync(join(withExt, "extensions", "my-tool")), "a normal extension is copied");
+	assert.equal(existsSync(join(withExt, "extensions", "pi-dispatch-admin")), false, "the admin extension is hard-blocked");
+	assert.match(text(), /blocked extension "pi-dispatch-admin"/);
+});
+
+test("import-pi errors clearly when the source agent dir is absent", () => {
+	const { out, text } = capture();
+	const code = run(join(tmpdir(), "nope-does-not-exist-xyz"), overlayDir(), [], out);
+	assert.equal(code, 1);
+	assert.match(text(), /no pi setup found/);
+});
+
+test("findLiteralSecret: catches literal apiKey and auth headers, passes env/command indirections", () => {
+	assert.equal(findLiteralSecret({ providers: { p: { apiKey: "sk-literal" } } }), "providers.p.apiKey");
+	assert.equal(findLiteralSecret({ providers: { p: { apiKey: "$MY_KEY" } } }), null, "$ENV reference is not a literal");
+	assert.equal(findLiteralSecret({ providers: { p: { apiKey: "!op read x" } } }), null, "!command is not a literal");
+	assert.equal(findLiteralSecret({ providers: { p: { headers: { Authorization: "Bearer sk-x" } } } }), "providers.p.headers.Authorization");
+	assert.equal(findLiteralSecret({ providers: { p: { headers: { "Content-Type": "application/json" } } } }), null, "a non-secret header is fine");
+	assert.equal(findLiteralSecret({ providers: {} }), null);
+});

--- a/worker/test/init.test.mjs
+++ b/worker/test/init.test.mjs
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runInit } from "../src/init.mjs";
+
+const tmp = () => mkdtempSync(join(tmpdir(), "pi-init-"));
+function capture() {
+	const buf = [];
+	return { out: (s) => buf.push(s), text: () => buf.join("") };
+}
+
+test("init scaffolds the three config files with the empty templates the worker validates against", () => {
+	const dir = tmp();
+	writeFileSync(join(dir, ".env.example"), "ANTHROPIC_API_KEY=\n"); // stand in for the repo's example
+	const { out, text } = capture();
+
+	const code = runInit(dir, { out });
+
+	assert.equal(code, 0);
+	assert.ok(existsSync(join(dir, ".env")), ".env is copied from the example");
+	assert.deepEqual(JSON.parse(readFileSync(join(dir, "triggers.json"), "utf8")), { triggers: [] });
+	assert.deepEqual(JSON.parse(readFileSync(join(dir, "pause-windows.json"), "utf8")), { windows: [] });
+	assert.match(text(), /pi install npm:@edgehero\/pi-dispatch-admin/, "next steps name the operator panel");
+});
+
+test("init is idempotent and never overwrites operator edits", () => {
+	const dir = tmp();
+	writeFileSync(join(dir, ".env.example"), "ANTHROPIC_API_KEY=\n");
+	writeFileSync(join(dir, ".env"), "ANTHROPIC_API_KEY=sk-mine\n"); // already configured
+	writeFileSync(join(dir, "triggers.json"), JSON.stringify({ triggers: [{ id: "keep" }] }));
+	const { out, text } = capture();
+
+	const code = runInit(dir, { out });
+
+	assert.equal(code, 0);
+	assert.equal(readFileSync(join(dir, ".env"), "utf8"), "ANTHROPIC_API_KEY=sk-mine\n", ".env left untouched");
+	assert.deepEqual(JSON.parse(readFileSync(join(dir, "triggers.json"), "utf8")), { triggers: [{ id: "keep" }] });
+	assert.deepEqual(JSON.parse(readFileSync(join(dir, "pause-windows.json"), "utf8")), { windows: [] }, "the missing one is still created");
+	assert.match(text(), /kept.*\.env/, "an existing file is reported as kept");
+});

--- a/worker/test/pause-gate.test.mjs
+++ b/worker/test/pause-gate.test.mjs
@@ -48,6 +48,7 @@ function harness({ pauseUntil, redis = fakeRedis() }) {
 		getSettings: () => ({ provider: "anthropic", model: "m", maxTurns: 30, dailyCap: 10, weeklyCap: null, monthlyCap: null, concurrency: 3, softHoldPct: null }),
 		applyConcurrency: () => {},
 		pauseUntil,
+		now: () => NOW, // fixed clock so the defer guard shares the predicate's clock (else it rots past NOW)
 		recordRun: () => {},
 		timeoutMs: 100000,
 		deps: {


### PR DESCRIPTION
## What & why

Installing pi-dispatch was a fuzzy six-step manual whose slowest, most fragile step was the local job-image build (Chromium + Playwright + fonts, minutes), and setup was **blind** — you discovered a missing Docker daemon, unreachable Valkey, or absent image only when a job failed. This makes the happy path fast and self-checking, and surfaces the already-supported `pi install` of the operator panel.

Scope confirmed with the maintainer: **guided CLI + prebuilt image + docs** (no new clone-free npm CLI).

## Changes

**1. `pi-dispatch init` + `pi-dispatch doctor`** (`worker/src/init.mjs`, `worker/src/doctor.mjs`, wired in `cli.mjs`)
- `init` scaffolds `.env` + `triggers.json` + `pause-windows.json` in the cwd — idempotent, never clobbers, prints next steps.
- `doctor` is a ✓/⚠/✗ preflight: Node floor, `.env`, Docker daemon, the job image, Valkey reachability, and the provider **key presence** (value never printed). Exits non-zero on a hard failure, so it's scriptable. Reads `config.mjs`'s own defaults so it runs even when GitHub auth is unset (mirrors the kill switch). Reachability uses a raw fail-fast ioredis client with its own error handler, so a down Valkey is **one line, not a stack trace**.
- 8 new tests; verified end-to-end on a real host (init idempotency; doctor's down-path clean, up-path flips to ✓ against a live Valkey, key value never leaked).

**2. Prebuilt job image on GHCR** (`.github/workflows/image.yml`)
- Builds `image/Dockerfile` → `ghcr.io/edgehero/pi-job` (amd64 + arm64) on `main` pushes touching `image/**`, using the built-in `GITHUB_TOKEN` (**no secret required**). `PI_JOB_IMAGE` already accepts any ref, so **no worker code changes**.

**3. Docs**
- README quickstart is **pull-first** (local build stays the "bake your own toolchain" path) and routes through `init`/`doctor`.
- The Admin section leads with `pi install npm:@edgehero/pi-dispatch-admin` and the env a session needs to operate a **live** deployment. `.env.example` notes the pull.

## Heads-up: a pre-existing time-bomb test, fixed in its own commit

The first commit (`010b3bb`) is **unrelated to install** but was blocking green CI as of today. The scoped-pause defer test injected a `pauseUntil` returning a hardcoded window-end (`2026-07-24T06:00Z`) while the processor compared it against the **real** `Date.now()`. Once wall-clock crossed that instant, the guard saw the window-end as already past and stopped deferring — so the test began failing on 2026-07-24 with no code change. `makeProcessor` now takes an injectable `now` (default `Date.now`), snapshotted once for both the lookup and the guard. **Production behavior is unchanged.**

## Verification
- Full repo suite: **768 tests, 753 pass, 0 fail** (15 skipped — Valkey-integration, unchanged).
- `init`/`doctor` smoke-tested on this host (down + up Valkey), key value confirmed never printed.

## One-time maintainer action after merge
After the first `image` workflow run, make the `ghcr.io/edgehero/pi-job` package **Public** in the org's package settings (GHCR defaults to private on first publish); until then `docker pull` needs auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)