### PR TITLE
ci: repo-level GitHub Release on version bump (fixes 'no releases on merge')

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
-# Publish @edgehero/pi-dispatch-admin and cut a GitHub Release when its version changes on main.
+# Publish @edgehero/pi-dispatch-admin (npm) and cut its GitHub Release when admin/package.json's version
+# changes on main. This is the EXTENSION's pipeline: it tags admin-v*. The whole TOOL's releases (v*) are cut
+# by repo-release.yml off the ROOT package.json version — the two never share a tag.
 #
 # main is branch-protected (PR + 1 approving review required), so a push here is an already-approved merge —
 # the human gate is the merge, not this workflow (consistent with CONST-MERGE-NEVER-AUTOMATIC: nothing here
@@ -63,8 +65,10 @@ jobs:
           else
             echo "publish=yes" >> "$GITHUB_OUTPUT"
           fi
-          if gh release view "v$V" >/dev/null 2>&1; then
-            echo "release=no" >> "$GITHUB_OUTPUT"; echo "release v$V already exists — skip release"
+          # The admin EXTENSION's GitHub releases are tagged admin-v* so the tool's own releases own the v*
+          # namespace (see repo-release.yml). npm publish above is unaffected — it keys off the package version.
+          if gh release view "admin-v$V" >/dev/null 2>&1; then
+            echo "release=no" >> "$GITHUB_OUTPUT"; echo "release admin-v$V already exists — skip release"
           else
             echo "release=yes" >> "$GITHUB_OUTPUT"
           fi
@@ -81,7 +85,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           RELEASE_MODEL: ${{ vars.RELEASE_MODEL }}
         run: |
-          PREV=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          PREV=$(git tag --list 'admin-v*' --sort=-v:refname | head -n1)
           RANGE=${PREV:+$PREV..HEAD}
           COMMITS=$(git log $RANGE --no-merges --pretty=format:'- %s' -- admin/ | head -n 60)
           if [ -n "$ANTHROPIC_API_KEY" ] && COMMITS="$COMMITS" VERSION="v${{ steps.v.outputs.version }}" \
@@ -97,6 +101,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "v${{ steps.v.outputs.version }}" \
-            --title "v${{ steps.v.outputs.version }} — pi-dispatch operator extension" \
+          gh release create "admin-v${{ steps.v.outputs.version }}" \
+            --title "@edgehero/pi-dispatch-admin v${{ steps.v.outputs.version }}" \
             --notes-file /tmp/notes.md

--- a/.github/workflows/repo-release.yml
+++ b/.github/workflows/repo-release.yml
@@ -1,0 +1,81 @@
+# Cut a GitHub Release for the WHOLE pi-dispatch tool when the ROOT package.json version changes on main.
+#
+# This is distinct from release.yml, which PUBLISHES the @edgehero/pi-dispatch-admin npm package (and tags
+# its own releases admin-v*). This workflow owns the v* tags = the product's releases. To cut one, bump
+# `version` in the root package.json in a PR; it is idempotent (skips when the tag already exists), so an
+# unrelated root package.json edit — a dependency bump, a script tweak — is a no-op.
+#
+# main is branch-protected (PR + 1 approving review), so a push here is an already-approved merge — nothing
+# here merges anything (CONST-MERGE-NEVER-AUTOMATIC). No secret is required to tag a release; the optional
+# repo secret ANTHROPIC_API_KEY enables AI-written notes, and without it the release falls back to a plain
+# commit list. Optional repo variable RELEASE_MODEL (default: claude-sonnet-5).
+
+name: repo-release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "package.json" # the ROOT one only (a bare path does not match nested workspace package.json files)
+      - ".github/workflows/repo-release.yml"
+      - ".github/scripts/release-notes.mjs"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write # create tags + releases
+
+concurrency:
+  group: repo-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history for the release-notes commit range
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.19"
+
+      - name: Resolve version + decide release
+        id: v
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          V=$(node -p "require('./package.json').version")
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          if gh release view "v$V" >/dev/null 2>&1; then
+            echo "release=no" >> "$GITHUB_OUTPUT"; echo "release v$V already exists — skip"
+          else
+            echo "release=yes" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build release notes
+        if: steps.v.outputs.release == 'yes'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RELEASE_MODEL: ${{ vars.RELEASE_MODEL }}
+        run: |
+          # Range since the previous tool release (v*); the whole repo, not just one workspace.
+          PREV=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          RANGE=${PREV:+$PREV..HEAD}
+          COMMITS=$(git log $RANGE --no-merges --pretty=format:'- %s' | head -n 80)
+          if [ -n "$ANTHROPIC_API_KEY" ] && COMMITS="$COMMITS" VERSION="v${{ steps.v.outputs.version }}" \
+               node .github/scripts/release-notes.mjs > /tmp/notes.md 2>/tmp/notes.err; then
+            echo "release notes: AI-written"
+          else
+            echo "release notes: AI unavailable ($(head -n1 /tmp/notes.err 2>/dev/null)) — using commit list"
+            { echo "### Changes"; echo; printf '%s\n' "$COMMITS"; } > /tmp/notes.md
+          fi
+
+      - name: Create GitHub Release
+        if: steps.v.outputs.release == 'yes'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.v.outputs.version }}" \
+            --title "pi-dispatch v${{ steps.v.outputs.version }}" \
+            --notes-file /tmp/notes.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",


### PR DESCRIPTION
## Why releases stopped

The only release pipeline was the admin **extension's** (`release.yml`): it fires on `admin/**` changes plus an `admin/package.json` version bump. `git log v0.1.3..main -- 'admin/**'` is empty — the recent work (install ease, GHCR image, global overlay, auth-from-pi, docs) is all in `worker/`, `image/`, and docs, so that pipeline never ran and there was nothing to release. It's not broken — it's idle, because it only tracks the admin npm package.

## What this adds

A **tool-level** release, decoupled from the admin npm version:

- **`repo-release.yml`** — on a **root `package.json` version bump** merged to main, cut GitHub Release `v<version>` ("pi-dispatch v<version>") with **AI notes** (`release-notes.mjs`) over the whole repo since the last `v*` tag. Idempotent (skips if the tag exists), so unrelated root edits are no-ops. `workflow_dispatch` for manual runs; uses the built-in `GITHUB_TOKEN` (no secret to tag).
- **`release.yml` (admin)** — its GitHub release moves to the **`admin-v*`** namespace so the two pipelines never share a tag. **npm publish is unchanged.** Result: the **tool owns `v*`**, the **extension owns `admin-v*`**.
- **Root `package.json` 0.1.0 → 0.2.0** — the first tool release. **Merging this PR cuts `v0.2.0`** over `v0.1.3..HEAD` (the install/overlay/auth/docs arc).

## One dependency for AI notes

The notes are AI-written only if the `ANTHROPIC_API_KEY` repo secret is a valid `sk-ant-…` key (the earlier 401 was an invalid/OAuth key). Without it, the release still publishes — as a plain commit list. Going forward: **bump the root `package.json` version in a PR → merge → a `v<version>` release appears.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)