### PR TITLE
feat(worker): close the gh CLI gaps -- run.github token for cron jobs, source:gh scope warning, GH_TOKEN precedence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,7 @@ PI_JOB_IMAGE=pi-job:latest          # docker pull ghcr.io/edgehero/pi-job:latest
 # PI_GLOBAL_PI_DIR=                  # dir with your host pi setup (models.json/skills/APPEND_SYSTEM.md), mounted /opt/pi-global:ro into every job, layered UNDER each repo's .pi/. Unset = off. Stage it with: pi-dispatch import-pi
 # PI_GLOBAL_ALLOW_EXTENSIONS=       # set 1 to LOAD the overlay's extensions (default off). They run code against adversarial input with open egress — vet each; never the admin extension.
 # PI_FORWARD_ENV=                   # comma-separated extra env var NAMES to forward into the container (e.g. a CUSTOM provider's key). Explicit allowlist, not a pass-through.
+                                    # GITHUB_TOKEN/GH_TOKEN are refused here -- the worker mints per-job tokens
 
 PI_SCHEDULER_STALL_MAX=2            # tear down a scheduler after N consecutive stalls (money backstop)
 # PI_DISPATCH_RUN_ROOTS=            # OS-path-delimited allowlist (; on Windows, : elsewhere) of folders the model-callable dispatch_run may target; default empty = fail-closed (dispatch_run refuses every folder until you opt in)
@@ -59,6 +60,7 @@ WEBHOOK_SECRET=
 RECEIVER_PORT=3000
 RECEIVER_BIND=0.0.0.0
 # Worker GitHub auth: source is gh | pat | app (default gh)
+# gh = your full login scopes reach token-carrying jobs (doctor warns and names them); pat/app = narrower
 GITHUB_AUTH_SOURCE=gh
 # For GITHUB_AUTH_SOURCE=pat: a repo-scoped, short-expiry fine-grained PAT
 GITHUB_PAT=

--- a/README.md
+++ b/README.md
@@ -351,7 +351,9 @@ write waits on your confirmation.
 
 A cron trigger runs a local folder through a flow on a cron pattern — `pattern` is a 5- or 6-field cron
 expression; `provider`, `model`, and `maxTurns` are optional on `run` and fall back to the worker's
-defaults. A cron `folder` is a **host path** — the worker runs on the host
+defaults. `"github": true` on `run` is also optional — it mints the same per-job GitHub token the webhook
+path gets (injected as `GITHUB_TOKEN`/`GH_TOKEN`), so the flow can use `gh`; off by default. A cron
+`folder` is a **host path** — the worker runs on the host
 ([`DES-WORKER-ON-HOST`](specs/design.md)) and mounts that folder into the job container, so it must be
 readable by the worker's user.
 
@@ -405,8 +407,10 @@ pi-dispatch can also be triggered by GitHub — label an issue, and a container 
 opens a PR, and comments back. A repo **webhook** drives it (set a `WEBHOOK_SECRET`), and the worker
 authenticates to GitHub via `GITHUB_AUTH_SOURCE`: `gh` (a `gh auth token`) or a repo-scoped fine-grained
 **PAT** by default. A GitHub **App is optional** — it buys stronger token scoping and is what you need
-for multi-tenant. Which labels, comment phrases, and pull_request actions fire which flow is configured in
-the same unified **`triggers.json`** above; the receiver **requires** `PI_TRIGGERS_FILE`.
+for multi-tenant. The `gh` source hands your full login scopes to every token-carrying job — `doctor`
+warns and names them; use a fine-grained PAT or an App for per-job scoping. Which labels, comment
+phrases, and pull_request actions fire which flow is configured in the same unified **`triggers.json`**
+above; the receiver **requires** `PI_TRIGGERS_FILE`.
 
 ```mermaid
 flowchart LR

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -168,7 +168,13 @@ Stated openly rather than discovered later:
 - Do not blanket-forward host environment into job containers. Pass only the variables the configured
   provider needs. In particular `ANTHROPIC_OAUTH_TOKEN` silently takes precedence over
   `ANTHROPIC_API_KEY`, so a stray variable in the host environment can quietly redirect which credential
-  a job spends.
+  a job spends. `GITHUB_TOKEN` and `GH_TOKEN` are refused in `PI_FORWARD_ENV` at config load — the worker
+  sets both to the minted per-job value, and a forwarded operator token would silently override it.
+- **With `GITHUB_AUTH_SOURCE=gh` (the default), your entire gh login reaches every token-carrying job.**
+  The minted value is your own full-scope `gh auth token`, and `pi-dispatch doctor` warns and names the
+  scopes it carries (calling out broad ones like `admin:org`, `delete_repo`, `workflow`). Prefer a
+  fine-grained PAT — or an App — for real per-job scoping. Your `~/.config/gh` is never mounted into a
+  container; the credential reaches jobs only as env values.
 - **By default the worker sources the provider key from pi's `~/.pi/agent/auth.json` when the env has none.**
   It is a host-side read env-injected into the container — never a credential file mounted in — and accepts
   **API-key** logins only; an OAuth/subscription login is refused. The env always wins when set; set

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -375,14 +375,25 @@ Evidence convention as in `constitution.md`.
     reaps nothing. Chromium spawns many processes; zombies accumulate against `--pids-limit` until the
     job dies of something unrelated to its actual work.
   - Env **passed by the worker**: the configured provider's key variable(s), derived — not hardcoded
-    (see below); `GITHUB_TOKEN` (scoped, short-lived — GitHub-backed jobs only); `PI_JOB_ID`; `PI_PROVIDER`;
+    (see below); `GITHUB_TOKEN` and `GH_TOKEN`, both set to the same minted per-job token (short-lived; gh
+    prefers `GH_TOKEN`, and mirroring the two names forecloses precedence surprises) — present for
+    GitHub-backed jobs and for local cron jobs that opt in via `run.github: true`
+    (`INT-TRIGGERS-FILE-CONTRACT`), absent otherwise; `PI_JOB_ID`; `PI_PROVIDER`;
     `PI_MODEL`; `PI_MAX_TURNS`; `PI_MAX_TOKENS` (the per-job token budget — forwarded ONLY when set, omitted
     otherwise so the runner meters usage without a cap; `REQ-TOKEN-ACCOUNTING-AND-CAPS`); `PI_CODING_AGENT_DIR`
     (if not `$HOME/.pi/agent`); `PI_GLOBAL_ALLOW_EXTENSIONS=1` (forwarded ONLY when the operator armed overlay
     extensions — fail-closed; `REQ-GLOBAL-PI-OVERLAY`); and each name in `PI_FORWARD_ENV` (an explicit operator
     allowlist of extra host vars — e.g. a custom provider's key — forwarded by exact `-e NAME=VALUE`, never a
-    pass-through, so it satisfies `no-broad-env-into-container`). Note `PI_DAILY_TOKEN_CAP` is **worker-only and is
+    pass-through, so it satisfies `no-broad-env-into-container`; `GITHUB_TOKEN` and `GH_TOKEN` are refused in
+    the allowlist at config load — a forwarded operator token would silently override the minted per-job
+    value). Note `PI_DAILY_TOKEN_CAP` is **worker-only and is
     NOT forwarded** — the daily token counter is enforced host-side, and the container stays queue/budget-blind.
+  - **Per-job token *scoping* (`CONST-TOKEN-SCOPED-PER-JOB`) is the App path's property, not `gh`'s.** With
+    `GITHUB_AUTH_SOURCE=gh` (the default) the minted value is the operator's own full-scope `gh auth token`,
+    so every token-carrying job holds whatever that login can do; a fine-grained PAT approximates per-job
+    scoping for a single owner, and only the App path delivers it. `doctor` warns and names the actual
+    scopes. Either way the credential reaches the container only as env values — the operator's
+    `~/.config/gh` is never mounted.
   - Env **baked into the image**, because they are facts about the image and not choices a job makes:
     `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`, `PLAYWRIGHT_MCP_BROWSER=chromium`,
     `PLAYWRIGHT_MCP_SANDBOX=false`. **`PLAYWRIGHT_MCP_BROWSER` is load-bearing**: `playwright-cli`
@@ -539,7 +550,8 @@ and selects the `on.type` it owns (worker: `cron`; receiver: `label`, `comment`,
               "pattern": "<5 or 6 space-separated fields>" },
       "run": { "kind": "local", "folder": "<absolute HOST path, must exist>", "flow": "<flow name>",
                "task": "<operator-authored prompt text — DATA, lands in /job/prompt.md>",
-               "provider": "<optional passthrough>", "model": "<optional>", "maxTurns": <optional> } },
+               "provider": "<optional passthrough>", "model": "<optional>", "maxTurns": <optional>,
+               "github": <optional boolean> } },
     { "on": { "type": "label", "any": [...], "all": [...], "none": [...] },
       "run": { "kind": "github", "flow": "<flow name>" } },
     { "on": { "type": "comment", "phrase": "<trigger phrase>" },       // at most one
@@ -552,6 +564,11 @@ and selects the `on.type` it owns (worker: `cron`; receiver: `label`, `comment`,
   every webhook type (`label`, `comment`, `pull_request`) `⟹ run.kind:"github"`. Off-diagonal throws a
   `piDispatchConfig` error — a `cron` trigger has no webhook delivery, issue/PR number, title, or body to
   supply a github run, and a webhook trigger is adversarial input that always produces a github job.
+- **`run.github` (cron only, optional boolean)**: absent or `false` = no token — the zero-GitHub default;
+  `true` = the worker mints the same per-job token the GitHub path mints and injects it as
+  `GITHUB_TOKEN`/`GH_TOKEN` (`INT-CONTAINER-RUNTIME-CONTRACT`), so the flow can use the `gh` CLI. A
+  non-boolean value is refused at load; with `GITHUB_AUTH_SOURCE=app` a `run.github` job refuses at mint
+  time — an installation token is per-repo, and a local job has no repo to scope it to.
 - **Why**: The operator's trigger set is one host file — diffable, reviewable, git-trackable — rather than
   two files in two shapes across two services. The schema unifies the *view*; evaluation still splits by
   owner (a `label` is never scheduled; a `cron` never receives a webhook). `on.id` (cron only) must be
@@ -765,6 +782,7 @@ and selects the `on.type` it owns (worker: `cron`; receiver: `label`, `comment`,
 
 | Date | Change |
 |---|---|
+| 2026-07-27 | Closed the gh CLI gaps (issue #50): INT-TRIGGERS-FILE-CONTRACT's cron `run` gains an optional boolean `github` — absent/false = no token (the zero-GitHub default), `true` = the worker mints the SAME per-job token the GitHub path mints; a non-boolean value is refused at load, and `GITHUB_AUTH_SOURCE=app` refuses at mint time, since an installation token is per-repo and a local job has no repo to scope it to. INT-CONTAINER-RUNTIME-CONTRACT: the minted value is now injected as BOTH `GITHUB_TOKEN` and `GH_TOKEN` (gh prefers `GH_TOKEN`; mirroring forecloses precedence surprises), and both names are refused in the `PI_FORWARD_ENV` allowlist at config load — a forwarded operator token would otherwise silently override the minted one. Documented the `source:gh` trade-off next to `CONST-TOKEN-SCOPED-PER-JOB`: per-job scoping is the App path's property (a fine-grained PAT approximates it for a single owner); `gh` hands the operator's full-scope login to every token-carrying job, `doctor` names the actual scopes, and the operator's `~/.config/gh` is never mounted into a container. |
 | 2026-07-22 | Unified triggers (issue #20 + `pull_request` triggers): replaced INT-SCHEDULES-FILE-CONTRACT with **INT-TRIGGERS-FILE-CONTRACT** — one `triggers.json` of `{ on, run }` entries via `PI_TRIGGERS_FILE`, read by both worker (`on.type:cron`) and receiver (`label`/`comment`/`pull_request`), with the `on × run` diagonal enforced fail-loud at load. Expanded INT-WEBHOOK-PAYLOAD-SUBSET to consume the `pull_request` event and its fields (`number`/`title`/`body`/`author_association`/`labels[].name`/`head.{ref,sha,repo.full_name}`/`base.ref`) plus `issue.pull_request` as a presence marker — `head`/`base` are attacker-controlled DATA, never a clone ref. Amended INT-CONTAINER-JOB-INPUTS: `/job/event.json` now carries an `issue` OR a `pull_request` body per the job-data `target` discriminator. See `DES-TRIGGERS-UNIFIED-FILE`, `DES-PR-TRIGGER-ROUTES-TO-FLOW`. |
 | 2026-07-22 | Corrected INT-CONTAINER-RUNTIME-CONTRACT's mount-mechanism sentence: the `/job:ro`, `/workspace:rw`, and local-only `/outbox:rw` mounts are host bind mounts (`-v host:container`), not the superseded named-volume + `volume-subpath` mechanism. Aligns the INT with `DES-WORKER-ON-HOST` and the shipped `worker/src/docker-run.mjs`. Also corrected INT-RUN-HISTORY-FILE-CONTRACT's `chainRefused` annotation from `<bool>` to `<int>` (a count of refused `/outbox` requests on the parent; `0` = none), matching the shipped `buildRecord`, which stores the collector's running `refused` count verbatim. |
 | 2026-07-21 | Extended INT-CONFIG-OVERLAY-CONTRACT's write protocol: an invalid existing file is repaired by the next write, which rebuilds from scratch with the sanitized candidate and surfaces a loud key-only notice — the fail-closed guarantee is stated to live only on the worker's job-start read. |

--- a/worker/src/config.mjs
+++ b/worker/src/config.mjs
@@ -71,6 +71,19 @@ function commaList(raw) {
 		.filter((s) => s.length > 0);
 }
 
+// PI_FORWARD_ENV, with the token names the worker itself owns refused at boot. env-allowlist.mjs
+// sets GITHUB_TOKEN and GH_TOKEN from the per-job mint; forwarding either from the host would
+// silently swap which credential every job spends, so this fails loud here rather than per-job.
+function forwardEnvList(raw) {
+	const names = commaList(raw);
+	if (names.includes("GITHUB_TOKEN") || names.includes("GH_TOKEN")) {
+		throw configError(
+			"PI_FORWARD_ENV must not forward GITHUB_TOKEN or GH_TOKEN -- the worker mints a per-job token (CONST-TOKEN-SCOPED-PER-JOB) and a forwarded operator token would silently override it",
+		);
+	}
+	return names;
+}
+
 // The operator's global pi overlay dir (REQ-GLOBAL-PI-OVERLAY). Unset/empty = feature off. When set it
 // must EXIST at boot -- a typo pointing at nothing would silently drop the operator's whole setup on
 // every job, so fail loud like every other config error rather than degrade to nothing.
@@ -105,7 +118,7 @@ export function loadConfig(env = process.env, { fileExists = existsSync } = {}) 
 		jobImage: env.PI_JOB_IMAGE ?? "pi-job:latest",
 		globalPiDir: resolveGlobalPiDir(env, fileExists), // REQ-GLOBAL-PI-OVERLAY: operator's ~/.pi/agent subset, :ro-mounted; null = off
 		allowGlobalExtensions: env.PI_GLOBAL_ALLOW_EXTENSIONS === "1", // fail-closed: overlay extensions load only when armed
-		forwardEnv: commaList(env.PI_FORWARD_ENV), // extra host var NAMES to forward (e.g. a custom provider's key); explicit allowlist
+		forwardEnv: forwardEnvList(env.PI_FORWARD_ENV), // extra host var NAMES to forward (e.g. a custom provider's key); explicit allowlist, GitHub token names refused
 		authFromPi: env.PI_AUTH_FROM_PI !== "0", // ON by default: use the key in ~/.pi/agent/auth.json when the env has none (api-key only). PI_AUTH_FROM_PI=0 forces env-only.
 		jobsDir: env.PI_JOBS_DIR ?? defaultJobsDir(),
 		triggersFile: env.PI_TRIGGERS_FILE ?? null, // DES-CRON-VIA-BULLMQ-SCHEDULER: unified triggers file; null = cron disabled for the worker (it selects on.type:"cron")

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -6,6 +6,12 @@
  * runs even when GitHub auth is unset — a local-folder deployment needs none of it. Mirrors the kill
  * switch in cli.mjs, which reads only VALKEY_URL for the same reason (it must work when GitHub is
  * misconfigured). The provider key is checked for presence only and never printed (secrets-and-pii).
+ *
+ * GitHub auth gets two advisory (never failing) checks: the default GITHUB_AUTH_SOURCE=gh mints from the
+ * operator's FULL-scope gh login, which then reaches every token-carrying job container — the opposite of
+ * the App path's per-repo short-lived tokens (CONST-TOKEN-SCOPED-PER-JOB) — so doctor names the scopes it
+ * carries; and gh is preflighted inside the job image, since a token that works host-side but not
+ * in-container fails jobs mid-run, not at submit. Token values travel via the spawn env only, never argv.
  */
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -23,6 +29,9 @@ const PROVIDER_KEYS = {
 	google: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
 	gemini: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
 };
+
+// gh login scopes that reach well past what a job should ever hold — called out by name in the fix line.
+const BROAD_SCOPES = ["admin:org", "delete_repo", "workflow"];
 
 export async function runDoctor(env = process.env, deps = {}) {
 	const {
@@ -62,6 +71,75 @@ export async function runDoctor(env = process.env, deps = {}) {
 		label: `Job image present (${jobImage})`,
 		fix: "docker pull ghcr.io/edgehero/pi-job:latest && docker tag ghcr.io/edgehero/pi-job:latest pi-job:latest  (or build image/Dockerfile)",
 	});
+
+	// The default source `gh` mints job tokens from the operator's gh login, so the FULL-scope login token
+	// reaches every token-carrying job container — the opposite of the App path's per-repo short-lived
+	// tokens (CONST-TOKEN-SCOPED-PER-JOB). Both checks below warn, never fail: a local-only deployment with
+	// the default source is valid, for the same reason the worker's own auth at start is best-effort.
+	const ghSource = env.GITHUB_AUTH_SOURCE ?? "gh"; // config.mjs's own default, read directly — no loadConfig
+	if (ghSource === "gh") {
+		// gh writes `auth status` to stdout or stderr depending on version — capture both combined.
+		const status = await runCmdCapture(spawn, "gh", ["auth", "status"]);
+		if (status.code === 0) {
+			const scopes = parseGhTokenScopes(status.output);
+			const broad = (scopes ?? []).filter((s) => BROAD_SCOPES.includes(s));
+			checks.push({
+				ok: false,
+				warn: true,
+				label: `GITHUB_AUTH_SOURCE=gh forwards your full gh login into every token-carrying job container (${
+					scopes ? `scopes: ${scopes.join(", ")}` : "scopes not reported (fine-grained token)"
+				})`,
+				fix:
+					(broad.length > 0 ? `this token carries broad scopes (${broad.join(", ")}) -- ` : "") +
+					"use a fine-grained PAT (GITHUB_AUTH_SOURCE=pat) or a GitHub App for per-job scoping -- see SECURITY.md",
+			});
+		} else {
+			checks.push({
+				ok: false,
+				warn: true,
+				label: "GITHUB_AUTH_SOURCE is gh but `gh auth status` failed",
+				fix: "run `gh auth login` (or switch GITHUB_AUTH_SOURCE) -- github jobs and run.github cron triggers will refuse to run",
+			});
+		}
+	}
+
+	// Preflight gh INSIDE the job image: a token that works host-side but not in-container (no egress from
+	// containers, stale image) fails jobs mid-run, not at submit. Only meaningful when docker and the image
+	// are green; otherwise it is noise on top of the failures already reported above.
+	if (dockerCode === 0 && imageCode === 0) {
+		if (ghSource === "app") {
+			checks.push({ ok: true, label: "in-image gh auth: skipped (GITHUB_AUTH_SOURCE=app mints per-job)" });
+		} else {
+			let token = "";
+			if (ghSource === "gh") {
+				const minted = await runCmdCapture(spawn, "gh", ["auth", "token"]);
+				if (minted.code === 0) token = minted.output.trim();
+				// mint failed → skip: the status check above already warned that gh auth is broken
+			} else if (ghSource === "pat") {
+				const patVar = env.GITHUB_PAT_VAR ?? "GITHUB_PAT"; // config.mjs's patVar default, read directly
+				token = (env[patVar] ?? "").trim(); // absent → skip; loadConfig fails loud at worker boot anyway
+			}
+			if (token) {
+				// Value-less `-e` flags: docker forwards GH_TOKEN/GITHUB_TOKEN from the spawn env, so the
+				// token value never enters argv (visible in `ps`) and never reaches doctor's output.
+				const probe = await runCmdCapture(
+					spawn,
+					"docker",
+					["run", "--rm", "-e", "GH_TOKEN", "-e", "GITHUB_TOKEN", "--entrypoint", "gh", jobImage, "auth", "status"],
+					{ env: { ...env, GH_TOKEN: token, GITHUB_TOKEN: token } },
+				);
+				checks.push({
+					ok: probe.code === 0,
+					warn: true,
+					label:
+						probe.code === 0
+							? `gh authenticates inside the job image (${jobImage})`
+							: `gh cannot authenticate inside the job image (${jobImage})`,
+					fix: "check network egress from containers or rebuild/pull the job image -- jobs that use gh will fail mid-run",
+				});
+			}
+		}
+	}
 
 	checks.push({
 		ok: await probeValkey(valkeyUrl),
@@ -171,6 +249,57 @@ function runCmd(spawn, cmd, args) {
 		child.on("error", () => resolve(null)); // ENOENT etc. — the binary is not available
 		child.on("close", (code) => resolve(code));
 	});
+}
+
+/**
+ * Like runCmd but collects stdout+stderr into one combined string — gh moves its human output between
+ * the two across versions, so callers get both. Resolves `{code, output}`; `code: null` when the command
+ * could not be launched or overran the timeout (default 30s, so a hung docker daemon cannot stall doctor).
+ * `opts.env` is passed through to the spawn so secrets can travel via env instead of argv.
+ */
+function runCmdCapture(spawn, cmd, args, opts = {}) {
+	const { timeoutMs = 30000 } = opts;
+	return new Promise((resolve) => {
+		let child;
+		try {
+			child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"], ...(opts.env ? { env: opts.env } : {}) });
+		} catch {
+			resolve({ code: null, output: "" });
+			return;
+		}
+		let output = "";
+		let done = false;
+		const finish = (code) => {
+			if (done) return;
+			done = true;
+			clearTimeout(timer);
+			resolve({ code, output });
+		};
+		const timer = setTimeout(() => {
+			try {
+				child.kill();
+			} catch {}
+			finish(null);
+		}, timeoutMs);
+		child.stdout?.on("data", (d) => (output += d));
+		child.stderr?.on("data", (d) => (output += d));
+		child.on("error", () => finish(null)); // ENOENT etc. — the binary is not available
+		child.on("close", (code) => finish(code));
+	});
+}
+
+/**
+ * Pull the scope list out of `gh auth status` output. The line reads like
+ * `  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'` (older gh omits the quotes). Returns null
+ * when the line is absent — fine-grained tokens report no classic scopes at all.
+ */
+function parseGhTokenScopes(output) {
+	const m = output.match(/Token scopes:\s*(.+)/);
+	if (!m) return null;
+	return m[1]
+		.split(",")
+		.map((s) => s.trim().replace(/^'(.*)'$/, "$1"))
+		.filter((s) => s.length > 0);
 }
 
 /**

--- a/worker/src/env-allowlist.mjs
+++ b/worker/src/env-allowlist.mjs
@@ -97,7 +97,8 @@ function resolveEnvName(provider, cred) {
 
 /**
  * Assemble the container env. `hostEnv` is the worker's process.env; `job` carries the resolved
- * config and the per-job scoped token (GitHub-backed jobs only).
+ * config and the per-job scoped token (GitHub-backed jobs, and local cron jobs that opted in via
+ * run.github).
  *
  * Throws if the provider is not configured -- a deterministic misconfiguration the caller maps to
  * a pre-spend refusal, never a launched-then-failed container.
@@ -137,9 +138,16 @@ export function buildContainerEnv({ provider, model, maxTurns, maxTokens, jobId,
 		if (hostEnv[name] !== undefined) env[name] = hostEnv[name];
 	}
 
-	// GitHub-backed jobs only. Local-folder jobs have no token (CONST-TOKEN-SCOPED-PER-JOB is
-	// scoped to GitHub jobs). Absent token => absent variable, never an empty one.
-	if (githubToken) env.GITHUB_TOKEN = githubToken;
+	// GitHub-backed jobs, and local cron jobs that opted in via run.github. Other local-folder jobs
+	// have no token (CONST-TOKEN-SCOPED-PER-JOB). The mint goes into BOTH variables because the gh
+	// CLI prefers GH_TOKEN over GITHUB_TOKEN -- mirroring forecloses any precedence surprise inside
+	// the container. This assignment deliberately sits AFTER the PI_FORWARD_ENV loop so a forwarded
+	// name can never override the mint (and loadConfig refuses those names at load anyway).
+	// Absent token => absent variable, never an empty one.
+	if (githubToken) {
+		env.GITHUB_TOKEN = githubToken;
+		env.GH_TOKEN = githubToken;
+	}
 
 	return env;
 }

--- a/worker/src/get-token.mjs
+++ b/worker/src/get-token.mjs
@@ -6,6 +6,9 @@
  * CONST-TOKEN-SCOPED-PER-JOB: the App path mints one installation token per job, scoped to the one
  * repo, expiring in an hour. That short-lived, repo-scoped expiry IS the blast-radius bound for an
  * exfiltrated environment (App: 1h; a single-owner fine-grained PAT: operator-set, still short).
+ * The per-job SCOPING claim is the App path's property alone: `gh` and `pat` hand out the
+ * operator-scoped credential and rely on the operator keeping that credential narrow (the
+ * INT-CONTAINER-RUNTIME-CONTRACT trade-off note).
  *
  * Money-hole invariant: `mintToken` NEVER returns "" / null. `env-allowlist.mjs` forwards the token
  * as `GITHUB_TOKEN` only when truthy (`if (githubToken)`), so an empty token becomes an ABSENT
@@ -81,6 +84,13 @@ export async function makeGitHubAuth(cfg, deps = {}) {
 		const selfId = await resolveSelfId({ source: "app", octokit });
 
 		const mintToken = async (repo) => {
+			// A local run.github job passes no repo, and an installation token MUST be scoped to one
+			// (CONST-TOKEN-SCOPED-PER-JOB) -- refuse deterministically rather than mint broad.
+			if (!repo || !String(repo).trim()) {
+				throw configError(
+					"GITHUB_AUTH_SOURCE=app mints per-repo installation tokens, and a local run.github job has no repo to scope to -- use gh or pat for run.github cron triggers, or run the work as a github job",
+				);
+			}
 			const repositoryNames = [repoNameOf(repo)]; // scope to the ONE repo; owner stripped
 			let minted;
 			try {

--- a/worker/src/processor.mjs
+++ b/worker/src/processor.mjs
@@ -8,8 +8,10 @@ import { EXIT_COMPLETED, EXIT_INFRA, EXIT_POLICY } from "./exit-code.mjs";
  *
  * The order is the contract, and every step before `runContainer` must be free of provider spend:
  *
- *   1. mint a scoped token (GitHub jobs)          -- CONST-TOKEN-SCOPED-PER-JOB
- *   2. REFUSE an unprotected default branch       -- REQ-BRANCH-PROTECTION-PRECONDITION
+ *   1. mint a scoped token (GitHub jobs, and local jobs opted in via `github: true`)
+ *                                                 -- CONST-TOKEN-SCOPED-PER-JOB
+ *   2. REFUSE an unprotected default branch (GitHub jobs only -- a local job has no repo)
+ *                                                 -- REQ-BRANCH-PROTECTION-PRECONDITION
  *   3. resolve the default-branch SHA (fresh API), clone at it, materialise .pi/, write the prompt
  *   4. reserve a budget slot                      -- CONST-BUDGET-BEFORE-TOKENS
  *   5. ONLY NOW run the container (the only step that spends provider tokens)
@@ -30,7 +32,7 @@ export async function runJob(job, deps) {
 		softHoldPct, // int 1-99 or null; the soft-hold band applied to every active window
 		tokenCap = null, // int or null; the daily TOKEN cap (issue #25). Check-AFTER, so it gates the NEXT job on prior spend
 		recordSpend = recordTokenSpend, // injected so the post-container INCRBY is testable/stubbable
-		mintToken, // (repo) => scoped short-lived token | null for local-folder jobs
+		mintToken, // (repo) => scoped short-lived token. Called with the repo for github jobs, with undefined for local jobs opted in via `github: true`; unflagged local jobs never mint (token stays null)
 		isDefaultBranchProtected, // (repo, token) => boolean
 		prepareWorkspace, // (job, token) => { workspaceDir, jobDir }  (clone+materialise+prompt)
 		// runContainer({ job, token, prepared, name, signal }) => { code, aborted, turns }. It MUST honour
@@ -48,25 +50,31 @@ export async function runJob(job, deps) {
 	} = deps;
 
 	const isGitHub = job.kind === "github";
+	// A local job opted in via `github: true` (cron trigger opt-in, INT-TRIGGERS-FILE-CONTRACT) mints the
+	// same scoped per-job token the github path mints (CONST-TOKEN-SCOPED-PER-JOB) -- repo arg undefined,
+	// since a local job has none. Unflagged local jobs stay tokenless, exactly as before.
+	const wantsGitHubToken = isGitHub || job.github === true;
 	let token = null;
 	let prepared = null;
 	let reserved = false;
 
 	try {
-		if (isGitHub) {
-			token = await mintToken(job.repo);
+		if (wantsGitHubToken) {
+			token = await mintToken(isGitHub ? job.repo : undefined);
 
 			// Defense-in-depth at the DI seam: mintToken is injected, so we cannot assume it routed
 			// through get-token's own empty-token guard. An empty credential here would reach
 			// env-allowlist's `if (githubToken)` as a falsy value -> GITHUB_TOKEN omitted -> an
 			// anonymous paid run. Refuse before reserveBudget so a bad token burns no cap slot.
-			if (isGitHub && (typeof token !== "string" || token.trim() === "")) {
+			if (typeof token !== "string" || token.trim() === "") {
 				throw configError("mintToken returned an empty credential");
 			}
+		}
 
+		if (isGitHub) {
 			// REQ-BRANCH-PROTECTION-PRECONDITION. The agent's token can merge (contents:write covers
 			// push AND merge), so branch protection is the only technical barrier to a self-merge.
-			// Refuse before spending anything.
+			// Refuse before spending anything. GitHub jobs only: a local job has no job.repo to check.
 			if (!(await isDefaultBranchProtected(job.repo, token))) {
 				await comment(job, "Refused: the default branch is not protected. See SECURITY.md.");
 				log("refused_unprotected", { repo: job.repo });

--- a/worker/src/schedules.mjs
+++ b/worker/src/schedules.mjs
@@ -44,8 +44,10 @@ function normalizeCronSchedule({ on, run }, path, existsSync) {
 
 	// Absent provider/model/maxTurns stay absent (undefined) so the value resolves at job start against the
 	// settings overlay/env, not a default frozen here (INT-CONFIG-OVERLAY-CONTRACT). data key order matches
-	// queue.mjs -- the shape the processor's runJob consumes.
-	const data = { kind: "local", folder: run.folder, flow: run.flow, task: run.task, provider: run.provider, model: run.model, maxTurns: run.maxTurns };
+	// queue.mjs -- the shape the processor's runJob consumes. `github` (the opt-in token flag,
+	// INT-TRIGGERS-FILE-CONTRACT) rides along the same way: undefined drops out at JSON serialization, so
+	// an unflagged schedule stays byte-identical to today's.
+	const data = { kind: "local", folder: run.folder, flow: run.flow, task: run.task, provider: run.provider, model: run.model, maxTurns: run.maxTurns, github: run.github };
 	// Retention only; the deterministic repeat:<id>:<millis> jobId supplies dedup, so no jobId here, and
 	// scheduler jobs are not retried (DES-CRON-VIA-BULLMQ-SCHEDULER) so no attempts/backoff.
 	const opts = { removeOnComplete: { age: 24 * 3600 }, removeOnFail: { age: 7 * 24 * 3600 } };

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -259,7 +259,7 @@ export async function startWorker(
 			mintToken:
 				gh?.mintToken ??
 				(async () => {
-					throw configError("github jobs require a working GITHUB_AUTH_SOURCE (gh/pat/app)");
+					throw configError("github jobs and cron triggers with run.github require a working GITHUB_AUTH_SOURCE (gh/pat/app)");
 				}),
 			isDefaultBranchProtected: host.isDefaultBranchProtected,
 		},

--- a/worker/src/triggers.mjs
+++ b/worker/src/triggers.mjs
@@ -124,11 +124,20 @@ function normalizeCron(on, run, index, path, state) {
 		throw configError(`cron trigger "${id}": run.task must be a non-empty string: ${path}`);
 	}
 
+	// Cron jobs are the zero-GitHub path by default; `run.github: true` is the per-trigger opt-in that
+	// makes the worker mint the same scoped per-job token the github path mints, so the container can use
+	// the gh CLI (INT-TRIGGERS-FILE-CONTRACT). Strictly boolean, fail-loud: a truthy string like "true"
+	// silently opting a trigger into a credential is exactly the drift this validator exists to refuse.
+	if (run.github !== undefined && typeof run.github !== "boolean") {
+		throw configError(`cron trigger "${id}": run.github must be true or false when present: ${path}`);
+	}
+
 	// provider/model/maxTurns stay absent when omitted so the value resolves at job start against the
-	// settings overlay/env, not a default frozen here (INT-CONFIG-OVERLAY-CONTRACT).
+	// settings overlay/env, not a default frozen here (INT-CONFIG-OVERLAY-CONTRACT). github stays absent
+	// the same way, so an unflagged trigger's schedule is byte-identical to today's.
 	return {
 		on: { type: "cron", id, pattern },
-		run: { kind: "local", folder: run.folder, flow: run.flow, task: run.task, provider: run.provider, model: run.model, maxTurns: run.maxTurns },
+		run: { kind: "local", folder: run.folder, flow: run.flow, task: run.task, provider: run.provider, model: run.model, maxTurns: run.maxTurns, github: run.github },
 	};
 }
 

--- a/worker/test/config.test.mjs
+++ b/worker/test/config.test.mjs
@@ -91,6 +91,16 @@ test("forwardEnv is a comma list of names -- trimmed, empties dropped, default [
 	assert.deepEqual(loadConfig({ PI_FORWARD_ENV: "MY_KEY, OTHER ,,THIRD" }).forwardEnv, ["MY_KEY", "OTHER", "THIRD"]);
 });
 
+test("forwardEnv refuses GITHUB_TOKEN and GH_TOKEN at boot -- a forwarded operator token would override the mint", () => {
+	for (const bad of ["GH_TOKEN", "GITHUB_TOKEN", "FOO,GH_TOKEN"]) {
+		assert.throws(
+			() => loadConfig({ PI_FORWARD_ENV: bad }),
+			(e) => e.piDispatchConfig === true && /CONST-TOKEN-SCOPED-PER-JOB/.test(e.message),
+			`PI_FORWARD_ENV=${bad}`,
+		);
+	}
+});
+
 test("authFromPi defaults ON; only PI_AUTH_FROM_PI=0 forces env-only", () => {
 	assert.equal(loadConfig({}).authFromPi, true, "reusing the pi login is the default — no flag needed");
 	assert.equal(loadConfig({ PI_AUTH_FROM_PI: "1" }).authFromPi, true);

--- a/worker/test/doctor.test.mjs
+++ b/worker/test/doctor.test.mjs
@@ -5,29 +5,58 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runDoctor } from "../src/doctor.mjs";
 
-// A fake `spawn`: resolves each `docker <sub>` to a canned exit code, or an "enoent" launch failure.
-function fakeSpawn(plan) {
-	return (_cmd, args) => {
-		const sub = args[0]; // "info" | "image"
-		const outcome = plan[sub];
-		const handlers = {};
-		queueMicrotask(() => {
-			if (outcome === "enoent") handlers.error?.(new Error("spawn docker ENOENT"));
-			else handlers.close?.(outcome);
+// A fake `spawn`: plan keys are command-line prefixes ("docker info", "docker image", "docker run",
+// "gh auth status", "gh auth token") mapped to a canned exit code, a `{code, output}` pair (output is
+// emitted on the fake stdout for doctor's capture helper), or "enoent" for a launch failure. Every spawn
+// is recorded into `calls` (cmd, args, opts) so tests can assert argv and the spawn env.
+function fakeSpawn(plan, calls = []) {
+	return (cmd, args, opts) => {
+		const line = [cmd, ...args].join(" ");
+		const key = Object.keys(plan).find((k) => line.startsWith(k));
+		const outcome = plan[key];
+		calls.push({ cmd, args, opts });
+		const stream = () => ({
+			handlers: {},
+			on(ev, cb) {
+				this.handlers[ev] = cb;
+				return this;
+			},
 		});
-		return {
+		const handlers = {};
+		const child = {
+			stdout: stream(),
+			stderr: stream(),
+			kill() {},
 			on(ev, cb) {
 				handlers[ev] = cb;
 				return this;
 			},
 		};
+		queueMicrotask(() => {
+			if (outcome === "enoent") {
+				handlers.error?.(new Error(`spawn ${cmd} ENOENT`));
+				return;
+			}
+			const { code, output } = typeof outcome === "object" && outcome !== null ? outcome : { code: outcome, output: "" };
+			if (output) child.stdout.handlers.data?.(output);
+			handlers.close?.(code);
+		});
+		return child;
 	};
 }
 function capture() {
 	const buf = [];
 	return { out: (s) => buf.push(s), text: () => buf.join("") };
 }
-const green = { info: 0, image: 0 };
+const green = { "docker info": 0, "docker image": 0 };
+// A classic-token `gh auth status` (newer gh quotes each scope; the parser also accepts unquoted).
+const ghStatusOutput = [
+	"github.com",
+	"  ✓ Logged in to github.com account octocat (keyring)",
+	"  - Active account: true",
+	"  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'",
+	"",
+].join("\n");
 
 test("doctor: all prerequisites present passes and exits 0", async () => {
 	const { out, text } = capture();
@@ -44,7 +73,7 @@ test("doctor: docker down, valkey down, no key exits 1 with fixes", async () => 
 	const { out, text } = capture();
 	const code = await runDoctor(
 		{ PI_PROVIDER: "anthropic" }, // no credential
-		{ out, spawn: fakeSpawn({ info: 1 }), probeValkey: async () => false, fileExists: () => true, nodeVersion: "22.19.0" },
+		{ out, spawn: fakeSpawn({ "docker info": 1 }), probeValkey: async () => false, fileExists: () => true, nodeVersion: "22.19.0" },
 	);
 	assert.equal(code, 1);
 	assert.match(text(), /start Docker/, "a down daemon (exit != 0) is distinguished from a missing binary");
@@ -56,7 +85,7 @@ test("doctor: a missing docker binary reads as 'install', not 'start'", async ()
 	const { out, text } = capture();
 	await runDoctor(
 		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x" },
-		{ out, spawn: fakeSpawn({ info: "enoent" }), probeValkey: async () => true, fileExists: () => true, nodeVersion: "22.19.0" },
+		{ out, spawn: fakeSpawn({ "docker info": "enoent" }), probeValkey: async () => true, fileExists: () => true, nodeVersion: "22.19.0" },
 	);
 	assert.match(text(), /install Docker/, "an unlaunchable docker is an install problem");
 });
@@ -65,9 +94,16 @@ test("doctor: the provider key value is never printed", async () => {
 	const { out, text } = capture();
 	await runDoctor(
 		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-secret-value" },
-		{ out, spawn: fakeSpawn(green), probeValkey: async () => true, fileExists: () => true, nodeVersion: "22.19.0" },
+		{
+			out,
+			spawn: fakeSpawn({ ...green, "gh auth status": { code: 0, output: ghStatusOutput }, "gh auth token": { code: 0, output: "gho_secret_mint\n" }, "docker run": 0 }),
+			probeValkey: async () => true,
+			fileExists: () => true,
+			nodeVersion: "22.19.0",
+		},
 	);
 	assert.doesNotMatch(text(), /sk-secret-value/, "the credential must never reach output");
+	assert.doesNotMatch(text(), /gho_secret_mint/, "the minted gh token must never reach output");
 });
 
 test("doctor: an outdated Node is flagged and fails", async () => {
@@ -175,4 +211,89 @@ test("doctor: an OAuth login in pi auth.json is flagged as not usable for a serv
 	);
 	assert.equal(code, 1, "an OAuth/subscription login is not a usable service credential");
 	assert.match(text(), /OAuth\/subscription/);
+});
+
+// GITHUB_AUTH_SOURCE=gh (the default) forwards the operator's full gh login into every token-carrying job
+// container (CONST-TOKEN-SCOPED-PER-JOB) — doctor surfaces the trade-off as a warning, never a failure.
+const ghDeps = (out, plan, calls) => ({ out, spawn: fakeSpawn(plan, calls), probeValkey: async () => true, fileExists: () => true, nodeVersion: "22.19.0" });
+const ghEnv = (extra = {}) => ({ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x", ...extra });
+
+test("doctor: default source gh warns with the login's scopes and names the broad ones", async () => {
+	const { out, text } = capture();
+	const code = await runDoctor(ghEnv(), ghDeps(out, { ...green, "gh auth status": { code: 0, output: ghStatusOutput } }));
+	assert.equal(code, 0, "the scope warning never fails doctor");
+	assert.match(text(), /⚠ GITHUB_AUTH_SOURCE=gh forwards your full gh login into every token-carrying job container \(scopes: gist, read:org, repo, workflow\)/);
+	assert.match(text(), /this token carries broad scopes \(workflow\)/, "broad scopes are called out by name");
+	assert.match(text(), /fine-grained PAT \(GITHUB_AUTH_SOURCE=pat\) or a GitHub App/);
+});
+
+test("doctor: a fine-grained token (no scopes line) is reported as such", async () => {
+	const { out, text } = capture();
+	await runDoctor(ghEnv(), ghDeps(out, { ...green, "gh auth status": { code: 0, output: "github.com\n  ✓ Logged in to github.com account octocat\n" } }));
+	assert.match(text(), /scopes not reported \(fine-grained token\)/);
+	assert.doesNotMatch(text(), /broad scopes/);
+});
+
+test("doctor: GITHUB_AUTH_SOURCE=pat emits no scope warning", async () => {
+	const { out, text } = capture();
+	await runDoctor(ghEnv({ GITHUB_AUTH_SOURCE: "pat" }), ghDeps(out, green));
+	assert.doesNotMatch(text(), /forwards your full gh login/);
+});
+
+test("doctor: source gh with gh missing warns 'auth status failed', still exits 0", async () => {
+	const { out, text } = capture();
+	const code = await runDoctor(ghEnv(), ghDeps(out, { ...green, "gh auth": "enoent" }));
+	assert.equal(code, 0, "a local-only deployment with the default source is valid — warn, don't fail");
+	assert.match(text(), /⚠ GITHUB_AUTH_SOURCE is gh but `gh auth status` failed/);
+	assert.match(text(), /run `gh auth login` \(or switch GITHUB_AUTH_SOURCE\)/);
+});
+
+test("doctor: the in-image probe passes the token via the spawn env, never argv", async () => {
+	const calls = [];
+	const { out, text } = capture();
+	const plan = {
+		...green,
+		"gh auth status": { code: 0, output: ghStatusOutput },
+		"gh auth token": { code: 0, output: "gho_fake_mint_123\n" },
+		"docker run": 0,
+	};
+	const code = await runDoctor(ghEnv(), ghDeps(out, plan, calls));
+	assert.equal(code, 0);
+	const run = calls.find((c) => c.cmd === "docker" && c.args[0] === "run");
+	assert.ok(run, "the in-image probe spawned docker run");
+	assert.equal(run.args[run.args.indexOf("--entrypoint") + 1], "gh", "the image entrypoint is overridden to gh");
+	// value-less -e flags: only the names appear in argv, the values ride the spawn env
+	assert.deepEqual(run.args.filter((_, i) => run.args[i - 1] === "-e"), ["GH_TOKEN", "GITHUB_TOKEN"]);
+	assert.ok(!run.args.some((a) => a.includes("gho_fake_mint_123")), "the token never enters argv");
+	assert.equal(run.opts.env.GH_TOKEN, "gho_fake_mint_123");
+	assert.equal(run.opts.env.GITHUB_TOKEN, "gho_fake_mint_123");
+	assert.match(text(), /✓ gh authenticates inside the job image \(pi-job:latest\)/);
+	assert.doesNotMatch(text(), /gho_fake_mint_123/, "the token never reaches output");
+});
+
+test("doctor: an in-image gh auth failure warns with the egress fix, exits 0", async () => {
+	const { out, text } = capture();
+	const plan = { ...green, "gh auth status": { code: 0, output: ghStatusOutput }, "gh auth token": { code: 0, output: "gho_x\n" }, "docker run": 1 };
+	const code = await runDoctor(ghEnv(), ghDeps(out, plan));
+	assert.equal(code, 0, "an in-container auth failure warns but never fails doctor");
+	assert.match(text(), /⚠ gh cannot authenticate inside the job image \(pi-job:latest\)/);
+	assert.match(text(), /check network egress from containers/);
+});
+
+test("doctor: no in-image probe when docker is not green (gating)", async () => {
+	const calls = [];
+	const { out } = capture();
+	const plan = { "docker info": 1, "gh auth status": { code: 0, output: ghStatusOutput }, "gh auth token": { code: 0, output: "gho_x\n" } };
+	await runDoctor(ghEnv(), ghDeps(out, plan, calls));
+	assert.ok(!calls.some((c) => c.cmd === "docker" && c.args[0] === "run"), "no docker run on top of a down daemon");
+});
+
+test("doctor: GITHUB_AUTH_SOURCE=app skips the in-image probe (mints per-job)", async () => {
+	const calls = [];
+	const { out, text } = capture();
+	const code = await runDoctor(ghEnv({ GITHUB_AUTH_SOURCE: "app" }), ghDeps(out, green, calls));
+	assert.equal(code, 0);
+	assert.match(text(), /✓ in-image gh auth: skipped \(GITHUB_AUTH_SOURCE=app mints per-job\)/);
+	assert.ok(!calls.some((c) => c.cmd === "docker" && c.args[0] === "run"), "app mints per-job — nothing to preflight");
+	assert.doesNotMatch(text(), /forwards your full gh login/, "no scope warning for source app");
 });

--- a/worker/test/env-allowlist.test.mjs
+++ b/worker/test/env-allowlist.test.mjs
@@ -59,7 +59,7 @@ test("the container env is a CLOSED set: only the provider key, never the whole 
 	assert.equal(env.OPENAI_API_KEY, undefined); // wrong provider's key not forwarded either
 });
 
-test("a local-folder job (no token) gets NO GITHUB_TOKEN var at all -- not an empty one", { skip }, () => {
+test("a local-folder job (no token) gets NO GITHUB_TOKEN or GH_TOKEN var at all -- not an empty one", { skip }, () => {
 	const env = buildContainerEnv({
 		provider: "anthropic",
 		model: "m",
@@ -69,6 +69,34 @@ test("a local-folder job (no token) gets NO GITHUB_TOKEN var at all -- not an em
 		hostEnv: HOST,
 	});
 	assert.ok(!("GITHUB_TOKEN" in env), "absent token must mean absent variable");
+	assert.ok(!("GH_TOKEN" in env), "the mirror var is absent too, never an empty one");
+});
+
+test("the minted token is mirrored into BOTH GITHUB_TOKEN and GH_TOKEN (gh prefers GH_TOKEN)", { skip }, () => {
+	const env = buildContainerEnv({
+		provider: "anthropic",
+		model: "m",
+		maxTurns: 5,
+		jobId: "j",
+		githubToken: "ghs_scoped",
+		hostEnv: HOST,
+	});
+	assert.equal(env.GITHUB_TOKEN, "ghs_scoped");
+	assert.equal(env.GH_TOKEN, "ghs_scoped", "gh reads GH_TOKEN first -- both must carry the same mint");
+});
+
+test("a forwarded GH_TOKEN can never override the mint -- the token assignment sits after the forward loop", { skip }, () => {
+	const env = buildContainerEnv({
+		provider: "anthropic",
+		model: "m",
+		maxTurns: 5,
+		jobId: "j",
+		githubToken: "minted-token",
+		hostEnv: { ...HOST, GH_TOKEN: "operator-token" },
+		forwardEnv: ["GH_TOKEN"],
+	});
+	assert.equal(env.GH_TOKEN, "minted-token", "the operator token must not beat the per-job mint");
+	assert.equal(env.GITHUB_TOKEN, "minted-token");
 });
 
 test("PI_MAX_TOKENS is forwarded only when the per-job budget is set", { skip }, () => {

--- a/worker/test/get-token.test.mjs
+++ b/worker/test/get-token.test.mjs
@@ -104,6 +104,14 @@ test("gh happy: mintToken returns the trimmed `gh auth token` stdout, selfId res
 	assert.equal(await auth.mintToken("owner/repo"), "ghs_ghtoken");
 });
 
+test("gh mintToken(undefined) still resolves -- a local run.github job has no repo and gh ignores it", async () => {
+	const auth = await makeGitHubAuth(
+		{ source: "gh" },
+		{ Octokit: FakeOctokit(USER_ROUTES), execFile: fakeExecFile({ stdout: "ghs_ghtoken\n" }) },
+	);
+	assert.equal(await auth.mintToken(undefined), "ghs_ghtoken");
+});
+
 test("gh logged-out (exit 0, empty stdout) is a config error", async () => {
 	await assert.rejects(
 		() => makeGitHubAuth({ source: "gh" }, { Octokit: FakeOctokit(USER_ROUTES), execFile: fakeExecFile({ stdout: "" }) }),
@@ -150,6 +158,26 @@ test("app mint strips the owner: repositoryNames gets the bare repo name", async
 	await auth.mintToken("acme-corp/widgets");
 	assert.deepEqual(calls[0].repositoryNames, ["widgets"]);
 	assert.equal(calls[0].type, "installation");
+});
+
+test("app mintToken with no repo (local run.github job) is a config error steering to gh/pat", async () => {
+	const calls = [];
+	const auth = await makeGitHubAuth(
+		{ source: "app", appId: "123", installationId: "456", privateKeyPath: "/keys/app.pem" },
+		{
+			Octokit: FakeOctokit(APP_ROUTES),
+			createAppAuth: fakeCreateAppAuth({ result: { token: "ghs_x" }, calls }),
+			readFile: async () => "PEM",
+		},
+	);
+	for (const repo of [undefined, ""]) {
+		await assert.rejects(
+			() => auth.mintToken(repo),
+			(e) => e.piDispatchConfig === true && /run\.github/.test(e.message),
+			`repo=${JSON.stringify(repo)}`,
+		);
+	}
+	assert.equal(calls.length, 0, "the refusal happens before any mint attempt");
 });
 
 test("app missing config (no installationId) is a config error before any network call", async () => {

--- a/worker/test/processor.test.mjs
+++ b/worker/test/processor.test.mjs
@@ -152,12 +152,68 @@ test("a whitespace-only minted token is also refused as configError", async () =
 	assert.equal(redis.incrCalls, 0, "whitespace is empty -- no slot burned");
 });
 
-test("a local job does not hit the empty-credential guard (guard is isGitHub-gated)", async () => {
+test("an unflagged local job does not hit the empty-credential guard (it never mints)", async () => {
 	const redis = fakeRedis();
 	const { deps: d } = deps({ redis, mintToken: async () => "" });
 	const localJob = { kind: "local", folder: "/home/rob/proj", provider: "anthropic", model: "m", maxTurns: 5 };
 	const r = await runJob(localJob, d);
-	assert.equal(r.outcome, "completed", "a local job never mints, so the empty-token guard cannot fire");
+	assert.equal(r.outcome, "completed", "an unflagged local job never mints, so the empty-token guard cannot fire");
+});
+
+// ---- run.github opt-in: a local cron job flagged `github: true` mints the same scoped per-job token
+// ---- the github path mints (CONST-TOKEN-SCOPED-PER-JOB), with no repo to pass or branch-check.
+
+const flaggedLocalJob = { kind: "local", folder: "/home/rob/proj", github: true, provider: "anthropic", model: "m", maxTurns: 5 };
+
+test("a run.github local job mints with an UNDEFINED repo, skips the branch check, and threads the token through", async () => {
+	const minted = [];
+	const tokens = { prepare: "unset", container: "unset" };
+	const { deps: d, calls } = deps({
+		mintToken: async (repo) => (minted.push(repo), "tok-local"),
+		prepareWorkspace: async (_job, token) => ((tokens.prepare = token), { workspaceDir: "/w", jobDir: "/j" }),
+		runContainer: async ({ token }) => ((tokens.container = token), { code: 0, aborted: false }),
+	});
+	const r = await runJob(flaggedLocalJob, d);
+	assert.equal(r.outcome, "completed");
+	assert.deepEqual(minted, [undefined], "mintToken is called exactly once, with no repo (a local job has none)");
+	assert.ok(!calls.includes("branch-check"), "no branch-protection check -- REQ-BRANCH-PROTECTION-PRECONDITION is github-jobs-only");
+	assert.equal(tokens.prepare, "tok-local", "the minted token reaches prepareWorkspace");
+	assert.equal(tokens.container, "tok-local", "the minted token reaches runContainer");
+});
+
+test("a local job WITHOUT the flag never mints; the container sees a null token (today's behavior)", async () => {
+	const tokens = { container: "unset" };
+	const { deps: d, calls } = deps({
+		runContainer: async ({ token }) => ((tokens.container = token), { code: 0, aborted: false }),
+	});
+	const localJob = { kind: "local", folder: "/home/rob/proj", provider: "anthropic", model: "m", maxTurns: 5 };
+	const r = await runJob(localJob, d);
+	assert.equal(r.outcome, "completed");
+	assert.ok(!calls.some((c) => c.startsWith("mint")), "no mint for an unflagged local job");
+	assert.equal(tokens.container, null, "token stays null exactly as before the opt-in existed");
+});
+
+test("a flagged local job whose mint rejects (config-tagged) propagates BEFORE reserveBudget -- no cap slot burned", async () => {
+	const redis = fakeRedis();
+	const { deps: d, calls } = deps({
+		redis,
+		mintToken: async () => {
+			const e = new Error("github jobs and cron triggers with run.github require a working GITHUB_AUTH_SOURCE (gh/pat/app)");
+			e.piDispatchConfig = true;
+			throw e;
+		},
+	});
+	await assert.rejects(() => runJob(flaggedLocalJob, d), (e) => e.piDispatchConfig === true);
+	assert.equal(redis.incrCalls, 0, "reserveBudget never reached -- no slot burned on a broken auth source");
+	assert.ok(!calls.includes("run-container"), "no container, no provider spend");
+});
+
+test("a flagged local job with an empty minted token is refused by the empty-credential guard", async () => {
+	const redis = fakeRedis();
+	const { deps: d, calls } = deps({ redis, mintToken: async () => "" });
+	await assert.rejects(() => runJob(flaggedLocalJob, d), (e) => e.piDispatchConfig === true);
+	assert.equal(redis.incrCalls, 0, "no slot burned on an empty credential");
+	assert.ok(!calls.includes("run-container"), "an empty credential must never reach a paid run");
 });
 
 test("container-never-started (spawn fault) after reserving RELEASES the slot, still throws InfraRetry", async () => {

--- a/worker/test/schedules.test.mjs
+++ b/worker/test/schedules.test.mjs
@@ -75,6 +75,7 @@ test("a valid cron trigger normalizes to the scheduler shape; omitted provider/m
 		provider: undefined,
 		model: undefined,
 		maxTurns: undefined,
+		github: undefined,
 	});
 
 	// opts: retention only -- no jobId, attempts, or backoff.
@@ -90,6 +91,16 @@ test("run-level provider/model/maxTurns pass through verbatim into data", () => 
 	assert.equal(s.data.provider, "openai");
 	assert.equal(s.data.model, "gpt-x");
 	assert.equal(s.data.maxTurns, 5);
+});
+
+test("run.github: true flows into the scheduler data (the token opt-in reaches the job template)", () => {
+	const [s] = load([{ ...CRON, run: { ...CRON.run, github: true } }]);
+	assert.equal(s.data.github, true);
+});
+
+test("an unflagged cron trigger's data.github is undefined -- drops out at JSON serialization, schedule byte-identical to today's", () => {
+	const [s] = load([CRON]);
+	assert.equal(s.data.github, undefined);
 });
 
 test("multiple valid cron entries with distinct ids all normalize in order", () => {

--- a/worker/test/triggers.test.mjs
+++ b/worker/test/triggers.test.mjs
@@ -54,10 +54,10 @@ test("a non-object entry / on / run is a config error", () => {
 
 // --- cron (ported from schedules.test.mjs) ---
 
-test("a valid cron trigger normalizes; omitted provider/model/maxTurns pass through absent", () => {
+test("a valid cron trigger normalizes; omitted provider/model/maxTurns/github pass through absent", () => {
 	const [t] = parse([CRON]);
 	assert.deepEqual(t.on, { type: "cron", id: "nightly-tidy", pattern: "0 3 * * *" });
-	assert.deepEqual(t.run, { kind: "local", folder: "/proj", flow: "tidy", task: "run the tidy pass", provider: undefined, model: undefined, maxTurns: undefined });
+	assert.deepEqual(t.run, { kind: "local", folder: "/proj", flow: "tidy", task: "run the tidy pass", provider: undefined, model: undefined, maxTurns: undefined, github: undefined });
 });
 
 test("cron entry-level provider/model/maxTurns pass through verbatim", () => {
@@ -94,6 +94,24 @@ test("cron id with an out-of-charset character is a config error", () => {
 
 test("duplicate cron id is a config error", () => {
 	assert.throws(() => parse([CRON, { ...CRON, run: { ...CRON.run, folder: "/other" } }]), (e) => isConfigError(e) && /duplicate/.test(e.message));
+});
+
+test("cron run.github: true survives normalization (the per-trigger token opt-in)", () => {
+	const [t] = parse([{ ...CRON, run: { ...CRON.run, github: true } }]);
+	assert.equal(t.run.github, true);
+	const [f] = parse([{ ...CRON, run: { ...CRON.run, github: false } }]);
+	assert.equal(f.run.github, false);
+});
+
+test("cron run.github absent stays absent (undefined) -- the zero-GitHub default", () => {
+	const [t] = parse([CRON]);
+	assert.equal(t.run.github, undefined);
+});
+
+test('cron run.github that is not strictly boolean ("true", 1, null) is a config error naming the trigger', () => {
+	assert.throws(() => parse([{ ...CRON, run: { ...CRON.run, github: "true" } }]), (e) => isConfigError(e) && e.message.includes("nightly-tidy"));
+	assert.throws(() => parse([{ ...CRON, run: { ...CRON.run, github: 1 } }]), (e) => isConfigError(e) && e.message.includes("nightly-tidy"));
+	assert.throws(() => parse([{ ...CRON, run: { ...CRON.run, github: null } }]), (e) => isConfigError(e) && e.message.includes("nightly-tidy"));
 });
 
 test("cron missing folder / flow / task is a config error", () => {


### PR DESCRIPTION
Closes #50.

## Gap 1 — opt-in token for local/cron jobs

Cron triggers gain an optional boolean `run.github`. Absent/false is byte-identical to today: the zero-GitHub path, no token. With `"github": true` the processor mints the same per-job token the webhook path mints (`mintToken(undefined)` — no repo arg, a local job has none) and the container gets it like any github job. Branch protection stays github-only: a local job has no `job.repo` to check, and any push a flow makes via `gh` is still governed by the remote's own protection.

Per source: `gh` and `pat` ignore the repo argument and just work. `app` refuses the repo-less mint with a config error — an installation token is per-repo (`CONST-TOKEN-SCOPED-PER-JOB`) and minting broad instead would betray exactly the property that path exists for. The validator refuses non-boolean values at load, so a `"true"` string can't silently opt a trigger into a credential.

## Gap 2 — source:gh scope breadth, stated instead of implied

No hard refusal (source `gh` is the deliberate default, per OQ-006, and plenty of dev logins carry `workflow`) — but the trade-off is now stated everywhere it matters:

- `doctor` warns when the source resolves to `gh`, parsing `gh auth status` and naming the actual scopes, with `admin:org` / `delete_repo` / `workflow` called out explicitly.
- `specs/interfaces.md` documents next to the `CONST-TOKEN-SCOPED-PER-JOB` citations that per-job *scoping* is the App path's property; `gh` hands the operator-scoped credential to every token-carrying job.
- `get-token.mjs`'s header no longer lets the scoping claim cover a path it doesn't; SECURITY.md and `.env.example` carry the operator-facing version.

## Gap 3 — GH_TOKEN precedence + in-image preflight

- `PI_FORWARD_ENV` refuses `GITHUB_TOKEN` and `GH_TOKEN` at config load (boot-time, fail-loud — not per-job).
- `buildContainerEnv` mirrors the mint into both `GITHUB_TOKEN` and `GH_TOKEN`; gh prefers the latter, so mirroring forecloses the precedence surprise structurally, and the assignment sits after the forward loop so a forwarded name can never win.
- `doctor` preflights `gh auth status` *inside* the job image (`docker run --rm -e GH_TOKEN -e GITHUB_TOKEN --entrypoint gh <image> auth status` — value-less `-e` flags, token via the spawn env, never argv), gated on docker + image being green, warn-only, 30s timeout.

## Acceptance (from the issue)

- [x] A cron trigger with `run.github` enabled can run `gh` against its repo with a per-job token
- [x] Without it, no token is present (today's behavior — unflagged schedules stay byte-identical)
- [x] `doctor` warns about the scope breadth of `source: "gh"`, naming the scopes
- [x] `doctor` verifies `gh` authenticates inside the image
- [x] `GH_TOKEN` cannot silently override the minted `GITHUB_TOKEN` (refused in the allowlist + mirrored assignment after the forward loop)
- [x] No `gh` config file is ever mounted into a job container

22 new tests across triggers/schedules/processor/get-token/config/env-allowlist/doctor; full suite green (806 pass, 15 Valkey-gated skips). Verified the doctor checks live against a real `gh` login — the scope warning names the token's actual scopes and flags `workflow`.

Follow-ups deliberately left out: an admin-panel field for `run.github`, an optional `run.repo` for the `app` source, `github` inheritance for outbox-chained children, and a broader `PI_FORWARD_ENV` denylist of worker-managed names.
