### PR TITLE
docs: version the image URLs so the updated banner reaches readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/images/banner.png" alt="pi-dispatch — run the pi coding agent as a self-hosted service" width="880">
+  <img src="docs/images/banner.png?v=0.3.0" alt="pi-dispatch — run the pi coding agent as a self-hosted service" width="880">
 </p>
 
 # pi-dispatch
@@ -8,9 +8,9 @@
 cron schedule, or by a GitHub or GitLab issue, comment or pull/merge request — in a container you control, with a durable queue, a
 spend cap, and a live admin panel.**
 
-![The /dispatch dashboard overlay — theme-colored: live queue state, day/week/month spend meters + a daily token counter, the unified triggers pane (cron, label, comment, pull_request — selectable and editable), and the interactive runs list, in one framed TUI](docs/images/dispatch-dashboard.svg)
+![The /dispatch dashboard overlay — theme-colored: live queue state, day/week/month spend meters + a daily token counter, the unified triggers pane (cron, label, comment, pull_request — selectable and editable), and the interactive runs list, in one framed TUI](docs/images/dispatch-dashboard.svg?v=0.3.0)
 
-![Transcript of /dispatch status, runs, and triggers — queue counts, the run-history table with per-job token and cost accounting, and the unified {on,run} triggers list](docs/images/dispatch-commands.svg)
+![Transcript of /dispatch status, runs, and triggers — queue counts, the run-history table with per-job token and cost accounting, and the unified {on,run} triggers list](docs/images/dispatch-commands.svg?v=0.3.0)
 
 pi has no job queue, no concurrency control, no spend limit, and — by its own README — no permission
 system. **pi-dispatch is exactly that missing operational layer, and nothing else.**

--- a/admin/README.md
+++ b/admin/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/banner.png" alt="pi-dispatch — run the pi coding agent as a self-hosted service" width="880">
+  <img src="https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/banner.png?v=0.3.0" alt="pi-dispatch — run the pi coding agent as a self-hosted service" width="880">
 </p>
 
 # pi-dispatch — run the pi coding agent as a self-hosted service
@@ -40,7 +40,7 @@ Every trigger produces the same job, through the same path — one queue, one co
 This extension puts a live TUI over the whole deployment in one command:
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/dispatch-dashboard.png" alt="The /dispatch panel: status, spend meters, triggers, runs, and settings" width="820">
+  <img src="https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/dispatch-dashboard.png?v=0.3.0" alt="The /dispatch panel: status, spend meters, triggers, runs, and settings" width="820">
 </p>
 
 - **Status & spend.** Queue and worker state, day/week/month **spend meters** + a daily token counter, and a run-history table with per-job token & cost.

--- a/admin/package.json
+++ b/admin/package.json
@@ -39,7 +39,7 @@
     "skills": [
       "./skills"
     ],
-    "image": "https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/banner.png"
+    "image": "https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/banner.png?v=0.3.0"
   },
   "scripts": {
     "build": "node build.mjs",


### PR DESCRIPTION
The banner and panel mocks updated in #63 merged correctly — `raw.githubusercontent` serves the new bytes and the SVG on `main` carries the GitLab text — but the rendered README still shows the old ones.

GitHub proxies README images through **camo**, which keys its cache on the URL. The file changed; the path did not. So the stale copy keeps being served, and it keeps being served **to everyone** — camo is a shared server-side cache, so a hard refresh fixes it for one reader and nobody else.

Appending `?v=0.3.0` changes the cache key. Verified that `raw.githubusercontent` serves the identical bytes with the query present, so the only thing that changes is the key.

The version is the release the images belong to rather than an arbitrary token — the next person to change an image has an obvious thing to bump and a reason to.

**Scope:** only the four images this release actually changed. `dispatch-run-detail.svg` is untouched, so versioning it would be churn that makes a later reader wonder what moved. The mention in `docs/demo.md` is prose — it names the file, it does not embed it — so it is left alone.

`admin/package.json`'s gallery image gets the same treatment, but it reaches npm only on the **next** publish: 0.1.4 is already out, and `release.yml` correctly skips a version already on npm rather than republishing.

Docs only — no code, no tests affected.