### PR TITLE
Re-open a finished run's sandbox instead of losing it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,15 @@ PI_JOB_IMAGE=pi-job:latest          # the DEFAULT job image. Any trigger may nam
 # PI_LOGS_DIR=                      # where per-job status records (and optional raw logs) land (default: OS temp /pi-dispatch/logs)
 # PI_CAPTURE_JOB_LOGS=              # default 0; set 1 to ALSO write raw container output to logs/<jobId>.log -- PII-bearing (issue/comment text), host-only (never mounted into the container), off by default (opt-in)
 # PI_LOG_RETENTION_DAYS=            # default 30; boot-time prune of logs older than N days; 0 = keep forever
+# PI_SANDBOX_DIR=                   # where a finished run's directory is kept so you can re-open it (default: <PI_JOBS_DIR>/sandboxes, mode 0700)
+#                                     `pi-dispatch sandbox <jobId>` starts a fresh container from the same image with the same workspace and NO credentials (docs/sandbox.md)
+#                                     A retained directory holds the run's clone plus its prompt.md/event.json -- so issue text. Host-only; never mounted into a job
+# PI_SANDBOX_RETENTION_HOURS=       # default 24. NOTE: 0 means OFF here -- nothing is retained and cleanup deletes as it always did
+#                                     This is the OPPOSITE of PI_LOG_RETENTION_DAYS/PI_SESSIONS_TTL_DAYS, where 0 means keep forever
+#                                     There is deliberately no keep-forever value: one repo clone per run with no ceiling is a disk bomb. Use --pin for the one run worth keeping
+# PI_SANDBOX_PIN_DAYS=              # default 7; `pi-dispatch sandbox <jobId> --pin` extends THAT run to now + this many days. Still swept afterwards
+# PI_SANDBOX_IDLE_MINUTES=          # default 30; bash's own TMOUT inside a sandbox, so a forgotten shell closes itself; 0 = no idle logout
+#                                     Honest gap: TMOUT does not tick while a foreground command runs, so a sandbox left serving an app stays up (`pi-dispatch sandbox --list` finds it)
 # PI_SESSIONS_DIR=                  # NO DEFAULT, on purpose. Where persisted agent transcripts live, so a trigger with "resume": true can continue the session that opened the PR (docs/sessions.md)
                                     # Unset = the feature is unavailable and an armed trigger refuses PRE-SPEND rather than running unpersisted and looking like it worked
                                     # A transcript is the most PII-bearing thing this system stores -- issue text, file contents, tool output, the agent's own reasoning. Mode 0700, host-only, OUTSIDE any git repo

--- a/README.md
+++ b/README.md
@@ -324,6 +324,25 @@ because that raw stream can contain issue and comment text (PII). Both files sta
 mounted into the job container, and are gitignored. A boot-time sweep prunes anything older than
 `PI_LOG_RETENTION_DAYS` (default 30; `0` keeps them forever).
 
+## Re-open a finished run
+
+The container is gone the moment a job exits, and stays gone. But the run's workspace is kept for a
+short window, so you can start a **fresh** container on it and see what the agent actually built:
+
+```bash
+pi-dispatch sandbox --list                    # what is still re-openable, and for how long
+pi-dispatch sandbox gh-12345 --publish 3000   # a shell in that run's workspace, app on 127.0.0.1:3000
+```
+
+Same image, same workspace, same isolation flags — and **no credentials**: no minted forge token, no
+provider key. The agent is not running; you are. Bring your own auth if you need to push. From the admin
+panel, press `b` on a run's detail screen.
+
+Retention is on by default for 24 hours (`PI_SANDBOX_RETENTION_HOURS`; `0` turns it off) and swept at
+worker boot. `--pin` keeps one run for `PI_SANDBOX_PIN_DAYS` (default 7) — bounded, never forever.
+A retained directory holds the run's clone **plus its issue text**, so read `docs/sandbox.md` before
+leaving it on.
+
 ## Flows: the custom prompt a trigger runs
 
 A **flow** is the recipe the agent follows — a pi **skill** committed to the target repo/folder at

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,7 +56,9 @@ Jobs are a **trigger × target** matrix, and the triggers do not share a threat 
 | A local folder's `.pi/` | **Whatever can write that folder** | No merge gate, no reviewer, no history |
 | The job image (`PI_JOB_IMAGE`, or a trigger's `run.image`) | **Operator — the same trust as baking it** | It *is* the code every job executes: the pi version, the runner and its exit codes, the guardrail floor, the loader's discovery posture and the non-root user all come from it. Nothing here verifies an image this project did not build. The isolation flags are applied by the worker's argv and hold for **any** image; the **contents** do not. |
 | The job container | **None** — it is the untrusted side | It runs the agent |
-| A job container's `/outbox` request file | **None** — agent-authored | The container's **only** signal channel back to the host; validated host-side before anything is enqueued |
+| A job container's `/outbox` request file | **None** — agent-authored | An agent-initiated signal channel back to the host; validated host-side before anything is enqueued. **Local jobs only** — a github job has no `/outbox` mount at all |
+| A job container's `/session` transcript | **None** — agent-authored | The **second** agent-initiated channel, and this row exists because the line above used to say "only". Written by the agent, read back host-side on a `completed` exit, `lstat`-checked and regular-files-only on both edges |
+| A **resurrected sandbox**'s operator shell (`pi-dispatch sandbox`) | **Operator — the same trust as a terminal on this host** | A third channel, and the first the **operator** opens rather than the agent. Not a job container: no minted token, no provider key, no agent running, started only by a keypress. It re-mounts a finished run's workspace, which for a forge job holds attacker-influenced code — the same trust shape as checking out a stranger's pull request locally. Every isolation flag still applies; ports it publishes are `127.0.0.1`-only and last only while it does |
 | Receiver, worker, queue, admin extension | Trusted | They never execute agent-authored content — the admin extension feeds only PII-free, fixed-enum run records to the model; raw container output stays in the overlay viewer |
 
 ## What is defended
@@ -83,6 +85,13 @@ Jobs are a **trigger × target** matrix, and the triggers do not share a threat 
 - **Isolation.** One ephemeral container per job: `--cap-drop=ALL`, `--security-opt no-new-privileges`,
   memory/CPU/pids limits, non-root, `--rm`. Per-job rather than per-session, so state cannot leak
   between mutually-untrusting issue authors.
+  **An operator can re-open a finished run's sandbox** (`pi-dispatch sandbox`, `docs/sandbox.md`), and
+  that does not weaken this: the *job* container is still single-use and still gone the moment it exits.
+  A sandbox is a **new** container, built from the same argv builder so it carries every flag above by
+  construction, holding **no credential of any kind**, started by an operator at a keyboard and never by
+  a trigger, an agent or a model tool. What it re-mounts is the run's workspace, retained on the host for
+  a bounded window (`PI_SANDBOX_RETENTION_HOURS`, 24h by default, `0` to disable). Its container name is
+  outside the `pi-job-*` namespace the boot reaper clears, so a worker restart cannot kill it.
 - **Credential scope.** A repo-scoped, short-lived token minted per job — a GitHub App installation
   token, or a single-owner fine-grained PAT. Its narrow scope and short expiry bound **where** and for
   **how long** an injected agent can act within that repo. See *What is NOT defended*.

--- a/admin/src/dashboard.ts
+++ b/admin/src/dashboard.ts
@@ -144,6 +144,10 @@ export function makeDashboard({
   let view = "LIST";
   let selected = 0;
   let detailRun: any = null;
+  // REQ-RESURRECTABLE-SANDBOX: whether the run opened in RUN_DETAIL still has a retained workspace, read
+  // ONCE on entry through the injected seam rather than on every tick -- the answer changes at worker boot,
+  // not per second, and this module does no I/O of its own.
+  let detailSandbox: any = null;
   let detailTrigger: any = null; // the trigger opened in TRIGGER_DETAIL (its display record + file index)
   // LIVE_TAIL state, held here in dedicated component fields keyed only by the id-only `activeJobId`. The
   // raw `.log` bytes in `tail` are PII-bearing and untrusted: they live here and reach the TUI overlay via
@@ -218,6 +222,8 @@ export function makeDashboard({
         tail,
         tailTop,
         tailAvailable: typeof deps?.tailLog === "function",
+        detailSandbox,
+        sandboxAvailable: typeof deps?.launchSandbox === "function",
       }, styler);
     },
     invalidate(): void {
@@ -226,11 +232,39 @@ export function makeDashboard({
     handleInput(data: string): void {
       if (view === "RUN_DETAIL") {
         // Escape backs out to the list only; it never closes the overlay or disposes the held clients.
-        // Every other key (including q/p/r) is inert in the detail view.
         if (matchesKey(data, "escape")) {
           view = "LIST";
+          detailSandbox = null;
           tui?.requestRender?.();
+          return;
         }
+        // `b` re-opens this run's sandbox as a shell (REQ-RESURRECTABLE-SANDBOX).
+        //
+        // Launched IN PLACE, unlike TRIGGER_DETAIL's `e`/`x`, which resolve the overlay so ctx.ui dialogs
+        // can run after it closes. This needs the opposite: the LIVE `tui`, because handing the terminal to
+        // an interactive container means suspending pi's own render loop and input handling for the
+        // duration and restoring them after. `stop()`/`start()` are pi's designed pair for exactly that --
+        // it uses them itself to launch $EDITOR -- and `requestRender(true)` forces the full redraw that
+        // an external program's output has invalidated.
+        //
+        // The spawn itself is the injected `launchSandbox`; this module holds the tui and nothing else.
+        if (data === "b" || data === "B") {
+          if (typeof deps?.launchSandbox !== "function" || !detailRun?.jobId) return;
+          if (detailSandbox && detailSandbox.retained === false) return; // nothing to open; the view says so
+          void (async () => {
+            tui?.stop?.();
+            try {
+              await deps.launchSandbox({ jobId: detailRun.jobId });
+            } catch {
+              // A failed launch must not leave the panel suspended -- the `finally` is the whole guarantee.
+            } finally {
+              tui?.start?.();
+              tui?.requestRender?.(true);
+            }
+          })();
+          return;
+        }
+        // Every other key (including q/p/r) is inert in the detail view.
         return;
       }
       if (view === "TRIGGER_DETAIL") {
@@ -300,6 +334,8 @@ export function makeDashboard({
           void refresh();
         } else {
           detailRun = row.record;
+          // One read on entry, through the seam whose fs access lives in index.ts.
+          detailSandbox = typeof deps?.sandboxInfo === "function" ? deps.sandboxInfo({ jobId: row.record?.jobId }) : null;
           view = "RUN_DETAIL";
           tui?.requestRender?.();
         }
@@ -380,7 +416,7 @@ function budgetMeters(budget: any, settings: any, width: number): string[] {
  * the same content with `box`, its inner column count driving every meter and clip.
  */
 function renderPanel(snapshot: any, width: number, state: any, styler: any): string[] {
-  const { view, selected, detailRun, detailTrigger, tailJobId, tail, tailTop, tailAvailable } = state;
+  const { view, selected, detailRun, detailTrigger, tailJobId, tail, tailTop, tailAvailable, detailSandbox, sandboxAvailable } = state;
   const framed = Number.isFinite(width) && Math.trunc(width) >= MIN_WIDTH;
   const inner = Math.trunc(width) - 4;
   const title = "pi-dispatch";
@@ -400,9 +436,10 @@ function renderPanel(snapshot: any, width: number, state: any, styler: any): str
     const detailTitle = `run ${detailRun?.jobId ?? "-"}`;
     const dw = framed ? Math.min(Math.trunc(width), DRILL_WIDTH) : Math.trunc(width);
     const allRuns = Array.isArray(snapshot?.runs) ? snapshot.runs : [];
-    const lines = renderRunDetail(detailRun, framed ? dw - 4 : 24, styler, allRuns);
-    if (!framed) return [detailTitle, "", ...lines.map((l: string) => styler.stripAnsi(l)), "", "esc back"];
-    const boxed = frame(styler, { title: detailTitle, width: dw, lines, footer: runDetailHints(dw - 4, styler) });
+    const canOpen = Boolean(sandboxAvailable && detailSandbox?.retained);
+    const lines = renderRunDetail(detailRun, framed ? dw - 4 : 24, styler, allRuns, detailSandbox);
+    if (!framed) return [detailTitle, "", ...lines.map((l: string) => styler.stripAnsi(l)), "", canOpen ? "b sandbox · esc back" : "esc back"];
+    const boxed = frame(styler, { title: detailTitle, width: dw, lines, footer: runDetailHints(dw - 4, styler, canOpen) });
     return centerBlock(boxed, Math.trunc(width), dw);
   }
 
@@ -991,7 +1028,7 @@ function renderLiveTail({ snapshot, framed, width, tailJobId, tail, tailTop, tai
  * already in the snapshot: no read, no `.log`, no `.data` -- exactly the PII-free run-history fields
  * (INT-RUN-HISTORY-FILE-CONTRACT). Every line is `inner` cols; a missing field renders `-` rather than throw.
  */
-function renderRunDetail(record: any, inner: number, styler: any, allRuns: any[] = []): string[] {
+function renderRunDetail(record: any, inner: number, styler: any, allRuns: any[] = [], sandbox: any = null): string[] {
   const r = record ?? {};
   const show = (v: any): string => (v === null || v === undefined ? "-" : String(v));
   const out: string[] = [];
@@ -1041,6 +1078,16 @@ function renderRunDetail(record: any, inner: number, styler: any, allRuns: any[]
   if (children.length > 0) chainBits.push(`spawned ${children.length} → ${children.map((c) => c.jobId).join(", ")}`);
   if (r.chainRefused) chainBits.push(`${r.chainRefused} refused`);
   out.push(kv("chain", chainBits.join(" · ")));
+
+  // REQ-RESURRECTABLE-SANDBOX. A retention state, never a path: the manifest holds a host path (which on
+  // Windows embeds the operator's account name) and this view is the one that renders beside PII-free
+  // record fields, so only the verdict crosses.
+  if (sandbox) {
+    const state = sandbox.retained
+      ? `${sandbox.running ? "running" : "retained"}${sandbox.expiresIn ? ` · ${sandbox.expiresIn} left` : ""}`
+      : (sandbox.reason ?? "swept");
+    out.push(kv("sandbox", state, sandbox.retained ? "success" : "dim"));
+  }
 
   out.push(styler.cell("", inner));
   out.push(styler.divider("post-mortem", null, inner));
@@ -1096,7 +1143,13 @@ function formatDuration(ms: number): string {
   return `${h}h ${m % 60}m`;
 }
 
-/** The RUN_DETAIL footer hint (read-only post-mortem; Esc backs out). */
-function runDetailHints(inner: number, styler: any): string {
-  return fitLine(styler.fg("accent", "esc") + " " + styler.fg("dim", "back"), inner, styler);
+/**
+ * The RUN_DETAIL footer hint. Still a read-only post-mortem, with one action: `b` re-opens this run's
+ * sandbox, offered ONLY while a retained workspace exists, so the key is never advertised where it would
+ * do nothing (`triggerDetailHints` is the shape).
+ */
+function runDetailHints(inner: number, styler: any, canOpen = false): string {
+  const k = (key: string, label: string) => styler.fg("accent", key) + " " + styler.fg("dim", label);
+  const bits = canOpen ? [k("b", "sandbox"), k("esc", "back")] : [k("esc", "back")];
+  return fitLine(bits.join(styler.fg("dim", "  ·  ")), inner, styler);
 }

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -59,6 +59,8 @@ import {
   enqueueDispatchRun,
   KNOWN_KEYS,
 } from "./read-model.mjs";
+import { buildSandboxRunArgs, launchSandbox as spawnSandbox, resolveSandbox, sandboxContainerName } from "@pi-dispatch/worker/sandbox";
+import { readManifest } from "@pi-dispatch/worker/sandbox-store";
 import { renderStatus, renderRuns, renderBudget, renderTriggers, renderSettingsView } from "./render.mjs";
 import { makeDashboard, createDashboardDeps } from "./dashboard.ts";
 import { matchesKey } from "./keys.mjs";
@@ -791,6 +793,12 @@ async function openDashboard(paths: any, ctx: any, notify: Notify): Promise<void
         ...createDashboardDeps(paths),
         // log read stays here; overlay-only, returns readLogTail's result verbatim
         tailLog: ({ jobId, lines }: { jobId: string; lines: number }) => readLogTail({ logsDir: paths.logsDir, jobId, lines }),
+        // REQ-RESURRECTABLE-SANDBOX, both seams. The fs read and the spawn live HERE for the same reason
+        // tailLog does: dashboard.ts renders and holds the tui, and touches no filesystem and no child
+        // process of its own. It brackets the launch with tui.stop()/tui.start(); this side only builds
+        // the argv and runs it attached to the terminal.
+        sandboxInfo: ({ jobId }: { jobId: string }) => readSandboxInfo(paths, jobId),
+        launchSandbox: ({ jobId }: { jobId: string }) => openSandboxSession(paths, jobId),
       },
     });
   const opts = { overlay: true, overlayOptions: { width: "75%", maxHeight: "90%", anchor: "center" } };
@@ -804,6 +812,76 @@ async function openDashboard(paths: any, ctx: any, notify: Notify): Promise<void
     if (!result || !result.action) return;
     await handleDashboardAction(result, paths, ctx);
   }
+}
+
+/**
+ * Whether this run is still re-openable, as a VERDICT rather than a path (REQ-RESURRECTABLE-SANDBOX).
+ *
+ * Synchronous on purpose: RUN_DETAIL reads it once on entry, inside a key handler, and one small
+ * `readFileSync` there is cheaper than making the overlay's state a promise. Whether a sandbox is
+ * currently running is deliberately NOT asked -- that needs docker and `pi-dispatch sandbox --list`
+ * already answers it.
+ */
+function readSandboxInfo(paths: any, jobId: string): any {
+  if (!jobId) return null;
+  if (!paths?.sandboxRetentionHours) return { retained: false, reason: "retention off" };
+  const manifest = readManifest({ sandboxDir: paths.sandboxDir, jobId });
+  if (!manifest) return { retained: false, reason: "swept" };
+  const keepUntil = Date.parse(manifest.keepUntil ?? "");
+  const createdAt = Date.parse(manifest.createdAt ?? "");
+  const until = Number.isFinite(keepUntil) ? keepUntil : createdAt + paths.sandboxRetentionHours * 3600000;
+  if (!Number.isFinite(until)) return { retained: true };
+  const hours = Math.max(0, Math.round((until - Date.now()) / 3600000));
+  return { retained: true, pinned: Number.isFinite(keepUntil), expiresIn: hours < 48 ? `${hours}h` : `${Math.round(hours / 24)}d` };
+}
+
+/**
+ * Open one run's sandbox attached to this terminal.
+ *
+ * The caller (dashboard.ts) has already suspended pi's TUI, so stdout is ours and `stdio: "inherit"` hands
+ * the terminal to the container until the operator exits. A refusal prints and returns rather than
+ * throwing: the panel is mid-suspend, and an exception here would surface as a broken screen instead of a
+ * sentence.
+ */
+async function openSandboxSession(paths: any, jobId: string): Promise<void> {
+  const resolved = resolveSandbox({
+    jobId,
+    sandboxDir: paths.sandboxDir,
+    retentionHours: paths.sandboxRetentionHours,
+  });
+  if (resolved.refused) {
+    process.stdout.write(`\ncannot open a sandbox for ${jobId}: ${resolved.message}\n`);
+    await pauseForMessage();
+    return;
+  }
+  const args = buildSandboxRunArgs({
+    image: resolved.manifest.image,
+    name: resolved.name,
+    workspace: resolved.manifest.workspace,
+    jobDir: resolved.manifest.dir,
+    term: process.env.TERM,
+    idleSeconds: (paths.sandboxIdleMinutes ?? 0) * 60,
+  });
+  process.stdout.write(`\nopening ${sandboxContainerName(jobId)} — image ${resolved.manifest.image}\n`);
+  process.stdout.write("no credentials are set in this container. exit the shell to return to the panel.\n\n");
+  const { error } = await spawnSandbox({ args });
+  if (error) {
+    process.stdout.write(`\ncould not start docker: ${error.message}\n`);
+    await pauseForMessage();
+  }
+}
+
+/**
+ * Hold the suspended terminal open long enough to read a refusal, then return.
+ *
+ * A TIMER, deliberately, and not a keypress. pi's `terminal.stop()` calls `process.stdin.pause()`, so a
+ * `stdin.once("data")` here would never fire and the panel would hang suspended forever -- waiting on
+ * input from a stream the suspend just paused. Resuming stdin to read one key would mean re-entering the
+ * input handling that the suspend exists to hand away. A fixed pause cannot deadlock, and this path is
+ * only reached when a workspace disappears between opening RUN_DETAIL and pressing the key.
+ */
+function pauseForMessage(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 2500));
 }
 
 /** Split a space-separated dialog answer into trimmed, non-empty words (label/action lists). */

--- a/admin/src/read-model.mjs
+++ b/admin/src/read-model.mjs
@@ -18,7 +18,7 @@
 import * as nodeFs from "node:fs";
 import { join, delimiter, sep } from "node:path";
 import { execFileSync } from "node:child_process";
-import { defaultLogsDir } from "@pi-dispatch/worker/config";
+import { defaultLogsDir, defaultSandboxDir } from "@pi-dispatch/worker/config";
 import { settingsFilePath, readOverlay, writeOverlay, KNOWN_KEYS } from "@pi-dispatch/worker/runtime-settings";
 import { sanitizeJobId } from "@pi-dispatch/worker/run-history";
 import { dayKey, weekKey, monthKey } from "@pi-dispatch/worker/budget";
@@ -52,6 +52,13 @@ export function resolvePaths(env = process.env) {
     // normal deployment, in which no trigger can arm any package.
     globalPiDir: env.PI_GLOBAL_PI_DIR || null,
     captureJobLogs: env.PI_CAPTURE_JOB_LOGS === "1",
+    // REQ-RESURRECTABLE-SANDBOX: where finished runs' directories are retained, and for how long. Read
+    // from env for the same reason as everything above -- never loadConfig. The `0` here means retention
+    // OFF (the panel then says so rather than offering a key that always refuses), which is the opposite
+    // of the log/session sentinels; worker/src/config.mjs carries the full reasoning.
+    sandboxDir: env.PI_SANDBOX_DIR || defaultSandboxDir(env),
+    sandboxRetentionHours: parseNonNegInt(env.PI_SANDBOX_RETENTION_HOURS, 24),
+    sandboxIdleMinutes: parseNonNegInt(env.PI_SANDBOX_IDLE_MINUTES, 30),
     // The two dispatch_run bounds the extension enforces producer-side, read DIRECTLY from env (never
     // loadConfig, which throws on unrelated GitHub-auth problems). `delimitedList`/`nonNegativeInt` are
     // private to the worker's config, so the same shapes are reimplemented here. Default roots [] fails

--- a/admin/test/dashboard.test.mjs
+++ b/admin/test/dashboard.test.mjs
@@ -703,3 +703,101 @@ test("the trust model is per forge -- an azure trigger must not claim HMAC or a 
   const github = (await renderTrigger({ type: "label", forge: "github", any: ["pi:go"], all: [], none: [], flow: "fix" })).detail;
   assert.match(github, /X-GitHub-Delivery/);
 });
+
+/** Open RUN_DETAIL on the single canned run, with sandbox seams wired as given. */
+async function openRunDetail(deps = {}, tui = fakeTui()) {
+  const comp = makeDashboard({ paths: {}, done() {}, tui, intervalMs: 100000, deps: cannedDeps(deps) });
+  await flush();
+  comp.handleInput("\r"); // row 0 is the only run
+  await flush();
+  return comp;
+}
+
+test("RUN_DETAIL shows a run's retention state, and offers `b` only when there is something to open", async () => {
+  const retained = await openRunDetail({
+    sandboxInfo: () => ({ retained: true, expiresIn: "19h" }),
+    launchSandbox: async () => {},
+  });
+  const out = stripAnsi(retained.render(80).join("\n"));
+  await retained.dispose();
+  assert.match(out, /sandbox\s+retained · 19h left/);
+  assert.match(out, /b\s+sandbox/, "the footer advertises the key");
+
+  const swept = await openRunDetail({ sandboxInfo: () => ({ retained: false, reason: "swept" }), launchSandbox: async () => {} });
+  const sweptOut = stripAnsi(swept.render(80).join("\n"));
+  await swept.dispose();
+  assert.match(sweptOut, /sandbox\s+swept/);
+  assert.equal(/b\s+sandbox/.test(sweptOut), false, "a key that would refuse is not advertised");
+});
+
+test("`b` suspends pi's TUI around the launch, and resumes it even when the launch fails", async () => {
+  // The whole contract of the handoff: docker owns the terminal only BETWEEN stop and start, and start is
+  // in a `finally` so a failed launch cannot leave the panel suspended with no way back.
+  const order = [];
+  const tui = {
+    requestRender: (force) => order.push(force ? "requestRender(true)" : "requestRender"),
+    stop: () => order.push("stop"),
+    start: () => order.push("start"),
+  };
+  const comp = await openRunDetail(
+    {
+      sandboxInfo: () => ({ retained: true }),
+      launchSandbox: async ({ jobId }) => {
+        order.push(`launch:${jobId}`);
+      },
+    },
+    tui,
+  );
+  order.length = 0; // drop the renders from opening the view
+  comp.handleInput("b");
+  await flush();
+  await comp.dispose();
+  assert.deepEqual(order, ["stop", "launch:j1", "start", "requestRender(true)"]);
+
+  const failOrder = [];
+  const failTui = {
+    requestRender: (force) => failOrder.push(force ? "requestRender(true)" : "requestRender"),
+    stop: () => failOrder.push("stop"),
+    start: () => failOrder.push("start"),
+  };
+  const failing = await openRunDetail(
+    {
+      sandboxInfo: () => ({ retained: true }),
+      launchSandbox: async () => {
+        failOrder.push("launch");
+        throw new Error("docker exploded");
+      },
+    },
+    failTui,
+  );
+  failOrder.length = 0;
+  failing.handleInput("b");
+  await flush();
+  await failing.dispose();
+  assert.deepEqual(failOrder, ["stop", "launch", "start", "requestRender(true)"], "the finally is the whole guarantee");
+});
+
+test("`b` is inert without the seam, and inert on a swept run -- it never suspends the panel for nothing", async () => {
+  for (const [deps, why] of [
+    [{ sandboxInfo: () => ({ retained: true }) }, "an unwired build has no launchSandbox"],
+    [{ sandboxInfo: () => ({ retained: false, reason: "swept" }), launchSandbox: async () => {} }, "there is nothing retained to open"],
+  ]) {
+    const order = [];
+    const tui = { requestRender() {}, stop: () => order.push("stop"), start: () => order.push("start") };
+    const comp = await openRunDetail(deps, tui);
+    comp.handleInput("b");
+    await flush();
+    await comp.dispose();
+    assert.deepEqual(order, [], why);
+  }
+});
+
+test("escape still backs out of RUN_DETAIL and drops the sandbox state it read on entry", async () => {
+  const comp = await openRunDetail({ sandboxInfo: () => ({ retained: true, expiresIn: "19h" }), launchSandbox: async () => {} });
+  assert.match(stripAnsi(comp.render(80).join("\n")), /sandbox\s+retained/);
+  comp.handleInput("\x1b");
+  await flush();
+  const out = stripAnsi(comp.render(80).join("\n"));
+  await comp.dispose();
+  assert.match(out, /TRIGGERS|PAUSED/, "back on the list");
+});

--- a/admin/test/read-model.test.mjs
+++ b/admin/test/read-model.test.mjs
@@ -131,12 +131,18 @@ test("resolvePaths reads env with safe defaults and never calls loadConfig", () 
     PI_CAPTURE_JOB_LOGS: "1",
     PI_DISPATCH_RUN_ROOTS: "/root-a",
     PI_DISPATCH_RUN_PER_HOUR: "5",
+    // Pinned so the sandbox default does not drag the OS temp dir into this equality
+    // (REQ-RESURRECTABLE-SANDBOX); the defaulting itself is asserted in its own test below.
+    PI_SANDBOX_DIR: "/sbx",
   });
   assert.deepEqual(p, {
     valkeyUrl: "redis://h:1",
     logsDir: "/l",
     settingsFile: "/s.json",
     triggersPath: "/f.json",
+    sandboxDir: "/sbx",
+    sandboxRetentionHours: 24,
+    sandboxIdleMinutes: 30,
     globalPiDir: "/srv/pi-global",
     captureJobLogs: true,
     dispatchRunRoots: ["/root-a"],

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,0 +1,131 @@
+# Resurrectable sandboxes
+
+A run finishes, opens a pull request, and says it built the thing. Sometimes you want to *see* it — click
+through the page, start the app, read the file it wrote. The container that built it is already gone:
+job containers run with `--rm` and are disposed the moment they exit, and that is not going to change.
+
+So the container is not kept alive. It is made **resurrectable**.
+
+```bash
+pi-dispatch sandbox --list          # what is still re-openable, and for how long
+pi-dispatch sandbox gh-12345        # a shell in that run's workspace
+pi-dispatch sandbox gh-12345 --publish 3000
+```
+
+A fresh container starts from the **same image** with the **same workspace** and the **same isolation
+flags** — and no credentials at all. The agent is not running. You are.
+
+You can also open one from the admin panel: `/dispatch`, Enter on a finished run, then `b`. The panel
+suspends itself, hands the terminal to the shell, and comes back when you exit.
+
+## What is preserved, and what is not
+
+| | |
+|---|---|
+| The image the run used | ✅ the exact tag, from the run's own manifest |
+| `/workspace` | ✅ the clone the agent worked in, or your own folder for a local run |
+| `/job` | ✅ read-only, the run's `prompt.md`, `event.json` and materialised `pi/` |
+| Processes | ❌ nothing is still running; you start what you want |
+| Anything the run installed outside `/workspace` | ❌ that belongs in the image |
+| Credentials | ❌ **deliberately** — see below |
+
+Same image plus same workspace, fresh processes. That contract covers "run it and click through it",
+which is the case worth serving. It does not pretend to be a snapshot, because it is not one.
+
+## Setup
+
+On by default, with a 24-hour window:
+
+```bash
+PI_SANDBOX_RETENTION_HOURS=24   # 0 = OFF. Note: not "keep forever" — see below
+PI_SANDBOX_DIR=                 # default <PI_JOBS_DIR>/sandboxes, created mode 0700
+PI_SANDBOX_PIN_DAYS=7           # what --pin extends a run to
+PI_SANDBOX_IDLE_MINUTES=30      # TMOUT inside the sandbox; 0 = no idle logout
+```
+
+**The `0` sentinel is inverted here, and that is on purpose.** `PI_LOG_RETENTION_DAYS=0` and
+`PI_SESSIONS_TTL_DAYS=0` mean *keep forever*. `PI_SANDBOX_RETENTION_HOURS=0` means **off** — nothing is
+retained, and teardown deletes exactly as it did before this feature existed. There is deliberately no
+keep-forever value: one repository clone per run with no ceiling is a disk bomb. Setting it to `0` also
+sweeps what an earlier setting retained, so turning it off actually turns it off.
+
+`pi-dispatch doctor` reports how many directories are being kept and where.
+
+## Read this before you leave it on
+
+**A retained directory holds issue text.** It is the run's whole per-job directory: the clone, plus
+`prompt.md` and `event.json`, which for a forge job carry the issue or comment body verbatim. That is
+the same data class as `logs/<jobId>.log`, which is opt-in and off by default. The directory is mode
+`0700`, host-only, and never mounted into a job container — but it is on your disk for 24 hours by
+default, so put `PI_JOBS_DIR` somewhere you would put issue text.
+
+**The transcript is not kept.** If a job persisted a session (`docs/sessions.md`), its per-job copy is
+deleted *before* the directory is retained. Transcripts live under `PI_SESSIONS_DIR` and expire on
+`PI_SESSIONS_TTL_DAYS`; carrying one into a directory with a different, pin-extendable lifetime would
+quietly extend that policy.
+
+**A forge workspace can contain adversarial code.** It is whatever the run produced from an issue anyone
+could open. Opening a shell next to it is your deliberate act — the same act as checking out a stranger's
+pull request on your own machine — and the container still applies every isolation flag a job gets:
+`--cap-drop=ALL`, `--security-opt no-new-privileges`, memory/CPU/pids limits, non-root, `--rm`.
+
+## No credentials, and why
+
+A sandbox carries no `GITHUB_TOKEN`, no `GH_TOKEN`, no GitLab/Forgejo/Azure token, and no provider API
+key. The env is two variables: `TERM` and `TMOUT`.
+
+This is not a precaution that could be relaxed with a flag. A job's credential is minted for that job,
+scoped to that repository, and short-lived (`CONST-TOKEN-SCOPED-PER-JOB`); a shell you can type into is
+not a job, and handing it a harness credential would make it a different security object entirely. If
+you need to push from inside a sandbox, authenticate yourself — `gh auth login` is in the image.
+
+## Publishing a port
+
+```bash
+pi-dispatch sandbox gh-12345 --publish 3000        # host 3000 -> container 3000
+pi-dispatch sandbox gh-12345 --publish 8080:3000   # host 8080 -> container 3000
+```
+
+**Always bound to `127.0.0.1`.** An explicit bind address is refused rather than honoured — there is no
+flag that puts a container full of agent-written code on your LAN. Ports exist only while the sandbox
+does; nothing is published by a job container, ever.
+
+## How it ends
+
+Exit the shell and the container is gone (`--rm`). The workspace stays retained until its window closes.
+
+A forgotten sandbox closes itself after `PI_SANDBOX_IDLE_MINUTES` of no input, via bash's own `TMOUT`.
+**Honest gap: `TMOUT` does not tick while a foreground command is running.** A sandbox left with
+`npm run dev` in the foreground stays up until you stop it. `pi-dispatch sandbox --list` marks anything
+running so you can find it:
+
+```
+gh-12345  github   RUNNING
+gh-12002  github   19h left
+local-77  local    pinned, 6d left
+```
+
+There is no wall-clock kill. A hard timeout would end a session you were still working in, which is
+worse than a container you can see and stop.
+
+## Keeping one longer
+
+```bash
+pi-dispatch sandbox gh-12345 --pin
+```
+
+Extends *that* run to `now + PI_SANDBOX_PIN_DAYS`. A pin is a timestamp, never a boolean — it survives a
+change to the retention window, and it still expires. The pin is written before the shell opens, so a
+session that ends in a closed laptop still keeps the workspace.
+
+## Known limitations
+
+- **Linux bind-mount ownership.** A local-folder sandbox runs as the image's non-root `pi` user (uid
+  1001) against files owned by your host account, so writes may fail with `EACCES` on Linux. This is not
+  new to sandboxes — local *jobs* have the same shape — and it does not arise on Docker Desktop, which
+  maps ownership for you.
+- **Sandboxes are not reaped by the worker.** They are named `pi-sandbox-*`, outside the `pi-job-*`
+  filter the boot reaper uses, precisely so a worker restart cannot kill a shell you are sitting in. The
+  cost is that stopping a forgotten one is yours: `docker stop pi-sandbox-<jobId>`.
+- **The retention window is bounded but not quota'd.** At the default daily cap that is roughly 25
+  directories at a time. There is no byte ceiling; `doctor` reports the count.

--- a/image/verify-image.sh
+++ b/image/verify-image.sh
@@ -49,6 +49,14 @@ docker run --rm --entrypoint pi "$IMAGE_REF" -p --help >/dev/null 2>&1 \
 	|| fail "pi is not on PATH, or -p is no longer a flag. The image must carry the pinned pi (CONST-PI-VERSION-PINNED); a stale or absent pi makes jobs no-ops that still report success."
 ok "pi is present and -p is still a flag"
 
+# bash, because `pi-dispatch sandbox` re-opens a finished run with `--entrypoint bash`
+# (REQ-RESURRECTABLE-SANDBOX). An image without it fails that at exit 127 -- long after the run it is
+# meant to let you inspect, and with an error naming a flag rather than a missing shell. It is also what
+# reads TMOUT, which is the only thing that closes a forgotten sandbox.
+docker run --rm --entrypoint bash "$IMAGE_REF" -c 'exit 0' >/dev/null 2>&1 \
+	|| fail "bash is not present. \`pi-dispatch sandbox\` re-opens a run with --entrypoint bash and would fail at exit 127, and TMOUT (the sandbox idle logout) is a bash feature."
+ok "bash is present (an operator can re-open a finished run)"
+
 # The forge CLIs the job envelopes instruct the agent to use. Each is only meaningful for jobs on its own
 # forge, but a MISSING one fails the same silent way: the agent follows an envelope naming a command that
 # is not there, reports what went wrong in prose, and exits 0.

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -122,11 +122,46 @@ that always fires is one nobody reads.
   would have preserved the enumeration below untouched, and it puts the transcript inside the worktree the
   agent commits from, one `git add -A` away from a public pull request. The enumeration is amended
   instead. The residual is `OQ-014`.
+
+  **A SECOND CONTAINER SHAPE NOW EXISTS, and the existing carve-out does not cover it.** With
+  `REQ-RESURRECTABLE-SANDBOX`, `pi-dispatch sandbox <jobId>` starts a container with an interactive TTY
+  and `--entrypoint bash` on a finished run's workspace. The Statement's carve-out is about **pi running
+  on the host** — an operator's own session hosting the admin extension — and says nothing about a
+  container that is not a job container; the Acceptance below is scoped *"Given any job"* and likewise
+  does not reach it. So this is argued here rather than assumed from either.
+
+  **What is unchanged, and it is the part that matters.** The *job* container is untouched: still
+  single-use, still `--rm`, still no TTY, still no published port, still gone at exit. A sandbox is a
+  **new** container built from the same `buildDockerRunArgs`, so every isolation flag applies to it by
+  construction rather than by a promise — `--cap-drop=ALL`, `no-new-privileges`, the pids/memory/cpu
+  bounds, non-root. Its name is outside the boot reaper's `pi-job-` namespace, which is the reason a
+  worker restart cannot kill it, not an exemption granted to it. With retention off, no directory is
+  kept and teardown is the `rm -rf` it always was.
+
+  **Three of the carve-out's four tests are met; the fourth is NOT, and that is the honest part.** It is
+  not a harness invocation — no trigger, no chain request and no model tool can reach it, only an
+  operator's keypress. It is operator-present by definition: it is a shell. It holds **no harness
+  credentials** — no minted forge token, no provider key, nothing forwarded — and that is structural
+  rather than careful, since `buildContainerEnv` throws without a provider credential and so cannot
+  produce this container's env at all. But it **does** process adversarial input: a forge job's workspace
+  is whatever a run produced from an issue anyone could open. The claim is not that this is harmless. It
+  is that opening a shell next to that code, cap-dropped and resource-bounded and credential-free, is the
+  same act as checking out a stranger's pull request on your own machine — which every maintainer this
+  project is for already does, with fewer flags.
+
+  **Rejected alternatives**, all three of which would have reached this entry rather than sat beside it:
+  *keeping the job container alive to `docker exec` into* — a live container that has run adversarial
+  code, still holding the minted token, with `--rm` removed; *a stdin channel to the running agent* —
+  the operator becomes an input to a session whose prompt carries untrusted issue text; *`docker commit`
+  snapshots* — gigabytes per run to preserve what belonged in the image. `DES-SANDBOX-IS-A-FRESH-CONTAINER`
+  records them in full. What survives a run is a **directory**, not a container, and it is swept on a
+  bounded window that has no keep-forever value.
 - **Evidence (upstream)**: pi README, verbatim: *"Pi does not include a built-in permission system for
   restricting filesystem, process, network, or credential access. By default, it runs with the
   permissions of the user and process that launched it."* … *"If you need stronger boundaries,
   containerize or sandbox Pi."*
-- **Traces to**: `INT-CONTAINER-RUNTIME-CONTRACT`, `CONST-TOKEN-SCOPED-PER-JOB`, `INT-SESSION-STORE-CONTRACT`
+- **Traces to**: `INT-CONTAINER-RUNTIME-CONTRACT`, `CONST-TOKEN-SCOPED-PER-JOB`, `INT-SESSION-STORE-CONTRACT`,
+  `INT-SANDBOX-CONTRACT`, `DES-SANDBOX-IS-A-FRESH-CONTAINER`
 - **Acceptance**: Given any job, the agent has no filesystem path to the host outside the declared mounts
   in `INT-CONTAINER-RUNTIME-CONTRACT` — `/job:ro`, `/workspace:rw`, `/outbox:rw` (local only),
   `/opt/pi-global:ro` (the operator global overlay, only when configured; `REQ-GLOBAL-PI-OVERLAY`), and
@@ -140,6 +175,12 @@ that always fires is one nobody reads.
   run. Given a fork pull request, no key resolves, no `/session` mount is created, and the docker argv is
   byte-identical to a job run before this feature existed. Given a trigger that did not arm `run.resume`,
   the same, and nothing is written to disk.
+  **Given a resurrected sandbox** (`INT-SANDBOX-CONTRACT`) — which is not a job, and so is asserted
+  separately rather than folded into the enumeration above: its argv carries every member of
+  `ISOLATION_FLAGS`, its env contains no minted forge token and no provider key, its name contains no
+  `pi-job-`, and no trigger, chain request or model tool can start one. Given
+  `PI_SANDBOX_RETENTION_HOURS=0`, no directory outlives a run and every job's argv and teardown are
+  byte-identical to one from before that feature existed.
 
 ## CONST-NO-CONTEXT-FILES-MANDATORY
 
@@ -581,6 +622,7 @@ that always fires is one nobody reads.
 
 | Date | Change |
 |---|---|
+| 2026-08-01 | `CONST-ISOLATION-CONTAINER-PER-JOB` **AMENDED** for `REQ-RESURRECTABLE-SANDBOX` (issue #55): a second container shape now exists — an operator-started interactive shell on a finished run's workspace. Written into this entry rather than somewhere quieter, for the reason the 2026-07-31 row gives about mounts: the Statement's carve-out covers **pi running on the host** and the Acceptance is scoped *"Given any job"*, so neither reaches a container that is not a job container and the case could not be borrowed from either. The job container is **UNCHANGED and was verified rather than asserted** — `--rm`, no TTY, no port, gone at exit; a sandbox is a NEW container built from the same `buildDockerRunArgs`, so the isolation flags apply by construction, and its name sits outside the boot reaper's namespace rather than being exempted from it. **Three of the carve-out's four tests are met and the fourth is explicitly NOT**: not harness-invoked, operator-present, no harness credentials (structural — `buildContainerEnv` throws without a provider key and so cannot produce this env), but it **does** process adversarial input, since a forge workspace is whatever a run made of an issue anyone could open. That is recorded as the accepted trade rather than argued away: the act is the one every maintainer already performs when they check out a stranger's pull request, here with cap-drop, resource bounds and no credentials. Acceptance extended with a `Given a resurrected sandbox` clause kept **separate** from the mount enumeration, because a sandbox is not a job and folding it in would have quietly widened a sentence that means something precise. `CONST-TOKEN-SCOPED-PER-JOB` **UNCHANGED, and checked** — a sandbox mints nothing and carries nothing, so the scoping rule has no new case to cover. |
 | 2026-07-15 | Initial. Extracted from `DESIGN.md` v0.1 (2026-07-14, local, uncommitted). That document recorded "50 claims adversarially verified: 48 confirmed, 2 refuted" — but verified **against documentation**. Source-verification at `earendil-works/pi @ 5e336cf` subsequently corrected ~7 points, two of them architecture-breaking. Hence the evidence convention above: source is authoritative, docs are a hint. |
 | 2026-07-15 | `CONST-NO-CONTEXT-FILES-MANDATORY` amended: it named only the CLI flag (`-nc`), but the runner uses the **SDK**, where the mechanism is `noContextFiles: true` on a caller-constructed `DefaultResourceLoader` — and it is **off by default**. The constraint therefore fails **open by omission**: there is no flag to forget, there is an entire object to forget to build. Statement and Evidence corrected; Acceptance unchanged (it was right; the named mechanism was wrong). This is the distinction the evidence convention exists to catch — the *requirement* was verified, the *mechanism* was assumed. |
 | 2026-07-17 | `CONST-TOKEN-SCOPED-PER-JOB` amended: Statement, Why, and Acceptance rewritten from a single-mechanism mandate (App installation token with one fixed expiry duration) to mechanism-neutral **required properties** — repo-scoped, minimally-permissioned, short-lived, host-held, env-injected, not merge-capable in practice. The App path satisfies them and stays **mandatory for multi-tenant**; a tightly-scoped short-expiry **fine-grained** PAT satisfies them for **single-owner**; a broad or long-lived classic PAT is excluded. The bound is the token's **expiry**, not a fixed duration — no acceptance clause mandates one. Provider-key exception preserved unchanged. |

--- a/specs/design.md
+++ b/specs/design.md
@@ -1234,6 +1234,46 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
 - **Traces to**: `REQ-RESUMABLE-SESSION`, `INT-SESSION-STORE-CONTRACT`, `DES-RUN-HISTORY-FLAT-FILES-NO-DB`;
   implemented in `worker/src/session-key.mjs`.
 
+## DES-SANDBOX-IS-A-FRESH-CONTAINER
+
+- **Decision**: To let an operator inspect what a run built, **retain the run's inputs and start a new
+  container**, rather than preserving the original one in any form. The job container stays single-use,
+  `--rm`, TTY-less and port-less; `pi-dispatch sandbox <jobId>` launches a second, differently-named
+  container from the same image with the same mounts and no credentials
+  (`REQ-RESURRECTABLE-SANDBOX`, `INT-SANDBOX-CONTRACT`).
+- **Why**: The thing an operator actually wants is *the app running against the files the agent wrote*.
+  That needs the image and the workspace — both of which already exist and are already cheap to keep. It
+  does not need the original process tree, and every design that tries to keep one trades away a property
+  the whole security model rests on. Framing it as "make it reproducible" rather than "make it survive"
+  is what keeps the change confined to how long a directory lives.
+- **Rejected**:
+  - *Keep the job container alive and `docker exec` into it.* A job container with an open operator
+    channel is a different security object from the one every isolation flag was chosen for: it is alive
+    while adversarial code has run in it, it still holds the minted forge token and the provider key in
+    its environment, and `--rm` — the flag that makes leakage between mutually-untrusting issue authors
+    structurally impossible rather than merely unlikely — has to go. The convenience is real and it is
+    not worth reopening `CONST-ISOLATION-CONTAINER-PER-JOB` for.
+  - *A stdin channel to the running agent.* Same objection plus a worse one: it makes the operator an
+    input to a session whose prompt already carries untrusted issue text, so the two trust classes meet
+    inside a running agent rather than at a boundary.
+  - *`docker commit` the container at exit.* This preserves strictly more — installed packages, process
+    residue — and costs gigabytes per run to do it. It serves a 5% case that image+workspace already
+    serves, and the extra it preserves is mostly the part that should have been in the image. The honest
+    version of the contract ("same image, same workspace, fresh processes") is the one that stays cheap.
+  - *Publish a port on job containers, gated by config.* An always-available network surface on the
+    untrusted side, live for every run, to serve the runs an operator is watching. The publish flag
+    exists only on an operator-started sandbox and only while it is up, bound to `127.0.0.1`.
+  - *Exempt `pi-sandbox-*` from the boot reaper by editing its filter.* The reaper's `name=pi-job-`
+    filter is a substring match, so a **separate namespace** already achieves this with no change to the
+    reaper at all. Editing the filter would put the guarantee in the reaper's code; keeping the names
+    disjoint puts it in the names, where a test can pin it.
+  - *Widen `makeLogReaper` to sweep retained directories too.* Its `.log`/`.json` filter and `logsDir`
+    scope are a documented contract, and these directories have a different retention policy, a
+    different PII class, and one requirement neither sibling has — asking docker what is live before
+    deleting. `session-store.mjs`'s `reapSessions` already set this precedent for the same reasons.
+- **Traces to**: `REQ-RESURRECTABLE-SANDBOX`, `CONST-ISOLATION-CONTAINER-PER-JOB`,
+  `CONST-TOKEN-SCOPED-PER-JOB`, `INT-SANDBOX-CONTRACT`, `DES-RUN-HISTORY-FLAT-FILES-NO-DB`
+
 ## Rejected alternatives (whole-project)
 
 Considered and declined. Recorded so they are not re-proposed.
@@ -1305,6 +1345,7 @@ a tunnel.
 
 | Date | Change |
 |---|---|
+| 2026-08-01 | Added **`DES-SANDBOX-IS-A-FRESH-CONTAINER`** (issue #55, `REQ-RESURRECTABLE-SANDBOX`): to let an operator inspect what a run built, retain the run's inputs and start a **new** container, never preserve the original. Six rejected alternatives recorded, and the first three are the ones that would otherwise be re-proposed — keeping the job container alive for `docker exec`, a stdin channel to the running agent, and `docker commit` snapshots. The first two reopen `CONST-ISOLATION-CONTAINER-PER-JOB` (a live container that has run adversarial code, still holding the minted token, with `--rm` removed); the third costs gigabytes per run to preserve mostly what belonged in the image. The other three are the smaller near-misses that each looked cheaper than the shipped answer and were not: publishing a port on job containers, editing the boot reaper's filter instead of using a disjoint name namespace, and widening `makeLogReaper` instead of adding a sibling. `DES-RUN-HISTORY-FLAT-FILES-NO-DB` **UNCHANGED, and checked** — the sandbox lookup is a filename-keyed read of one directory, adding no index and no query surface. |
 | 2026-07-28 | **The pi-normal discovery posture** (`CONST-NO-CONTEXT-FILES-MANDATORY`, amended). `DES-OPERATOR-GLOBAL-OVERLAY`: overlay extensions are staged and loaded **by default** — `--no-extensions` is the escape hatch, every staged extension is **printed by name**, and `PI_GLOBAL_ALLOW_EXTENSIONS` survives inverted as the `"0"` opt-out — and staged packages load for every job except one whose trigger set `run.packages: false`. The "gated four times, not two" framing is restated honestly as **three gates that refuse by default** (exact pin, all-or-nothing host stage, runner pre-spend path check) **plus one withdrawal**, since the per-trigger switch now defaults open. The *Rejected* entry "load overlay extensions by default" is **superseded rather than deleted**: it is rewritten in place to record that this is what shipped first, that the arming flag sat behind two gates the operator had already passed, and that its failure mode was silent in the expensive direction — a present-but-dormant overlay is a deployment quietly missing the setup its flows were written against. The "copy `~/.pi` wholesale" rejection lost its stale justification (it argued host-global discovery was off anyway) and now rests on the curated-subset argument, which is the one that was always doing the work. Two cross-references de-staled elsewhere in the file: `DES-PERSONA-VIA-APPEND-SYSTEM-MD`'s *Rejected* `AGENTS.md` bullet said **"forbidden"** and now records that it loads but is rejected as the *persona channel* on **placement** (pi emits context files into `<project_context>` after the append block, so it can never be the floor); and `DES-AI-TRIGGER-FLOW-GATE`'s trust-doctrine parenthetical, which cited the constraint as "a cloned repo's `AGENTS.md` … must not load", now cites it as amended — the doctrine it was actually appealing to, reading committed content at a **fixed SHA** rather than the live tree, is unchanged. `DES-USAGE-METER-VIA-API-PROVIDER-REGISTRY` was **checked and needed no change**: it asserts nothing about the discovery flags. |
 | 2026-07-15 | Initial. Extracted from `DESIGN.md` v0.1 (2026-07-14, local, uncommitted) §2, §3, §4, §5, §9, §11. That document recorded "50 claims adversarially verified: 48 confirmed, 2 refuted" — **verified against documentation**. Source-verification at `earendil-works/pi @ 5e336cf` subsequently corrected ~7 points. `DES-PERSONA-VIA-APPEND-SYSTEM-MD` is materially rewritten: the source doc's decisions #1 and #2 were mutually exclusive as written. `DES-NAME-KEEP-PI-DISPATCH` is new. `pi-harness` and `pi-sentry` were absent from the source doc's alternatives and are added. §5.7's "caches roll at midnight" caveat is **dropped** — 0.80.7 removed the date from the default system prompt. |
 | 2026-07-15 | An admin panel and cross-platform (Windows/macOS/Linux + Docker) added to scope. Two new decisions and one **security correction**. `DES-PANEL-SEPARATE-FROM-RECEIVER`: the source doc mounted Bull Board on the receiver — defensible for a read-only dashboard, **not** once the same surface sets the model and rewrites flows, because the receiver is the one process that must be internet-reachable. The panel and the receiver have opposite reachability requirements and cannot share a port. `DES-FLOWS-ARE-DATA-PERSONA-IS-CODE`: the panel requirement collided with keeping flows as reviewed repo markdown; resolved by observing that one file was carrying two jobs — hard rules need immutability, task recipes need editability. Architecture diagram and repo layout updated; the public edge is now drawn explicitly. Build order extended with panel and deploy. |

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -878,6 +878,78 @@ Evidence convention as in `constitution.md`.
   `run.image` naming an image absent from the host, `docker run` is never reached: the pre-spend inspect
   refuses first and `--pull=never` forecloses the fetch.
 
+## INT-SANDBOX-CONTRACT
+
+**operator → docker daemon.** A SIBLING of `INT-CONTAINER-RUNTIME-CONTRACT`, never an amendment to it.
+That contract governs the container the harness launches against untrusted input and says **"No TTY
+(`-it` absent)"**; this one governs a container an operator launches with no agent in it. IDs are
+permanent addresses, and the repo has made this call once already — `INT-GITLAB-PAYLOAD-SUBSET` is a
+sibling rather than an extension of the GitHub one for the same reason.
+
+- **Contract**:
+  - **The argv is built by the SAME builder.** `buildSandboxRunArgs` calls `buildDockerRunArgs` through
+    its `extraFlags` seam, so `ISOLATION_FLAGS`, `--memory` and `--cpus` reach this container **by
+    construction**: `--pull=never --rm --init --cap-drop=ALL --security-opt no-new-privileges
+    --pids-limit=512 --shm-size=1g --memory=4g --cpus=2`. This is the load-bearing sentence of the whole
+    contract. A leaner hand-written argv here would be a second place for the boundary to live, and the
+    copy that did not get the next flag would be the one nobody was looking at.
+  - **Adds exactly**: `-i -t --entrypoint bash`, and `-p 127.0.0.1:<host>:<container>` per `--publish`.
+  - **Mounts**: the retained per-job directory at `/job:ro` and its workspace at `/workspace:rw` — the
+    same two the run itself had, from the same paths. **No `/outbox`** (nothing to chain: no agent),
+    **no `/session`** (the transcript is deleted before retention), **no `/opt/pi-global`** (pi is not
+    running).
+  - **Env is exactly `TERM` and `TMOUT`.** No minted forge token under any forge's variable names, no
+    provider key, no `PI_FORWARD_ENV` pass-through, none of the `PI_*` job variables. `buildContainerEnv`
+    is NOT reused and cannot be: it writes the mint (`env-allowlist.mjs`) and throws when no provider
+    credential resolves, so it has no credential-free output to produce.
+  - **Name**: `pi-sandbox-<sanitizeJobId(jobId)>`. Docker matches `--filter name=` as a **substring**, and
+    the boot reaper filters `name=pi-job-`; `pi-sandbox-` shares no substring with it, which is the whole
+    reason a worker restart cannot `docker rm -f` a shell an operator is sitting in.
+  - **Retained directory layout**, under `PI_SANDBOX_DIR` (default `<PI_JOBS_DIR>/sandboxes`, mode `0700`):
+    ```
+    <sandboxDir>/<sanitizeJobId(jobId)>/
+      manifest.json          mode 0600
+      prompt.md  event.json  pi/     the run's /job inputs, mounted :ro
+      workspace/                     forge jobs only; a local job's workspace is the operator's folder
+    ```
+    ```jsonc
+    { "jobId": "gh-12345", "kind": "github", "image": "pi-job:latest",
+      "workspace": "/abs/host/path", "createdAt": "2026-08-01T10:00:00.000Z", "keepUntil": null }
+    ```
+    `image` is resolved through `resolveJobImage` — the same function the pre-spend preflight and
+    `run-container.mjs` use — so the tag that was checked, the tag that ran and the tag re-opened are one
+    answer rather than three call sites that agree by luck. `workspace` is rebased onto the retained
+    directory when the run's workspace lived inside it, and recorded verbatim when it did not; decided by
+    path containment, never by `kind`, so a preparer that moves its clone cannot record a path that does
+    not exist.
+  - **NOT the run-history record.** `INT-RUN-HISTORY-FILE-CONTRACT` is PII-free by construction, and that
+    property is what lets the admin extension feed those records to a model. This manifest holds a host
+    path — which on Windows embeds the operator's account name — so it is a separate file that never goes
+    near a prompt. The panel renders the retention *verdict*, never the path.
+  - **Retention**: `createdAt + PI_SANDBOX_RETENTION_HOURS`, or `keepUntil` when pinned. Swept at worker
+    boot. `0` = OFF: nothing retained, and the sweep's cutoff becomes `now`, so it also clears what an
+    earlier setting kept. There is no keep-forever value.
+  - **Age comes from `createdAt`, never mtime.** `makeLogReaper` calls mtime "the authority" and is right
+    about an append-once log file. An operator working inside a resurrected sandbox writes into the
+    directory, so mtime would keep moving and the window would never close — for exactly the directories
+    most likely to be large.
+  - **The sweep asks docker first.** `listRunningSandboxes` yields the job ids of live sandboxes and
+    **throws** when docker cannot be reached, because "none are running" and "I could not find out" must
+    not arrive as the same empty array in front of a `rm -rf`. A failed lookup skips the whole sweep.
+- **Why**: The 5% case (`REQ-RESURRECTABLE-SANDBOX`). Every choice above exists to keep the *job*
+  contract untouched while serving it: a second container shape rather than a longer-lived first one, a
+  second env builder rather than a credential-optional one, a second name namespace rather than a
+  reaper exemption, and a second reaper rather than a widened log sweep.
+- **Traces to**: `REQ-RESURRECTABLE-SANDBOX`, `CONST-ISOLATION-CONTAINER-PER-JOB`,
+  `CONST-TOKEN-SCOPED-PER-JOB`, `INT-CONTAINER-RUNTIME-CONTRACT`, `INT-SESSION-STORE-CONTRACT`,
+  `DES-SANDBOX-IS-A-FRESH-CONTAINER`
+- **Acceptance**: The sandbox argv contains every member of `ISOLATION_FLAGS` (asserted against the
+  imported array, not a copy), contains `-i`, `-t` and `--entrypoint bash`, ends with the image, and
+  contains no member of `MINTED_TOKEN_VARS` and no provider key variable. The container name contains no
+  `pi-job-`. `--publish 3000` yields `127.0.0.1:3000:3000` and an explicit bind address is refused. A
+  retained directory contains no `session/`. A directory whose sandbox is running is not swept, and a
+  sweep whose docker lookup failed removes nothing.
+
 ## INT-WEBHOOK-PAYLOAD-SUBSET
 
 **GitHub → receiver.** *(GitLab's is a separate contract — `INT-GITLAB-PAYLOAD-SUBSET`. This ID keeps
@@ -1633,6 +1705,7 @@ worker reads.
 
 | Date | Change |
 |---|---|
+| 2026-08-01 | Added **`INT-SANDBOX-CONTRACT`** (issue #55, `REQ-RESURRECTABLE-SANDBOX`) — the operator-session container shape, plus the retained-directory layout and its manifest. **A SIBLING of `INT-CONTAINER-RUNTIME-CONTRACT`, not an amendment to it**, and the reasoning is the same one `INT-GITLAB-PAYLOAD-SUBSET` recorded: IDs are permanent addresses, and a container an operator opens with no agent in it is a different object, not more of the job one. That entry is **UNCHANGED, and was checked rather than forgotten** — its `No TTY (-it absent)` line still describes every container the harness launches, which is precisely why the new shape needed its own address instead of a qualifier on that one. Three decisions written down because a later reader would otherwise re-litigate them: the sandbox argv comes from `buildDockerRunArgs` through the previously-unused `extraFlags` seam, so the isolation flags are inherited **by construction** rather than re-listed; the retained-directory manifest is a **separate file from the run-history sidecar**, because `INT-RUN-HISTORY-FILE-CONTRACT`'s PII-free-by-construction property is what lets the admin extension feed those records to a model and this one holds a host path (that entry likewise **UNCHANGED and checked**); and expiry reads the manifest's `createdAt` rather than mtime, inverting `makeLogReaper`'s documented "mtime is the authority" for the one case where it fails — an operator working inside a sandbox moves mtime, so the window would never close. `INT-SESSION-STORE-CONTRACT` **UNCHANGED, and checked**: the per-job `/session` copy is deleted **before** retention, so no transcript ever enters a directory whose lifetime `--pin` can extend. |
 | 2026-07-28 | **The pi-normal discovery posture** (`CONST-NO-CONTEXT-FILES-MANDATORY`, amended in the same change). **INT-SDK-SESSION-OPTIONS**: the contract block showed all three suppression flags `true` and was two flags and two options behind the runner — it now mirrors the shipped loader (`noContextFiles: false`, `noExtensions: false`, `noSkills: true`, the `settingsManager`, `extensionsOverride`, and the `outboxProtocol` entry in `appendSystemPromptOverride` that a local job's `/outbox` mount adds). Trap **(c)** rewritten from "`noContextFiles: true` is the SDK equivalent of `-nc`, and it is OFF BY DEFAULT" to the amended posture, keeping the point that the value is written out **because** it is the decision on the record, and naming the inverted trap it leaves (the loader is not forgiving elsewhere). Trap **(f)** rewritten and this is the correction worth reading twice: it said "Project trust is never granted, and is not needed", which conflated *we never call `resolveProjectTrust`* (true) with *the project is untrusted* (false — `SettingsManager.fromStorage` takes `options.projectTrusted ?? true` and `inMemory` forwards no options). The distinction was **inert** while both discovery flags were `true` and is now **load-bearing**: that default is exactly what makes `addAutoDiscoveredResources`' `if (projectTrusted)` branch load `/workspace/.pi/extensions`, so if a future pi flips it, repo extensions stop loading **silently** — which is why the loader tests pin the outcome (the factory ran) and never the flag. Trap **(e)** flagged as MORE reachable, not historical. Two new traps: **(j)** the `extensionsOverride` recursion guard — two signals (entry-NAME pattern, and the `^dispatch_` TOOL-SURFACE check that actually catches this repo's `.pi/extensions/dispatch.ts`), applied before the loader stores the set so a dropped extension registers no tool and receives no event, with the honest limits recorded (the factory has already run; a repo's own `dispatch_*` tool is lost, logged and rename-able; a renamed re-export under other tool names is out of reach); **(k)** why `noSkills` STAYS `true` — mechanical, not caution: discovery double-registers every repo skill under `/workspace/.pi/skills` ahead of `additionalSkillPaths` and first-path-wins demotes the pinned-sha read-only mount to a collision diagnostic. Acceptance inverted to match (the `AGENTS.md` sentinel must now be **present** in `getAgentsFiles()` and **absent** from the append block), and a pinned-artifact evidence block added for the trust default and the two merge branches. **INT-CONTAINER-JOB-INPUTS**: a new bullet for what the container now reads from `/workspace` (`AGENTS.md`, `.pi/extensions`) and why neither is a `/job` input; the "why materialise" rationale re-grounded — it had claimed the checkout "for a PR-triggered job may be a fork", which `prepare-github.mjs` contradicts (always the base repo's default-branch sha, detached), so the surviving reasons are `:ro` untamperability and symlink-safety, both independent of trust. **INT-TRIGGERS-FILE-CONTRACT**: `run.packages` inverted to an **opt-OUT** (absent or `true` load; only `false` withholds), recording that the strictness which used to live in the worker's `=== true` moved to `parseTriggers`' load-time boolean validation, and that the damaging misreading flipped from a truthy `"true"` arming a trigger to a `"false"` string that looks like an opt-out and is not one. |
 | 2026-07-28 | **Corrected INT-SDK-SESSION-OPTIONS trap (g)**, which the row below stated as a flat, unconditional fact ("pi-ai is installed TWICE"). It is not unconditional — it is a property of the **install**, not of pi. The dual layout appears wherever the **worker's** dependencies are installed as well (a dev checkout, the contract-tests job), because the hoisted copy IS the worker's declared dependency, and that layout is what makes a bare specifier bind the wrong registry and meter nothing while reporting success. The **job image** installs the **runner's** dependencies only (`image/runner/package.json` declares `@earendil-works/pi-coding-agent` and `@playwright/cli`, never pi-ai), so there the nested copy is the ONLY copy and the same bare specifier does not resolve at all — `ERR_MODULE_NOT_FOUND`, not a wrong binding. The trap now leads with the invariant that holds in BOTH and is the thing worth remembering: **never reach pi-ai by bare specifier** — register through `modelRegistry.registerProvider` and let the **runtime mutation probe** decide which module object the registry actually writes to — and records that `resolvePiAiCompat` wraps **both** lookups in `tryResolve` for exactly this reason, so an unresolvable candidate is skipped rather than thrown and one implementation is correct in both environments. Found by the `image` CI job, whose pi-ai step asserted the dual layout *inside the container* and failed there while the code it was guarding was correct in both places; that step now runs `resolvePiAiCompat` inside the built image and asserts the NESTED copy is offered first with the compat surface the probe and the wrapper need, and the dual-copy fact stays pinned by `image/runner/test/pinned-api.test.mjs` in the contract-tests job, which is the environment where it is true. |
 | 2026-07-28 | Process-wide metering + operator-staged packages (issue #58). **INT-SDK-SESSION-OPTIONS**: the contract block now mirrors the shipped wiring — a HOISTED `sessionManager` so `rootSessionId` exists before the meter, the meter installed after `ModelRegistry.create` and before `createAgentSession`, a deterministic `arm()` after it (extensions register their own api providers during the call), `packagePaths` appended LAST to `additionalExtensionPaths`, and a `skillsOverride` that re-imposes protected-root skill precedence. Three new traps: **(g)** pi-ai is installed TWICE with separate module-level registries and pi-coding-agent uses the NESTED one, so a bare specifier binds the hoisted copy and meters nothing while reporting success — `import.meta.resolve` names the wrong path, and only a runtime mutation probe can decide it; **(h)** `resetApiProviders()` (what `AgentSession.reload()` calls) WIPES the registry, so registration goes through `modelRegistry.registerProvider` (which `refresh()` re-applies) plus a re-arm, and a wrapped entry is recognised by object identity because `refresh()` returns fresh objects; **(i)** skill precedence is decided by `skillsOverride`, NOT by path order — pi puts a staged package's skill paths first in `skillPaths` and `loadSkills` is first-path-wins, but the loader's declared `skillsOverride` runs on that result before anything is stored, and pi's public `loadSkillsFromDir` supplies the substitute, so `REQ-GLOBAL-PI-OVERLAY`'s "repo wins on conflict" is enforced rather than asserted. **INT-CONTAINER-RUNTIME-CONTRACT**: env gains `PI_PACKAGES` (conditional, fail-closed, `":"`-delimited container paths, omitted when empty) and `PI_OFFLINE=1` — flagged as the ONE env addition that is not opt-in, because it is a narrowing that makes pi's job-time `npm install` branch unreachable rather than merely unused; the `/opt/pi-global` sentence now names `packages/` as a fourth thing the overlay carries, and states that **the mount list itself is unchanged**. **INT-CONTAINER-JOB-INPUTS**: DELETED the `/job/pi/extensions/...` line — the materialiser only ever writes `APPEND_SYSTEM.md` and `skills/<name>/SKILL.md`, so it documented a path the worker never writes — with a note that the seam is kept deliberately (repo extensions are arbitrary merged-branch code and are not materialised), that it already yields a permanent unread `"path does not exist"` error on every job, and that this permanence is precisely why the staged-package existence check is scoped to package roots instead of surfacing pi's error list. **INT-TRIGGERS-FILE-CONTRACT**: `run.packages` (optional boolean) on all four `run` shapes with its own bullet mirroring `run.github`, and the cron byte-match acceptance extended for `packages` plus an explicit `PI_OFFLINE=1` env carve-out (same precedent as the cron `trigger:{id,pattern}` carve-out). **NEW INT-PI-PACKAGES-FILE-CONTRACT**: the `pi-packages.json` shape, the exact-version rule citing `CONST-PI-VERSION-PINNED`, the npm name charset, the `dir` sanitisation and uniqueness rule, the admin-name refusal, the `..`/absolute manifest refusal, the npm flag set with the reason for each, the staged layout, and `packages.json` as the never-throwing worker/doctor read model. The install target travels as the exec's **`cwd`**, not `--prefix`, so argv carries **no filesystem path at all** — recorded as a load-bearing safety property, because it is what makes the win32 `shell: true` (required since Node 18.20.2 refuses to spawn `npm.cmd` without one) safe: everything left in argv is a literal flag or a pre-validated `name@version`. **INT-RUNNER-EXIT-CODE-PROTOCOL**: the eight new `tokens` telemetry keys, restating that none of them feeds classification, plus a row for a process-wide breach mid-fanout (exit `2` / `token_budget`, deliberately the same row — one flag, one code). **INT-RUN-HISTORY-FILE-CONTRACT**: the widened `tokens` object, still additive and nullable-as-a-whole, noting `parseExitTokens` and `buildRecord` are unchanged and that `recordTokenSpend` now charges process-wide spend. |

--- a/specs/open-questions.md
+++ b/specs/open-questions.md
@@ -533,10 +533,41 @@ adversarial passes did.
 
 ---
 
+## OQ-016 — The admin panel suspends pi's TUI to hand the terminal to a sandbox, and that pair is verified by reading, not by running
+
+- **Status**: `WATCH`
+- **Position**: `b` on the RUN_DETAIL screen opens a run's sandbox **in place**: `tui.stop()`, spawn
+  `docker run -it` with `stdio: "inherit"`, then `tui.start()` and a forced full re-render
+  (`REQ-RESURRECTABLE-SANDBOX`). Nothing in pi's *extension* API offers this — `ExtensionUIContext` has
+  `select`/`confirm`/`input`/`notify`/`onRawInput`/`custom` and nothing else, and `execCommand` captures
+  stdout rather than inheriting it. What makes it work is that the `custom` factory hands the component
+  the real `TUI`, whose `start`/`stop` are a symmetric suspend/resume pair: `stop()` clears the render
+  timer, moves the cursor past the rendered content, restores the cursor, and calls `terminal.stop()`,
+  which disables bracketed paste and the Kitty protocol, removes listeners, pauses stdin and restores the
+  prior raw-mode state.
+- **Why it is a WATCH row and not a claim**: this is verified **against the pinned artifact by reading
+  it**, plus the strongest circumstantial evidence available — pi uses the same pair itself, for the same
+  purpose, to launch `$EDITOR` (`modes/interactive/components/extension-editor.js`), and
+  `ProcessTerminal.start`'s own comment says the dimensions refresh exists because *"SIGWINCH is lost
+  while the process is stopped"*, which is a sentence about being suspended across an external program.
+  It has **not** been run end-to-end here. `constitution.md`'s evidence rule is to verify against the
+  pinned artifact rather than HEAD; it does not claim reading is the same as running, and neither does
+  this row.
+- **What bounds it meanwhile**: the failure mode is cosmetic and recoverable, not a security or
+  correctness one — a panel that does not redraw cleanly is fixed by reopening `/dispatch`. `tui.start()`
+  sits in a `finally`, so a launch that throws still resumes the panel, and a test pins that ordering.
+  The CLI path (`pi-dispatch sandbox`) shares none of this: it owns its terminal outright.
+- **What would reopen it**: any pi upgrade that changes `TUI.start`/`TUI.stop`, `ProcessTerminal`, or
+  drops `tui` from the `custom` factory's arguments — the last of which would be a compile-time break
+  rather than a silent one. Also: the first report of a panel that does not come back cleanly on a
+  terminal we have not tried.
+- **Related risks**: `OQ-012` (a conformance list this repo cannot enforce), `OQ-004`.
+
 ## Revision History
 
 | Date | Change |
 |---|---|
+| 2026-08-01 | Added **`OQ-016`** (`WATCH`) — the admin panel's `tui.stop()` → spawn → `tui.start()` handoff for `REQ-RESURRECTABLE-SANDBOX` is verified by reading the pinned pi and by pi's own `$EDITOR` use of the same pair, **not** by having been run. Recorded rather than left implicit because the mechanism reaches past the extension API (which has no terminal handoff) into the `TUI` object the `custom` factory happens to hand over, so it is exactly the class of assumption `REQ-UPSTREAM-CONTRACT-TESTS` exists to catch — with the difference, stated in the row, that this one fails cosmetically and recoverably rather than silently. |
 | 2026-07-15 | Initial. Replaces `DESIGN.md` v0.1 §10. Collapsed from ~10 checklist items to 5 rows: source-verification at `earendil-works/pi @ 5e336cf` answered most of them. The register's value inverted in the process — from "holds ten unknowns" to "holds one known-incoming breaking change" (`OQ-005`). |
 | 2026-07-16 | `OQ-005` **retracted and re-corrected** to `WATCH — NOT IN THE PIN`. The 2026-07-15 "correction" below was itself wrong: it read `sdk.ts` at `5e336cf` (**HEAD**) to describe npm `0.80.7` (**the pin**), concluded `modelRuntime` had already landed, and declared the changelog unreliable. `ModelRuntime` does not exist in `0.80.7` — no `model-runtime` in its `dist/`, not exported from `dist/index.js`. The changelog said `[Unreleased]` and was exactly right. The runner was written against the phantom API, the image built cleanly, and every job would have died on a missing export; CI caught it on the first real container run. `constitution.md`'s evidence convention now requires verification against the **published artifact**, and `pinned-api.test.mjs` asserts `ModelRuntime` is absent so the real migration fails a test instead of a job. |
 | 2026-07-15 | ~~`OQ-005` corrected to **WATCH — PARTIALLY LANDED**~~ — **this entry was wrong; see above.** It claimed `modelRuntime` was already in `CreateAgentSessionOptions` at the pinned sha and that the changelog was not a reliable signal. Both false: the sha was HEAD, not the pin. Kept rather than deleted, because a spec that hides having been wrong teaches the next reader to trust it more than it deserves. |

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -755,6 +755,57 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   non-completed exit, the canonical transcript is unchanged. Given an armed trigger with `PI_SESSIONS_DIR`
   unset, the job is refused before a budget slot is reserved.
 
+## REQ-RESURRECTABLE-SANDBOX
+
+- **Statement**: A finished run's per-job directory shall be retained for a bounded window, and
+  `pi-dispatch sandbox <jobId>` shall start a **new** container from that run's image with that run's
+  mounts as an interactive operator shell holding **no credentials**. The job container is unchanged:
+  still `--rm`, still no TTY, still no published port. With the window at `0` nothing is retained and
+  teardown is the `rm -rf` it always was.
+- **Scope**: Every job kind. A forge job's clone travels with its directory; a local job's workspace is
+  the operator's own folder and is never moved, so only its `/job` inputs and `/outbox` are retained.
+  Available from the CLI and from the admin panel's RUN_DETAIL screen; never from a trigger, an
+  `/outbox` chain request, or a model tool.
+- **Why**: Perhaps 5% of runs end on a question the run record cannot answer — *does the thing it built
+  actually work?* Three separate facts make that unanswerable today: `--rm` disposes the container at
+  exit, stdin is `ignore` with no TTY so nothing can be typed into a live run either, and for a forge
+  job `cleanup` deletes the directory the clone lives in. The first two are load-bearing and must not
+  move; only the third is incidental. So the container is not kept alive — it is made reproducible, and
+  the *only* thing that had to change is how long its inputs survive it.
+- **What is NOT preserved, and the contract says so.** Process state and every filesystem change outside
+  `/workspace`. Same image plus same workspace, fresh processes. That covers "start the app and click
+  through it"; anything a run installed outside the workspace belongs in the image. A `docker commit`
+  snapshot would preserve more and is rejected in `DES-SANDBOX-IS-A-FRESH-CONTAINER` — gigabytes per run
+  to serve a case image+workspace already serves.
+- **No credential, and it is not a knob.** No minted forge token, no provider key, no forwarded host
+  variable; the container env is `TERM` and `TMOUT`. `buildContainerEnv` is deliberately not reused —
+  it writes the mint into that forge's variable names and throws when no provider credential resolves,
+  so a credential-free container cannot be produced from it. An operator who needs to push authenticates
+  themselves inside the shell.
+- **Bounded, and swept like every other artifact.** `PI_SANDBOX_RETENTION_HOURS` (default 24) with a
+  boot sweep, `--pin` extending ONE run to `now + PI_SANDBOX_PIN_DAYS`. A pin is a timestamp, never a
+  boolean: there is no keep-forever value, because a repository clone per run with no ceiling is
+  unbounded growth wearing a feature's clothing. `0` means the feature is OFF — the OPPOSITE of
+  `PI_LOG_RETENTION_DAYS` and `PI_SESSIONS_TTL_DAYS`, where `0` means keep forever — and it sweeps what
+  an earlier setting retained, so turning it off turns it off.
+- **The transcript is excluded by construction.** A retained directory may contain a job's `/session`
+  copy, which is the most PII-bearing artifact this system holds and belongs to `PI_SESSIONS_DIR`'s own
+  TTL (`INT-SESSION-STORE-CONTRACT`). It is deleted BEFORE the directory is retained. Carrying it along
+  would not weaken the session policy so much as end-run it, since `--pin` can extend this window and
+  cannot extend that one.
+- **Traces to**: `CONST-ISOLATION-CONTAINER-PER-JOB`, `CONST-TOKEN-SCOPED-PER-JOB`,
+  `INT-SANDBOX-CONTRACT`, `INT-CONTAINER-RUNTIME-CONTRACT`, `INT-SESSION-STORE-CONTRACT`,
+  `DES-SANDBOX-IS-A-FRESH-CONTAINER`, `OQ-016`
+- **Acceptance**: Given `PI_SANDBOX_RETENTION_HOURS=0`, a job's `docker run` argv is byte-identical to
+  one built before this feature existed and its per-job directory is deleted at teardown. Given the
+  default window, a finished run is listed by `pi-dispatch sandbox --list` and `pi-dispatch sandbox
+  <jobId>` opens a shell in its workspace; inside it, no forge token and no provider key are set, and
+  `capsh --print` shows no capabilities. Given `--publish 3000`, the port is reachable at `127.0.0.1`
+  and an explicit non-loopback bind is refused. Given a worker restart while a sandbox runs, the
+  container survives (`docker ps --filter name=pi-job-` never matches it) and its directory is not
+  swept. Given a run whose window has closed, the refusal names the window. Given a job that persisted a
+  session, no transcript exists anywhere under the retention root.
+
 ## Notes (not requirements)
 
 **Capacity and cost.** ~1.5–2.5 GB RAM per job (pi + dev server + headless Chromium) and roughly
@@ -773,6 +824,7 @@ wait-list working as designed, not a failure — see `README.md`.
 
 | Date | Change |
 |---|---|
+| 2026-08-01 | Added **`REQ-RESURRECTABLE-SANDBOX`** (issue #55): a finished run's per-job directory is retained for a bounded window and `pi-dispatch sandbox <jobId>` re-opens it as a credential-free operator shell. The job container is **UNCHANGED and was checked rather than assumed** — `--rm`, no TTY, no published port, and with `PI_SANDBOX_RETENTION_HOURS=0` the argv and the teardown are byte-identical to pre-feature. Three things went on the record because they are the ones a later reader would get wrong: retention covers **every job kind**, not just forge jobs, which is why the unit is the per-job *directory* rather than a workspace; `0` means **off** here, the inverse of `PI_LOG_RETENTION_DAYS`/`PI_SESSIONS_TTL_DAYS`, and there is deliberately no keep-forever value; and the per-job `/session` copy is **deleted before** retention, because `--pin` can extend this window and cannot extend `PI_SESSIONS_TTL_DAYS`, so carrying a transcript across would end-run that policy rather than merely weaken it. `REQ-RESUMABLE-SESSION` **UNCHANGED, and checked** — the retained directory holds no transcript, so nothing about what resumes moved. |
 | 2026-07-28 | **The pi-normal discovery posture, and operator-staged code on by default** (`CONST-NO-CONTEXT-FILES-MANDATORY` amended in the same change). `REQ-UPSTREAM-CONTRACT-TESTS`: the `AGENTS.md` bullet is **inverted** — it asserted the sentinel appears **nowhere** in the assembled prompt (`-nc` holds) and now asserts it appears in `getAgentsFiles()` and **nowhere in the append block**, because the shipped loader sets `noContextFiles: false`. Two bullets added, both pinned on **outcome** rather than on a flag: a repo `.pi/extensions` factory ran while an admin-named or `dispatch_*`-registering one is absent (project-resource discovery hangs on pi's `isProjectTrusted()` default, which would take the path down silently if it flipped), and a repo skill resolves **once** from `/job/pi/skills`. The silent failure this REQ exists for did not vanish, it **moved**, and the entry says so. `REQ-GLOBAL-PI-OVERLAY`: overlay extensions are **staged and loaded by default** — `import-pi` copies `extensions/` unless `--no-extensions` and **prints every extension it staged by name** (the vetting step is a list, not a flag), the admin extension is still hard-blocked, and `PI_GLOBAL_ALLOW_EXTENSIONS` survives only as an **opt-OUT** where unset/`""`/legacy `"1"` load, exactly `"0"` disables, and **any other value is a loud `configError` at all three enforcement points** — the strict parse is unchanged but the damaging misreading flipped, since `=false` used to degrade safely to "dormant" and would now silently mean "on". A new `Why` paragraph records the reasoning: the operator vetted the code twice (running it in `~/.pi/agent`, staging it with a printed list), so a third gate is friction, and a present-but-dormant overlay is a deployment silently missing the setup its flows were written against. `run.packages` inverted to an **opt-OUT** on all four trigger kinds (absent or `true` load; only `false` withholds), with `parseTriggers`' load-time boolean validation now the only place that strictness lives; the four-gate framing restated honestly as three gates that refuse by default plus one withdrawal, and `Scope`'s "inert until a trigger arms them" corrected. Acceptance updated throughout for both inversions. |
 | 2026-07-15 | Initial. Extracted from `DESIGN.md` v0.1 §1, §5.1–5.2, §5.6, §7, §8. `REQ-RUNNER-TURN-BUDGET` and `REQ-UPSTREAM-CONTRACT-TESTS` are **new** — both exist because source-verification refuted design assumptions the doc had marked "verify". §8's failure-mode table was the richest source; one of its rows ("verify: pi max-turns option") was wrong. |
 | 2026-07-17 | Added REQ-BRANCH-PROTECTION-PRECONDITION, formalizing the branch-protection refusal already enforced in `processor.mjs`/`github-host.mjs` (was a dangling code citation). |

--- a/worker/package.json
+++ b/worker/package.json
@@ -28,6 +28,8 @@
     "./get-token": "./src/get-token.mjs",
     "./runtime-settings": "./src/runtime-settings.mjs",
     "./run-history": "./src/run-history.mjs",
+    "./sandbox": "./src/sandbox.mjs",
+    "./sandbox-store": "./src/sandbox-store.mjs",
     "./budget": "./src/budget.mjs",
     "./scheduler-stall-guard": "./src/scheduler-stall-guard.mjs"
   },

--- a/worker/src/cli.mjs
+++ b/worker/src/cli.mjs
@@ -16,6 +16,12 @@ const USAGE = `pi-dispatch — run pi coding-agent flows on your own folders
 
   pi-dispatch run <folder> --task "<what to do>" [--flow <name>]
                            [--provider <p>] [--model <m>] [--max-turns <n>] [--image <ref>] [--force]
+  pi-dispatch sandbox <jobId>
+                           re-open a finished run's sandbox as a shell — same image, same workspace,
+                           no credentials  [--publish <port>[:<containerPort>]] [--pin]
+  pi-dispatch sandbox --list
+                           what is still re-openable, for how long, and what is running now
+
   pi-dispatch worker       drain the queue (run this in another terminal, or as a service)
   pi-dispatch pause        stop taking new jobs (durable; survives worker restart)
   pi-dispatch resume       resume taking jobs
@@ -39,6 +45,11 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
 	if (cmd === "import-pi") {
 		const { runImportPi } = await import("./import-pi.mjs");
 		return runImportPi(argv.slice(1), { env });
+	}
+
+	if (cmd === "sandbox") {
+		const { runSandbox } = await import("./sandbox-cli.mjs");
+		return runSandbox(argv.slice(1), { env });
 	}
 
 	if (cmd === "worker") {

--- a/worker/src/config.mjs
+++ b/worker/src/config.mjs
@@ -164,6 +164,16 @@ export function loadConfig(env = process.env, { fileExists = existsSync } = {}) 
 		forwardEnv: forwardEnvList(env.PI_FORWARD_ENV), // extra host var NAMES to forward (e.g. a custom provider's key); explicit allowlist, GitHub token names refused
 		authFromPi: env.PI_AUTH_FROM_PI !== "0", // ON by default: use the key in ~/.pi/agent/auth.json when the env has none (api-key only). PI_AUTH_FROM_PI=0 forces env-only.
 		jobsDir: env.PI_JOBS_DIR ?? defaultJobsDir(),
+		// REQ-RESURRECTABLE-SANDBOX. `||` (not `??`) so an empty string falls back, matching logsDir.
+		sandboxDir: env.PI_SANDBOX_DIR || defaultSandboxDir(env),
+		// Hours a finished run's directory stays re-openable. NOTE THE SENTINEL, which is the OPPOSITE of
+		// logRetentionDays' and sessionsTtlDays': 0 means the feature is OFF (nothing is retained, cleanup
+		// is the `rm` it always was), NOT keep-forever. There is deliberately no keep-forever value -- a
+		// full repository clone per run with no ceiling is a disk bomb, and `--pin` exists for the one run
+		// worth keeping longer, bounded by sandboxPinDays.
+		sandboxRetentionHours: nonNegativeInt(env, "PI_SANDBOX_RETENTION_HOURS", 24),
+		sandboxPinDays: nonNegativeInt(env, "PI_SANDBOX_PIN_DAYS", 7), // `--pin` extends to now + this, never to forever
+		sandboxIdleMinutes: nonNegativeInt(env, "PI_SANDBOX_IDLE_MINUTES", 30), // bash's own TMOUT inside a sandbox; 0 = no idle logout
 		triggersFile: env.PI_TRIGGERS_FILE ?? null, // DES-CRON-VIA-BULLMQ-SCHEDULER: unified triggers file; null = cron disabled for the worker (it selects on.type:"cron")
 		pauseWindowsFile: env.PI_PAUSE_WINDOWS_FILE ?? null, // REQ-SCOPED-PAUSE-WINDOWS: per-folder/repo timed pause; null = no scoped pauses
 		schedulerStallMax: positiveInt(env, "PI_SCHEDULER_STALL_MAX", 2), // CONST-RETRY-INFRA-ONLY: per-scheduler stall backstop; positiveInt rejects <1 so a 0 threshold fails closed
@@ -235,6 +245,15 @@ function defaultJobsDir() {
 	// Under the OS temp dir by default. Holds only the read-only /job inputs (prompt + .pi/); the
 	// workspace for a local job is the operator's own folder, not here.
 	return `${process.env.TMPDIR ?? process.env.TEMP ?? "/tmp"}/pi-dispatch/jobs`.replace(/\\/g, "/");
+}
+
+export function defaultSandboxDir(env = process.env) {
+	// Beside the per-job dirs, because a retained directory IS a per-job dir -- `cleanup` renames it here
+	// rather than copying, which only stays atomic while both live on one filesystem. Created mode 0700 by
+	// the retention step, since the OS temp dir is 1777 on POSIX and a retained tree holds a repository
+	// clone plus the run's prompt.md/event.json. Exported so the admin extension resolves the same default
+	// without calling loadConfig, which throws on unrelated env problems.
+	return `${env.PI_JOBS_DIR ?? defaultJobsDir()}/sandboxes`.replace(/\\/g, "/");
 }
 
 export function defaultLogsDir() {

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -25,11 +25,11 @@
  * Both end the same way -- pi skips an absent local source with no error, and the flow exits 0 without the
  * tools it was written for.
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawn as nodeSpawn } from "node:child_process";
-import { globalExtensionsEnabled } from "./config.mjs";
+import { defaultSandboxDir, globalExtensionsEnabled } from "./config.mjs";
 import { isForgeKind } from "./forges.mjs";
 import { findLiteralSecret, ADMIN_RE } from "./import-pi.mjs";
 import { PACKAGES_SUBDIR, readStageManifest } from "./packages.mjs";
@@ -408,6 +408,26 @@ export async function runDoctor(env = process.env, deps = {}) {
 		}
 	}
 
+	// REQ-RESURRECTABLE-SANDBOX. A warning, never a failure: retention is a convenience, and the only thing
+	// worth surfacing is that finished runs' directories -- a repository clone plus the run's prompt.md and
+	// event.json, so issue text -- are sitting on disk, and how many. An operator who never opens a sandbox
+	// should still know they are being kept.
+	{
+		const retentionHours = nonNegativeEnvInt(env.PI_SANDBOX_RETENTION_HOURS, 24);
+		const sandboxDir = env.PI_SANDBOX_DIR || defaultSandboxDir(env);
+		if (retentionHours === 0) {
+			checks.push({ ok: true, label: "Workspace retention off (PI_SANDBOX_RETENTION_HOURS=0) — finished runs are deleted, none are re-openable" });
+		} else {
+			const kept = countRetained(sandboxDir, fileExists);
+			checks.push({
+				ok: true,
+				warn: kept.count > 0,
+				label: `${kept.count} retained workspace(s) in ${sandboxDir}, swept after ${retentionHours}h — re-open one with \`pi-dispatch sandbox <jobId>\``,
+				fix: "each holds the run's clone plus its prompt.md/event.json (issue text); PI_SANDBOX_RETENTION_HOURS=0 turns retention off entirely",
+			});
+		}
+	}
+
 	let failed = false;
 	for (const c of checks) {
 		out(`${c.ok ? "✓" : c.warn ? "⚠" : "✗"} ${c.label}\n`);
@@ -418,6 +438,29 @@ export async function runDoctor(env = process.env, deps = {}) {
 	}
 	out(failed ? "\ndoctor: some checks failed — fix the above, then re-run.\n" : "\ndoctor: ready. Start the worker with `pi-dispatch worker`.\n");
 	return failed ? 1 : 0;
+}
+
+/**
+ * How many retained workspaces are sitting in the retention root.
+ *
+ * Reads its OWN env rather than loadConfig, like every other doctor check (`doctor.mjs` header): a broken
+ * GitHub auth must not stop the operator finding out how much disk this is using. Never throws -- an
+ * unreadable or absent root reports zero, which is the honest answer to "how many can I open".
+ */
+function countRetained(sandboxDir, fileExists) {
+	if (!fileExists(sandboxDir)) return { count: 0 };
+	try {
+		return { count: readdirSync(sandboxDir).length };
+	} catch {
+		return { count: 0 };
+	}
+}
+
+/** PI_SANDBOX_RETENTION_HOURS, parsed the same permissive way the admin's own env reads are. */
+function nonNegativeEnvInt(raw, fallback) {
+	if (raw === undefined || raw === "") return fallback;
+	const n = Number.parseInt(raw, 10);
+	return Number.isInteger(n) && n >= 0 && String(n) === String(raw).trim() ? n : fallback;
 }
 
 function nodeCheck(version) {

--- a/worker/src/prepare.mjs
+++ b/worker/src/prepare.mjs
@@ -1,6 +1,8 @@
 import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
+import { resolveJobImage } from "./image-preflight.mjs";
+import { retainJobDir } from "./sandbox-store.mjs";
 import { prepareGithubWorkspace } from "./prepare-github.mjs";
 import { gitlabRemoteUrl } from "./gitlab-host.mjs";
 import { forgejoRemoteUrl } from "./forgejo-host.mjs";
@@ -29,6 +31,12 @@ import { prepareLocalWorkspace } from "./prepare-local.mjs";
 export function makePrepareWorkspace({
 	jobsDir,
 	forgeFor,
+	// REQ-RESURRECTABLE-SANDBOX. The DEPLOYMENT default image, resolved per job against the trigger's own
+	// `run.image` through the SAME function the pre-spend preflight and run-container use -- so the tag that
+	// was checked, the tag that ran and the tag a sandbox later re-opens are one answer by construction
+	// rather than three call sites that happen to agree. Null leaves the stamp imageless, and
+	// `resolveSandbox` then refuses rather than guessing.
+	jobImage = null,
 	findPreviousRun = () => null,
 	// REQ-RESUMABLE-SESSION. The default returns null, so an unwired dispatcher -- tests, a bare
 	// construction -- prepares exactly what it always did: no /session mount, nothing on disk.
@@ -41,6 +49,10 @@ export function makePrepareWorkspace({
 	mkdirSync(jobsDir, { recursive: true });
 	return async function prepareWorkspace(job, token, { queueJobId, piVersion = null } = {}) {
 		const jobDir = mkdtempSync(join(jobsDir, "job-"));
+		// What `cleanup` needs to retain this run's directory, stamped here because this is the only place
+		// that holds all three at once. Applied to the RESULT rather than mutated in, so a preparer's
+		// `{ outcome: "policy" }` refusal -- which carries no jobDir -- is passed through untouched.
+		const sandbox = { jobId: queueJobId ?? null, kind: job.kind ?? null, image: resolveJobImage(job, jobImage) };
 		if (job.kind === "local") {
 			// Harness text above, operator DATA below: the fixed pointer line names /job/event.json so a
 			// flow can discover the trigger context (mirroring the github prompt, which names the same
@@ -51,21 +63,24 @@ export function makePrepareWorkspace({
 				? `Use the "${job.flow}" skill for this task.\n\n${pointer}${job.task ?? ""}`
 				: `${pointer}${job.task ?? ""}`;
 			const event = localEventContext(job, queueJobId, findPreviousRun);
-			return await prepareLocal({ folder: job.folder, task, jobDir, event });
+			return stampSandbox(await prepareLocal({ folder: job.folder, task, jobDir, event }), sandbox);
 		}
 		const prepare = preparers[job.kind];
 		if (prepare) {
 			const host = forgeFor?.(job)?.host;
-			return await prepare(job, token, {
-				jobDir,
-				resolveDefaultBranchSha: host?.resolveDefaultBranchSha,
-				// The head ref a pull/merge-request job keys on comes from the FORGE API, never the webhook
-				// payload: an issue_comment on a PR carries no head at all, and a payload-supplied head repo
-				// is attacker-controlled data that must not decide which transcript a job is handed.
-				resolvePullRequestHead: host?.resolvePullRequestHead,
-				resolveSession,
-				piVersion,
-			});
+			return stampSandbox(
+				await prepare(job, token, {
+					jobDir,
+					resolveDefaultBranchSha: host?.resolveDefaultBranchSha,
+					// The head ref a pull/merge-request job keys on comes from the FORGE API, never the webhook
+					// payload: an issue_comment on a PR carries no head at all, and a payload-supplied head repo
+					// is attacker-controlled data that must not decide which transcript a job is handed.
+					resolvePullRequestHead: host?.resolvePullRequestHead,
+					resolveSession,
+					piVersion,
+				}),
+				sandbox,
+			);
 		}
 		throw new Error(`unknown job kind: ${job.kind}`);
 	};
@@ -104,9 +119,44 @@ function scheduledForMillis(queueJobId) {
 	return Number.isFinite(millis) ? millis : null;
 }
 
+/**
+ * Attach the sandbox stamp to a successful prepare, and to nothing else.
+ *
+ * A preparer's determinate refusal (`{ outcome: "policy", reason: "sha-gone" }`) carries no `jobDir`, so
+ * it is returned verbatim: there is no directory to retain and the processor's policy branch reads the
+ * same object it always did.
+ */
+function stampSandbox(prepared, sandbox) {
+	if (!prepared?.jobDir) return prepared;
+	return { ...prepared, sandbox };
+}
+
 /** Remove a per-job dir after the run. The workspace (the operator's folder) is never touched here. */
 export async function cleanup(prepared) {
 	if (prepared?.jobDir) await rm(prepared.jobDir, { recursive: true, force: true });
+}
+
+/**
+ * The teardown the worker injects: retain this run's directory for a bounded window instead of deleting
+ * it, so `pi-dispatch sandbox` can re-open it (REQ-RESURRECTABLE-SANDBOX).
+ *
+ * With the window at 0 -- the documented "off" -- this IS `cleanup`, by the same `rm` on the same path,
+ * so a deployment that does not want retention keeps today's behaviour exactly rather than a
+ * near-equivalent of it. `retainJobDir` owns the other branch entirely, including removing `jobDir` on
+ * every failure path, which is why there is no `rm` here to pair with it.
+ *
+ * NEVER THROWS -- the processor already swallows this in a `finally`, and a retention fault must not be
+ * the thing that turns a paid, completed run into a failure.
+ */
+export function makeCleanup({ sandboxDir, retentionHours = 0, log = () => {} } = {}) {
+	return async function cleanupWithRetention(prepared) {
+		if (!prepared?.jobDir) return;
+		if (!sandboxDir || retentionHours <= 0) {
+			await cleanup(prepared);
+			return;
+		}
+		retainJobDir(prepared, { sandboxDir, log });
+	};
 }
 
 /**

--- a/worker/src/sandbox-cli.mjs
+++ b/worker/src/sandbox-cli.mjs
@@ -1,0 +1,156 @@
+import { parseArgs } from "node:util";
+import { loadConfig } from "./config.mjs";
+import { sanitizeJobId } from "./run-history.mjs";
+import { buildSandboxRunArgs, launchSandbox, listRunningSandboxes, parsePublish, resolveSandbox, sandboxContainerName } from "./sandbox.mjs";
+import { listSandboxes, pinSandbox } from "./sandbox-store.mjs";
+
+/**
+ * `pi-dispatch sandbox` -- re-open a finished run's sandbox as an interactive shell
+ * (REQ-RESURRECTABLE-SANDBOX).
+ *
+ * A command module beside doctor.mjs and import-pi.mjs, with the same posture: the whole I/O surface is
+ * injected so the decision paths are testable without docker, a terminal, or a disk, and every refusal
+ * names what to do about it rather than only what went wrong.
+ *
+ * The container this launches is NOT a job container. It carries the same isolation flags and the same
+ * mounts, and no credentials at all -- see sandbox.mjs, which owns that shape.
+ */
+export async function runSandbox(argv = [], { env = process.env, deps = {} } = {}) {
+	const {
+		out = (s) => process.stdout.write(s),
+		err = (s) => process.stderr.write(s),
+		isTty = Boolean(process.stdin.isTTY && process.stdout.isTTY),
+		running = listRunningSandboxes,
+		launch = launchSandbox,
+		now = () => Date.now(),
+	} = deps;
+
+	let values;
+	let positionals;
+	try {
+		({ values, positionals } = parseArgs({
+			args: argv,
+			allowPositionals: true,
+			options: {
+				list: { type: "boolean", default: false },
+				publish: { type: "string", multiple: true }, // repeatable; always bound to 127.0.0.1
+				pin: { type: "boolean", default: false },
+			},
+		}));
+	} catch (error) {
+		return fail(err, error.message);
+	}
+
+	const config = loadConfig(env);
+	// A docker that cannot be reached costs a column, never the command: `listRunningSandboxes` throws so
+	// the REAPER can tell "none" from "could not ask", and these callers only draw a marker. Asked only
+	// where it is used, and never before the arguments are known good -- a typo should not shell out.
+	const liveSandboxes = async () => new Set(await running().catch(() => []));
+
+	if (values.list) {
+		return renderList({ config, live: await liveSandboxes(), out, now });
+	}
+
+	const jobId = positionals[0];
+	if (!jobId) return fail(err, "a job id is required — `pi-dispatch sandbox --list` shows what is still re-openable");
+
+	// Refused BEFORE anything else that could half-succeed. `-t` against a pipe fails inside docker with
+	// "the input device is not a TTY", which names neither the cause nor the fix; a sandbox is an operator
+	// session by definition, so the absence of an operator is a refusal rather than a fallback.
+	if (!isTty) {
+		return fail(err, "`pi-dispatch sandbox` needs a terminal — it opens an interactive shell, so it cannot run from a pipe, a script without a TTY, or CI");
+	}
+
+	// `listRunningSandboxes` yields ids, already sanitized, so this compares like with like.
+	if ((await liveSandboxes()).has(sanitizeJobId(jobId))) {
+		return fail(err, `a sandbox for ${jobId} is already running — attach to it with \`docker attach ${sandboxContainerName(jobId)}\`, or exit it first`);
+	}
+
+	let publish;
+	try {
+		publish = parsePublish(values.publish ?? []);
+	} catch (error) {
+		return fail(err, error.message);
+	}
+
+	const resolved = resolveSandbox({
+		jobId,
+		sandboxDir: config.sandboxDir,
+		retentionHours: config.sandboxRetentionHours,
+		publish,
+	});
+	if (resolved.refused) return fail(err, resolved.message);
+
+	// Pin BEFORE the shell, not after: the operator asked to keep this one, and a session that ends in a
+	// crashed terminal or a closed laptop lid must not be the reason the pin never landed.
+	if (values.pin) {
+		const pinned = pinSandbox({ sandboxDir: config.sandboxDir, jobId, pinDays: config.sandboxPinDays, now });
+		if (pinned.pinned) out(`pinned ${jobId} until ${pinned.keepUntil} (${config.sandboxPinDays}d)\n`);
+		else err(`warning: could not pin ${jobId}: ${pinned.reason}\n`);
+	}
+
+	const args = buildSandboxRunArgs({
+		image: resolved.manifest.image,
+		name: resolved.name,
+		workspace: resolved.manifest.workspace,
+		jobDir: resolved.manifest.dir,
+		publish,
+		term: env.TERM,
+		idleSeconds: config.sandboxIdleMinutes * 60,
+	});
+
+	out(`opening ${resolved.name} — image ${resolved.manifest.image}, workspace ${resolved.manifest.workspace}\n`);
+	out("no credentials are set in this container. exit the shell to dispose of it.\n");
+	if (publish.length > 0) out(`published: ${publish.filter((f) => f !== "-p").join(", ")}\n`);
+
+	const { code, error } = await launch({ args });
+	if (error) return fail(err, `could not start docker: ${error.message}`);
+	return code ?? 0;
+}
+
+/**
+ * What is still re-openable, newest first, plus what is running right now.
+ *
+ * The running column is the honest answer to `TMOUT`'s one gap: an idle timeout does not tick while a
+ * foreground command runs, so a sandbox left serving an app stays up. Making it findable is the least
+ * this can do about that.
+ */
+function renderList({ config, live, out, now }) {
+	if (config.sandboxRetentionHours === 0) {
+		out("workspace retention is off (PI_SANDBOX_RETENTION_HOURS=0) — finished runs are deleted as before\n");
+	}
+	const rows = listSandboxes({ sandboxDir: config.sandboxDir });
+	if (rows.length === 0) {
+		out("no retained workspaces\n");
+		return 0;
+	}
+	const width = Math.max(...rows.map((r) => String(r.jobId ?? "").length), 5);
+	for (const row of rows) {
+		const id = String(row.jobId ?? "?").padEnd(width);
+		const kind = String(row.kind ?? "?").padEnd(8);
+		const state = live.has(sanitizeJobId(row.jobId)) ? "RUNNING" : remaining(row, config.sandboxRetentionHours, now());
+		out(`${id}  ${kind}  ${state}\n`);
+	}
+	return 0;
+}
+
+/** How long this one has left, from the manifest's own timestamps -- never from mtime, which a live sandbox moves. */
+function remaining(row, retentionHours, at) {
+	const keepUntil = Date.parse(row.keepUntil ?? "");
+	if (Number.isFinite(keepUntil)) return `pinned, ${humanise(keepUntil - at)} left`;
+	const createdAt = Date.parse(row.createdAt ?? "");
+	if (!Number.isFinite(createdAt)) return "expired";
+	return `${humanise(createdAt + retentionHours * 3600000 - at)} left`;
+}
+
+function humanise(ms) {
+	if (ms <= 0) return "0h";
+	const hours = Math.round(ms / 3600000);
+	if (hours < 48) return `${Math.max(1, hours)}h`;
+	return `${Math.round(hours / 24)}d`;
+}
+
+function fail(err, message) {
+	err(`error: ${message}\n`);
+	return 1;
+}

--- a/worker/src/sandbox-store.mjs
+++ b/worker/src/sandbox-store.mjs
@@ -1,0 +1,269 @@
+import { lstatSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, relative } from "node:path";
+import { sanitizeJobId } from "./run-history.mjs";
+
+/**
+ * sandbox-store.mjs -- the host side of a resurrectable sandbox (REQ-RESURRECTABLE-SANDBOX,
+ * INT-SANDBOX-CONTRACT).
+ *
+ * A job container is still single-use and still `--rm`s. What survives it, for a bounded window, is the
+ * per-job DIRECTORY: `cleanup` renames it here instead of deleting it, and `pi-dispatch sandbox` later
+ * mounts it into a fresh container. Nothing about the job path changes -- with the window at 0 this
+ * module is never reached and `cleanup` is byte-for-byte the `rm -rf` it always was.
+ *
+ * A SIBLING of makeLogReaper and of session-store's reapSessions rather than a widening of either: that
+ * one's `.log`/`.json` filter and logsDir scope are a documented contract, and these directories have a
+ * different retention policy and a different PII class again. Same never-throws shape, and three
+ * DELIBERATE divergences from makeLogReaper, each of which would be a silent bug if copied from it:
+ *
+ *   - `lstatSync`, never `statSync`. The retained tree is agent-written; a symlink planted in it resolves
+ *     on the HOST when the reaper stats it. session-store.mjs:192-201 records this lesson and
+ *     makeLogReaper is the habit that predates it.
+ *   - Age comes from the manifest's `createdAt`, never from mtime. makeLogReaper calls mtime "the
+ *     authority" and is right about an append-once log file. Here an operator working inside a resurrected
+ *     sandbox writes into the directory, so mtime would keep moving and the window would never close --
+ *     for exactly the directories most likely to be large.
+ *   - A directory whose sandbox container is RUNNING is skipped. The sweep runs at worker boot, an
+ *     operator's shell can outlive a worker restart by design (the container is named outside the
+ *     `pi-job-` reaper's filter), and deleting a live bind mount underneath it is a confusing failure
+ *     with a boring cause.
+ *
+ * NEVER THROWS, on any path. Retention is a convenience layered onto a job that has already finished and
+ * already been paid for; a disk fault here must degrade to "not resurrectable" and never to a failed run.
+ */
+
+/** The manifest filename inside a retained directory. */
+export const SANDBOX_MANIFEST = "manifest.json";
+
+const HOUR_MS = 3600000;
+const DAY_MS = 86400000;
+
+const defaultFs = { lstatSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync };
+
+/**
+ * Retain one finished job's directory, or delete it.
+ *
+ * Called by `makeCleanup` in place of the bare `rm -rf`. Returns the written manifest, or `null` when
+ * nothing was retained -- and on `null` the caller has nothing left to do, because every failure path
+ * here removes `jobDir` itself. Retention must never leave debris behind.
+ *
+ * `prepared.sandbox` is `{ jobId, kind, image }`, stamped by `makePrepareWorkspace`. Absent (a bare
+ * construction, a test, an unwired dispatcher) means no retention, which keeps such a caller on exactly
+ * the pre-feature path.
+ */
+export function retainJobDir(prepared, { sandboxDir, fs = defaultFs, log = () => {}, now = () => Date.now() } = {}) {
+	const jobDir = prepared?.jobDir;
+	const meta = prepared?.sandbox;
+	if (!jobDir) return null;
+	if (!sandboxDir || !meta?.jobId) {
+		discard(jobDir, fs);
+		return null;
+	}
+
+	const dest = join(sandboxDir, sanitizeJobId(meta.jobId));
+	try {
+		// FIRST, and load-bearing rather than hygiene. The per-job transcript copy is the most PII-bearing
+		// artifact this system holds -- tool output, file contents, the agent's own reasoning -- and it
+		// belongs to PI_SESSIONS_DIR's own TTL (INT-SESSION-STORE-CONTRACT). Carrying it into a directory
+		// with a different, operator-extendable lifetime would silently extend that TTL, which is not a
+		// weakening of the session policy so much as an end-run around it.
+		fs.rmSync(join(jobDir, "session"), { recursive: true, force: true });
+
+		fs.mkdirSync(sandboxDir, { recursive: true, mode: 0o700 });
+		// A BullMQ retry reuses the job id, so the previous attempt may already be sitting at `dest`. Last
+		// attempt wins: it is the one whose workspace matches the run the operator just watched.
+		fs.rmSync(dest, { recursive: true, force: true });
+		fs.renameSync(jobDir, dest);
+
+		const manifest = {
+			jobId: meta.jobId,
+			kind: meta.kind ?? null,
+			image: meta.image ?? null,
+			workspace: rebaseWorkspace(prepared.workspace, jobDir, dest),
+			createdAt: new Date(now()).toISOString(),
+			keepUntil: null,
+		};
+		fs.writeFileSync(join(dest, SANDBOX_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+		log("sandbox_retained", { jobId: meta.jobId, kind: manifest.kind });
+		return manifest;
+	} catch (err) {
+		// Fall back to the behaviour retention replaced. Both paths are attempted because the rename may
+		// have already moved the tree, in which case `jobDir` no longer exists and `dest` is the debris.
+		log("sandbox_retain_failed", { jobId: meta.jobId, reason: err?.message });
+		discard(jobDir, fs);
+		discard(dest, fs);
+		return null;
+	}
+}
+
+/**
+ * Where the sandbox's `/workspace` lives once the directory has moved.
+ *
+ * A forge job's workspace is a subdirectory of jobDir (prepare-github.mjs), so it travels with the rename
+ * and its recorded path must be rebased. A local job's workspace IS the operator's own folder, outside
+ * jobDir entirely, and must be recorded verbatim -- it was never ours to move.
+ *
+ * Decided by path containment rather than by `kind`, so a preparer that changes where it puts a clone
+ * cannot silently record a path that does not exist.
+ */
+function rebaseWorkspace(workspace, jobDir, dest) {
+	if (!workspace) return null;
+	const rel = relative(jobDir, workspace);
+	if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) return workspace;
+	return join(dest, rel);
+}
+
+/** Best-effort removal. Swallows everything: this is already the failure path. */
+function discard(dir, fs) {
+	try {
+		fs.rmSync(dir, { recursive: true, force: true });
+	} catch {
+		// nothing left to try
+	}
+}
+
+/** One retained run by (raw) job id, or null when absent, unreadable or not JSON. */
+export function readManifest({ sandboxDir, jobId, fs = defaultFs }) {
+	if (!sandboxDir || jobId === undefined || jobId === null) return null;
+	const dir = join(sandboxDir, sanitizeJobId(jobId));
+	try {
+		const manifest = JSON.parse(fs.readFileSync(join(dir, SANDBOX_MANIFEST), "utf8"));
+		return { ...manifest, dir };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Every retained run, newest first. A filename-keyed scan of one directory, exactly like
+ * makeFindPreviousRun's -- no index, no database, no new query surface (DES-RUN-HISTORY-FLAT-FILES-NO-DB).
+ * An entry with no readable manifest is skipped rather than surfaced: it cannot be resurrected, and the
+ * reaper removes it on the next sweep.
+ */
+export function listSandboxes({ sandboxDir, fs = defaultFs }) {
+	if (!sandboxDir) return [];
+	let names;
+	try {
+		names = fs.readdirSync(sandboxDir);
+	} catch {
+		return [];
+	}
+	const out = [];
+	for (const name of names) {
+		const dir = join(sandboxDir, name);
+		try {
+			const manifest = JSON.parse(fs.readFileSync(join(dir, SANDBOX_MANIFEST), "utf8"));
+			out.push({ ...manifest, dir });
+		} catch {
+			// unreadable or not a retained directory
+		}
+	}
+	return out.sort((a, b) => String(b.createdAt ?? "").localeCompare(String(a.createdAt ?? "")));
+}
+
+/**
+ * Extend one run's retention to `now + pinDays`, and say so on disk.
+ *
+ * Bounded on purpose: `keepUntil` is a timestamp, never a boolean. "Keep this one" that means "forever"
+ * is how a directory holding a full repository clone per run becomes unbounded, and the acceptance this
+ * feature was written against says retention stays swept.
+ */
+export function pinSandbox({ sandboxDir, jobId, pinDays, fs = defaultFs, now = () => Date.now() }) {
+	const manifest = readManifest({ sandboxDir, jobId, fs });
+	if (!manifest) return { pinned: false, reason: "absent" };
+	const keepUntil = new Date(now() + pinDays * DAY_MS).toISOString();
+	const { dir, ...body } = manifest;
+	try {
+		fs.writeFileSync(join(dir, SANDBOX_MANIFEST), `${JSON.stringify({ ...body, keepUntil }, null, 2)}\n`, { mode: 0o600 });
+		return { pinned: true, keepUntil };
+	} catch (err) {
+		return { pinned: false, reason: err?.message ?? "write-failed" };
+	}
+}
+
+/**
+ * The boot sweep. Fault isolation is the contract, mirroring makeLogReaper and makeReaper: `reapSandboxes`
+ * NEVER throws under any input, and one bad entry cannot abort the rest of the sweep.
+ *
+ * There is NO keep-forever sentinel here, unlike PI_LOG_RETENTION_DAYS and PI_SESSIONS_TTL_DAYS.
+ * `retentionHours === 0` is the feature being OFF, and it needs no special case: the cutoff becomes `now`,
+ * so every unpinned directory is already expired and gets swept. Turning retention off therefore also
+ * cleans up what an earlier setting retained, while an explicit `--pin` still runs to its own deadline --
+ * an operator's deliberate act outliving a config change is the behaviour worth having.
+ *
+ * `listRunning` yields the JOB IDS of live sandboxes -- ids, not container names, so this module needs to
+ * know nothing about how a container is named and the two files stay acyclic. It defaults to none, so an
+ * unwired reaper still sweeps; start.mjs injects the docker-backed one.
+ */
+export function makeSandboxReaper({
+	sandboxDir,
+	retentionHours,
+	fs = defaultFs,
+	log = () => {},
+	now = () => Date.now(),
+	listRunning = async () => [],
+}) {
+	return async function reapSandboxes() {
+		if (!sandboxDir) return;
+		let running = new Set();
+		try {
+			running = new Set(await listRunning());
+		} catch (err) {
+			// Could not ask docker. Sweeping blind risks pulling a mount out from under a live shell, so
+			// skip this sweep entirely: a directory kept one boot too long is the cheaper mistake.
+			log("sandbox_reaper_skipped", { reason: err?.message ?? "running-lookup-failed" });
+			return;
+		}
+
+		let names;
+		try {
+			names = fs.readdirSync(sandboxDir);
+		} catch (err) {
+			log("sandbox_reaper_skipped", { reason: err?.message });
+			return;
+		}
+
+		const at = now();
+		const cutoff = at - retentionHours * HOUR_MS;
+		for (const name of names) {
+			const dir = join(sandboxDir, name);
+			try {
+				// lstat: a symlink here resolves on the host, and this tree is agent-written.
+				if (!fs.lstatSync(dir).isDirectory()) {
+					fs.rmSync(dir, { recursive: true, force: true });
+					log("reaped_sandbox", { entry: name, reason: "not-a-directory" });
+					continue;
+				}
+				if (running.has(name)) continue; // an operator is inside it
+				const verdict = expiry(dir, fs, at, cutoff);
+				if (!verdict.expired) continue;
+				fs.rmSync(dir, { recursive: true, force: true });
+				log("reaped_sandbox", { entry: name, reason: verdict.reason });
+			} catch (err) {
+				log("sandbox_reaper_skipped", { entry: name, reason: err?.message });
+			}
+		}
+	};
+}
+
+/**
+ * Whether one retained directory is past its window.
+ *
+ * An unreadable, absent or unparseable manifest is EXPIRED, not skipped: without it the directory names no
+ * image, no workspace and no job, so nothing can resurrect it and keeping it is just disk. A pin wins over
+ * the base window while it lasts, and an unparseable `keepUntil` is treated as no pin rather than as
+ * forever -- the direction that stays bounded.
+ */
+function expiry(dir, fs, at, cutoff) {
+	let manifest;
+	try {
+		manifest = JSON.parse(fs.readFileSync(join(dir, SANDBOX_MANIFEST), "utf8"));
+	} catch {
+		return { expired: true, reason: "no-manifest" };
+	}
+	const keepUntil = Date.parse(manifest?.keepUntil ?? "");
+	if (Number.isFinite(keepUntil)) return keepUntil <= at ? { expired: true, reason: "pin-expired" } : { expired: false };
+	const createdAt = Date.parse(manifest?.createdAt ?? "");
+	if (!Number.isFinite(createdAt)) return { expired: true, reason: "no-created-at" };
+	return createdAt < cutoff ? { expired: true, reason: "window" } : { expired: false };
+}

--- a/worker/src/sandbox.mjs
+++ b/worker/src/sandbox.mjs
@@ -1,0 +1,171 @@
+import { execFile, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { promisify } from "node:util";
+import { configError } from "./config.mjs";
+import { buildDockerRunArgs } from "./docker-run.mjs";
+import { sanitizeJobId } from "./run-history.mjs";
+import { readManifest } from "./sandbox-store.mjs";
+
+/**
+ * sandbox.mjs -- the operator session's container shape (INT-SANDBOX-CONTRACT).
+ *
+ * A SECOND container shape, deliberately not a second copy of the first. The argv comes from
+ * `buildDockerRunArgs` through its `extraFlags` seam, so `ISOLATION_FLAGS`, `--memory` and `--cpus` reach
+ * this container BY CONSTRUCTION: a future change to the boundary cannot land on job containers and miss
+ * this one, which is the whole reason for reusing the builder rather than writing a leaner argv here.
+ *
+ * What differs from a job, and every difference is the point:
+ *   - `-i -t --entrypoint bash`. `INT-CONTAINER-RUNTIME-CONTRACT` says "No TTY (`-it` absent)" and stays
+ *     true; this is a different contract for a different object, not an amendment to that one.
+ *   - NO CREDENTIALS. Not the minted forge token, not the provider key, not one forwarded host variable.
+ *     `buildContainerEnv` is deliberately NOT reused: it writes the mint into that forge's variable names
+ *     (env-allowlist.mjs) and throws outright when no provider credential resolves, so a credential-free
+ *     container cannot be produced from it. The env here is two variables, both about the terminal.
+ *   - No `/outbox`, no `/session`, no `/opt/pi-global`. The agent is not running; there is nothing to
+ *     chain, no transcript to continue and no overlay to layer.
+ *
+ * The agent is not running. The operator is at the keyboard and brings their own auth if they need it.
+ */
+
+const exec = promisify(execFile);
+
+/**
+ * The name namespace, and it is load-bearing. The boot reaper filters `name=pi-job-`
+ * (`makeReaper` in start.mjs) and docker matches that as a SUBSTRING, so a sandbox must not contain it --
+ * otherwise a worker restart kills the shell an operator is sitting in. `pi-sandbox-` is outside that
+ * filter on purpose, and a test pins it.
+ */
+export const SANDBOX_NAME_PREFIX = "pi-sandbox-";
+
+/** `pi-sandbox-<jobId>`. `sanitizeJobId` already maps to `[A-Za-z0-9._-]`, which is a legal docker name. */
+export function sandboxContainerName(jobId) {
+	return `${SANDBOX_NAME_PREFIX}${sanitizeJobId(jobId)}`;
+}
+
+/**
+ * Turn `--publish` values into docker flags, BOUND TO LOOPBACK, always.
+ *
+ * `3000` publishes container 3000 on host 3000; `8080:3000` publishes container 3000 on host 8080. An
+ * explicit bind address is refused rather than honoured: this container holds whatever the agent wrote,
+ * and the deployment's own admin surface is 127.0.0.1-only for the same reason
+ * (`DES-PANEL-SEPARATE-FROM-RECEIVER`). Making the LAN case merely inconvenient would be a worse answer
+ * than making it unavailable.
+ */
+export function parsePublish(values = []) {
+	const flags = [];
+	for (const raw of values) {
+		const match = /^(\d{1,5})(?::(\d{1,5}))?$/.exec(String(raw).trim());
+		const host = match && Number(match[1]);
+		const container = match && Number(match[2] ?? match[1]);
+		if (!match || !inPortRange(host) || !inPortRange(container)) {
+			throw configError(`invalid --publish ${JSON.stringify(raw)} (want <port> or <hostPort>:<containerPort>; the bind address is always 127.0.0.1)`);
+		}
+		flags.push("-p", `127.0.0.1:${host}:${container}`);
+	}
+	return flags;
+}
+
+function inPortRange(n) {
+	return Number.isInteger(n) && n >= 1 && n <= 65535;
+}
+
+/**
+ * Build the `docker run` argv for one operator session (excluding the leading "docker").
+ *
+ * @param image        the image the original run used, from its manifest
+ * @param name         `pi-sandbox-<jobId>`
+ * @param workspace    host path mounted /workspace:rw -- the retained clone, or the operator's own folder
+ * @param jobDir       the retained per-job dir, mounted /job:ro exactly as the run had it
+ * @param publish      already-parsed `-p` flags
+ * @param term         the host's TERM, so the shell renders
+ * @param idleSeconds  bash's own TMOUT; 0 omits it
+ */
+export function buildSandboxRunArgs({ image, name, workspace, jobDir, publish = [], term, idleSeconds = 0 }) {
+	return buildDockerRunArgs({
+		image,
+		name,
+		workspace,
+		jobDir,
+		// The ONLY two variables, and neither is a credential. TERM so the shell renders; TMOUT so a
+		// forgotten session closes itself. `buildDockerRunArgs` skips undefined, so an unset TERM or a
+		// disabled idle timeout emits nothing rather than an empty string.
+		env: {
+			TERM: term || undefined,
+			TMOUT: idleSeconds > 0 ? String(idleSeconds) : undefined,
+		},
+		// Ahead of the env and the mounts, and well ahead of the image, which buildDockerRunArgs keeps as
+		// the final positional. `--entrypoint` also clears the image's CMD; this repo's Dockerfile sets
+		// none, so `bash` runs bare and `-it` makes it interactive, in the baked WORKDIR as the baked
+		// non-root USER.
+		extraFlags: ["-i", "-t", "--entrypoint", "bash", ...publish],
+	});
+}
+
+/**
+ * The JOB IDS of sandboxes running right now -- ids, not container names, because that is the shape both
+ * consumers want: the reaper compares them to directory names, and `--list` marks rows.
+ *
+ * THROWS when docker cannot be asked, and that is the point: "none are running" and "I could not find out"
+ * must not arrive as the same empty array. The reaper deletes directories, and it treats the second case as
+ * a reason to skip the whole sweep -- swallowing the error here would quietly turn a docker outage into a
+ * blind sweep that can pull a bind mount out from under a live shell. The CLI, which only draws a column,
+ * degrades on its own.
+ *
+ * TIMED, unlike the boot container reaper's own `docker ps`: an unreachable daemon does not fail the CLI
+ * fast, it blocks, and this call sits in front of a worker that has not started draining yet.
+ */
+export async function listRunningSandboxes({ execFn = exec } = {}) {
+	const { stdout } = await execFn("docker", ["ps", "--filter", `name=${SANDBOX_NAME_PREFIX}`, "--format", "{{.Names}}"], { timeout: 5000 });
+	return stdout
+		.split("\n")
+		.map((n) => n.trim())
+		.filter((n) => n.startsWith(SANDBOX_NAME_PREFIX))
+		.map((n) => n.slice(SANDBOX_NAME_PREFIX.length));
+}
+
+/**
+ * Resolve one retained run into a launchable argv, or a NAMED refusal.
+ *
+ * Split out from the launch so both callers -- the CLI and the admin panel -- refuse identically, and so
+ * the whole decision is testable without docker. Every refusal names what to do next, the posture
+ * `doctor` sets: a bare "not found" for a run the operator watched finish ten minutes ago is the least
+ * useful thing this could say.
+ */
+export function resolveSandbox({ jobId, sandboxDir, retentionHours, publish = [], fs, fileExists = existsSync }) {
+	if (!jobId) return { refused: "no-job-id", message: "a job id is required (see `pi-dispatch sandbox --list`)" };
+
+	const manifest = readManifest({ sandboxDir, jobId, ...(fs ? { fs } : {}) });
+	if (!manifest) {
+		return retentionHours === 0
+			? { refused: "retention-off", message: "workspace retention is off — set PI_SANDBOX_RETENTION_HOURS to a positive number to make future runs resurrectable" }
+			: { refused: "absent", message: `no retained workspace for ${jobId} — it was swept after ${retentionHours}h, or the run predates retention (\`pi-dispatch sandbox --list\` shows what is left)` };
+	}
+	if (!manifest.image) {
+		return { refused: "no-image", message: `the manifest for ${jobId} names no image, so the sandbox cannot reproduce the run` };
+	}
+	if (!manifest.workspace || !fileExists(manifest.workspace)) {
+		// The common cause for a local run: the operator's folder moved or was deleted. Naming the path is
+		// the whole diagnosis, so name it.
+		return { refused: "workspace-gone", message: `the workspace for ${jobId} is no longer at ${manifest.workspace} — a local folder that moved cannot be re-opened` };
+	}
+
+	return { manifest, name: sandboxContainerName(jobId), publish };
+}
+
+/**
+ * Launch one operator session, attached to the caller's terminal, and resolve its exit code.
+ *
+ * `spawn`, never `spawnSync`, and `stdio: "inherit"`: the same shape pi itself uses to hand the terminal
+ * to `$EDITOR` (`extension-editor.js`), whose comment records why the synchronous form is wrong -- on
+ * Windows it can keep libuv's console read active and race the child for input.
+ *
+ * The caller owns the terminal around this: the CLI simply has one, and the admin panel brackets the call
+ * with `tui.stop()`/`tui.start()`.
+ */
+export function launchSandbox({ args, spawnFn = spawn }) {
+	return new Promise((resolve) => {
+		const child = spawnFn("docker", args, { stdio: "inherit" });
+		child.on("error", (err) => resolve({ code: null, error: err }));
+		child.on("close", (code) => resolve({ code }));
+	});
+}

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -17,7 +17,9 @@ import { makeImagePreflight } from "./image-preflight.mjs";
 import { createWorker } from "./index.mjs";
 import { makeCollectChain } from "./outbox.mjs";
 import { containerPackagePaths, readStageManifest } from "./packages.mjs";
-import { cleanup, makeForgePreparers, makePrepareWorkspace } from "./prepare.mjs";
+import { makeCleanup, makeForgePreparers, makePrepareWorkspace } from "./prepare.mjs";
+import { listRunningSandboxes } from "./sandbox.mjs";
+import { makeSandboxReaper } from "./sandbox-store.mjs";
 import { makeSessionStore } from "./session-store.mjs";
 import { loadPauseWindows, pauseUntilMs } from "./pause-windows.mjs";
 import { makeQueue } from "./queue.mjs";
@@ -141,6 +143,7 @@ export async function startWorker(
 		makeLogSink: makeLogSinkFn = makeLogSink,
 		makeRecordWriter: makeRecordWriterFn = makeRecordWriter,
 		makeLogReaper: makeLogReaperFn = makeLogReaper,
+		makeSandboxReaper: makeSandboxReaperFn = makeSandboxReaper,
 		makeRunContainer: makeRunContainerFn = makeRunContainer,
 		makeImagePreflight: makeImagePreflightFn = makeImagePreflight,
 		makeGitLabAuth: makeGitLabAuthFn = makeGitLabAuth,
@@ -236,6 +239,22 @@ export async function startWorker(
 		await makeLogReaperFn({ logsDir: config.logsDir, retentionDays: config.logRetentionDays, log })();
 	} catch (err) {
 		log("log_reaper_skipped", { reason: err?.message });
+	}
+
+	// REQ-RESURRECTABLE-SANDBOX: sweep retained per-job directories past their window, so what `cleanup`
+	// kept for re-opening stays bounded. Third in the row and deliberately its own sweep -- a different
+	// retention policy, a different PII class, and one thing neither sibling needs: it asks docker which
+	// sandboxes are live first, because an operator's shell can outlive a worker restart by design and
+	// deleting a bind mount underneath it is a confusing failure with a boring cause. Same double-wrap.
+	try {
+		await makeSandboxReaperFn({
+			sandboxDir: config.sandboxDir,
+			retentionHours: config.sandboxRetentionHours,
+			listRunning: listRunningSandboxes,
+			log,
+		})();
+	} catch (err) {
+		log("sandbox_reaper_skipped", { reason: err?.message });
 	}
 
 	// One raw Redis client, shared by the budget (via the worker) and the scheduler stall guard, so it is
@@ -350,6 +369,9 @@ export async function startWorker(
 			prepareWorkspace: makePrepareWorkspace({
 				jobsDir: config.jobsDir,
 				forgeFor,
+				// REQ-RESURRECTABLE-SANDBOX: the deployment default, resolved per job against run.image so a
+				// retained directory records the image that actually ran and a sandbox re-opens that one.
+				jobImage: config.jobImage,
 				preparers: makeForgePreparers({ gitlabApiUrl: config.gitlab?.apiUrl ?? null, forgejoApiUrl: config.forgejo?.apiUrl ?? null, azureOrgUrl: config.azure?.orgUrl ?? null }),
 				// The cron event.json's previousRunAt (INT-CONTAINER-JOB-INPUTS): read back from the same
 				// per-job run-history sidecars recordRun writes above -- no new store, no new query surface.
@@ -359,7 +381,9 @@ export async function startWorker(
 				// PI_SESSIONS_DIR is unset -- and a null means no mount and nothing written.
 				resolveSession: sessionStore.resolveSession,
 			}),
-			cleanup,
+			// REQ-RESURRECTABLE-SANDBOX. With the window at 0 this IS the old bare `cleanup`, by the same
+			// `rm` on the same path -- a deployment that wants no retention keeps today's behaviour exactly.
+			cleanup: makeCleanup({ sandboxDir: config.sandboxDir, retentionHours: config.sandboxRetentionHours, log }),
 			comment: async (job, text) => {
 				// Best-effort: the processor awaits comment() inside its try, so a rejection here would
 				// corrupt the job outcome and could drive a wrong retry / second PR (CONST-RETRY-INFRA-ONLY).
@@ -472,6 +496,7 @@ export async function startWorker(
 		settingsFile: config.settingsFile,
 		captureJobLogs: config.captureJobLogs,
 		logRetentionDays: config.logRetentionDays,
+		sandboxRetentionHours: config.sandboxRetentionHours, // 0 = retention off; a run's directory is deleted as before
 	});
 	return worker;
 }

--- a/worker/test/prepare.test.mjs
+++ b/worker/test/prepare.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -237,5 +237,80 @@ test("every forge the table knows has a preparer -- a kind with none throws 'unk
 	const preparers = makeForgePreparers({ prepareForge: async () => ({ ok: true }) });
 	for (const kind of FORGE_KINDS) {
 		assert.equal(typeof preparers[kind], "function", `${kind}: a forge with no preparer burns a budget slot before it fails`);
+	}
+});
+
+test("a prepared job carries the stamp cleanup needs to retain it (REQ-RESURRECTABLE-SANDBOX)", async () => {
+	const { jobsDir, cleanup } = withJobsDir();
+	try {
+		const prepareWorkspace = makePrepareWorkspace({
+			jobsDir,
+			jobImage: "pi-job:deployment-default",
+			preparers: { github: async (_j, _t, { jobDir }) => ({ jobDir, workspace: join(jobDir, "workspace"), sha: "s" }) },
+			forgeFor: () => ({ host: { resolveDefaultBranchSha: async () => ({ sha: "s" }) } }),
+		});
+
+		const plain = await prepareWorkspace({ kind: "github", repo: "a/b" }, "tok", { queueJobId: "gh-7" });
+		assert.deepEqual(plain.sandbox, { jobId: "gh-7", kind: "github", image: "pi-job:deployment-default" });
+
+		// A trigger's own run.image wins, resolved through the SAME function the preflight and the runner
+		// use -- so the tag that was checked, the tag that ran and the tag a sandbox re-opens are one answer.
+		const perTrigger = await prepareWorkspace({ kind: "github", repo: "a/b", image: "pi-job:custom" }, "tok", { queueJobId: "gh-8" });
+		assert.equal(perTrigger.sandbox.image, "pi-job:custom");
+	} finally {
+		cleanup();
+	}
+});
+
+test("a preparer's policy refusal carries no jobDir, so it is passed through unstamped", async () => {
+	const { jobsDir, cleanup } = withJobsDir();
+	try {
+		const prepareWorkspace = makePrepareWorkspace({
+			jobsDir,
+			jobImage: "pi-job:latest",
+			preparers: { github: async () => ({ outcome: "policy", reason: "sha-gone" }) },
+			forgeFor: () => ({ host: {} }),
+		});
+		const refused = await prepareWorkspace({ kind: "github", repo: "a/b" }, "tok", { queueJobId: "gh-9" });
+		// The processor's policy branch reads exactly the object it always did -- no extra key, and nothing
+		// that could make a refusal look retainable.
+		assert.deepEqual(refused, { outcome: "policy", reason: "sha-gone" });
+	} finally {
+		cleanup();
+	}
+});
+
+test("with retention OFF, cleanup is the rm it always was", async () => {
+	const { jobsDir, cleanup } = withJobsDir();
+	try {
+		const { makeCleanup } = await import("../src/prepare.mjs");
+		const jobDir = mkdtempSync(join(jobsDir, "job-"));
+		const prepared = { jobDir, workspace: join(jobDir, "workspace"), sandbox: { jobId: "gh-1", kind: "github", image: "i" } };
+
+		await makeCleanup({ sandboxDir: join(jobsDir, "sandboxes"), retentionHours: 0 })(prepared);
+		assert.equal(existsSync(jobDir), false, "the per-job dir is deleted, exactly as before the feature");
+		assert.equal(existsSync(join(jobsDir, "sandboxes")), false, "and nothing is retained anywhere");
+	} finally {
+		cleanup();
+	}
+});
+
+test("with retention ON, cleanup retains the directory under the sandbox root", async () => {
+	const { jobsDir, cleanup } = withJobsDir();
+	try {
+		const { makeCleanup } = await import("../src/prepare.mjs");
+		const sandboxDir = join(jobsDir, "sandboxes");
+		const jobDir = mkdtempSync(join(jobsDir, "job-"));
+		mkdirSync(join(jobDir, "workspace"), { recursive: true });
+		writeFileSync(join(jobDir, "prompt.md"), "task");
+		const prepared = { jobDir, workspace: join(jobDir, "workspace"), sandbox: { jobId: "gh-1", kind: "github", image: "pi-job:latest" } };
+
+		await makeCleanup({ sandboxDir, retentionHours: 24 })(prepared);
+		assert.equal(existsSync(jobDir), false, "the original per-job dir is gone -- moved, not copied");
+		assert.equal(existsSync(join(sandboxDir, "gh-1", "prompt.md")), true, "the run's /job inputs travelled with it");
+		const manifest = JSON.parse(readFileSync(join(sandboxDir, "gh-1", "manifest.json"), "utf8"));
+		assert.equal(manifest.workspace, join(sandboxDir, "gh-1", "workspace"), "the workspace path follows the rename");
+	} finally {
+		cleanup();
 	}
 });

--- a/worker/test/sandbox-cli.test.mjs
+++ b/worker/test/sandbox-cli.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { runSandbox } from "../src/sandbox-cli.mjs";
+
+/**
+ * `pi-dispatch sandbox`, driven through its injected seams. Nothing here reaches docker or a terminal:
+ * `running` and `launch` are fakes and `isTty` is stated, so every refusal path is asserted on the
+ * machine that runs the suite rather than only on one with a daemon.
+ */
+
+/** A retention root with one retained run in it, on a real temp dir (readManifest reads it for real). */
+function retained({ jobId = "gh-1", image = "pi-job:latest", workspace, keepUntil = null } = {}) {
+	const root = mkdtempSync(join(tmpdir(), "sbx-"));
+	const dir = join(root, jobId);
+	mkdirSync(dir, { recursive: true });
+	const ws = workspace ?? join(dir, "workspace");
+	mkdirSync(ws, { recursive: true });
+	writeFileSync(join(dir, "manifest.json"), JSON.stringify({ jobId, kind: "github", image, workspace: ws, createdAt: new Date().toISOString(), keepUntil }));
+	return { root, dir, workspace: ws };
+}
+
+function capture(over = {}) {
+	const out = [];
+	const err = [];
+	return {
+		out,
+		err,
+		text: () => out.join(""),
+		errText: () => err.join(""),
+		deps: {
+			out: (s) => out.push(s),
+			err: (s) => err.push(s),
+			isTty: true,
+			running: async () => [],
+			launch: async () => ({ code: 0 }),
+			...over,
+		},
+	};
+}
+
+const envWith = (root, over = {}) => ({ VALKEY_URL: "redis://127.0.0.1:6399", PI_SANDBOX_DIR: root, ...over });
+
+test("a missing job id refuses, and never shells out to docker", async () => {
+	let asked = false;
+	const c = capture({
+		running: async () => {
+			asked = true;
+			return [];
+		},
+	});
+	assert.equal(await runSandbox([], { env: envWith("/nope"), deps: c.deps }), 1);
+	assert.match(c.errText(), /a job id is required/);
+	assert.equal(asked, false, "a typo must not cost a docker call");
+});
+
+test("without a terminal it refuses in words, rather than letting docker say 'the input device is not a TTY'", async () => {
+	const { root } = retained();
+	const c = capture({ isTty: false });
+	assert.equal(await runSandbox(["gh-1"], { env: envWith(root), deps: c.deps }), 1);
+	assert.match(c.errText(), /needs a terminal/);
+});
+
+test("a swept run names the window that expired; retention off names the variable", async () => {
+	const c1 = capture();
+	assert.equal(await runSandbox(["gh-404"], { env: envWith(mkdtempSync(join(tmpdir(), "sbx-"))), deps: c1.deps }), 1);
+	assert.match(c1.errText(), /swept after 24h/);
+
+	const c2 = capture();
+	assert.equal(await runSandbox(["gh-404"], { env: envWith(mkdtempSync(join(tmpdir(), "sbx-")), { PI_SANDBOX_RETENTION_HOURS: "0" }), deps: c2.deps }), 1);
+	assert.match(c2.errText(), /PI_SANDBOX_RETENTION_HOURS/);
+});
+
+test("an already-running sandbox is not opened twice; it points at docker attach", async () => {
+	const { root } = retained();
+	const c = capture({ running: async () => ["gh-1"] });
+	assert.equal(await runSandbox(["gh-1"], { env: envWith(root), deps: c.deps }), 1);
+	assert.match(c.errText(), /docker attach pi-sandbox-gh-1/);
+});
+
+test("a bad --publish is refused before anything launches", async () => {
+	const { root } = retained();
+	let launched = false;
+	const c = capture({
+		launch: async () => {
+			launched = true;
+			return { code: 0 };
+		},
+	});
+	assert.equal(await runSandbox(["gh-1", "--publish", "0.0.0.0:3000:3000"], { env: envWith(root), deps: c.deps }), 1);
+	assert.match(c.errText(), /invalid --publish/);
+	assert.equal(launched, false);
+});
+
+test("a good run builds a credential-free argv, launches it, and returns the shell's exit code", async () => {
+	const { root, dir, workspace } = retained();
+	let args = null;
+	const c = capture({
+		launch: async (a) => {
+			args = a.args;
+			return { code: 7 };
+		},
+	});
+	const code = await runSandbox(["gh-1", "--publish", "3000"], { env: envWith(root, { TERM: "xterm-256color" }), deps: c.deps });
+
+	assert.equal(code, 7, "the shell's exit code is the command's");
+	assert.ok(args.includes("--name=pi-sandbox-gh-1"));
+	assert.ok(args.includes("127.0.0.1:3000:3000"), "published, and bound to loopback");
+	assert.ok(args.includes(`${dir}:/job:ro`) && args.includes(`${workspace}:/workspace`));
+	assert.ok(args.includes("TMOUT=1800"), "the default 30-minute idle logout");
+	assert.ok(!args.join(" ").includes("TOKEN") && !args.join(" ").includes("API_KEY"));
+	assert.match(c.text(), /no credentials are set in this container/);
+});
+
+test("a docker that will not start is reported as such, not as a shell that exited", async () => {
+	const { root } = retained();
+	const c = capture({ launch: async () => ({ code: null, error: new Error("spawn docker ENOENT") }) });
+	assert.equal(await runSandbox(["gh-1"], { env: envWith(root), deps: c.deps }), 1);
+	assert.match(c.errText(), /could not start docker/);
+});
+
+test("--pin stamps a deadline BEFORE the shell opens, so a lost session cannot lose the pin", async () => {
+	const { root, dir } = retained();
+	const order = [];
+	const c = capture({
+		launch: async () => {
+			order.push("launch");
+			return { code: 0 };
+		},
+	});
+	await runSandbox(["gh-1", "--pin"], { env: envWith(root), deps: c.deps });
+
+	const manifest = JSON.parse(await import("node:fs").then((fs) => fs.readFileSync(join(dir, "manifest.json"), "utf8")));
+	assert.ok(manifest.keepUntil, "the pin is on disk");
+	assert.ok(Date.parse(manifest.keepUntil) > Date.now(), "and it is in the future");
+	assert.match(c.text(), /pinned gh-1 until/);
+	assert.deepEqual(order, ["launch"], "the pin landed first; the launch still happened");
+});
+
+test("--list shows what is left, how long it has, and what is running", async () => {
+	const { root } = retained({ jobId: "gh-1" });
+	retained({ jobId: "gh-2" }); // a second root; only the configured one is listed
+	const c = capture({ running: async () => ["gh-1"] });
+	assert.equal(await runSandbox(["--list"], { env: envWith(root), deps: c.deps }), 0);
+
+	assert.match(c.text(), /gh-1\s+github\s+RUNNING/);
+	assert.ok(!c.text().includes("gh-2"), "only the configured retention root is read");
+});
+
+test("--list says so when retention is off, rather than showing an empty table", async () => {
+	const c = capture();
+	const root = mkdtempSync(join(tmpdir(), "sbx-"));
+	assert.equal(await runSandbox(["--list"], { env: envWith(root, { PI_SANDBOX_RETENTION_HOURS: "0" }), deps: c.deps }), 0);
+	assert.match(c.text(), /retention is off/);
+});
+
+test("a pinned row reads as pinned, and a plain one counts down the window", async () => {
+	const soon = new Date(Date.now() + 3 * 86400000).toISOString();
+	const { root } = retained({ jobId: "gh-1", keepUntil: soon });
+	const c = capture();
+	await runSandbox(["--list"], { env: envWith(root), deps: c.deps });
+	assert.match(c.text(), /pinned, 3d left/);
+
+	const { root: root2 } = retained({ jobId: "gh-9" });
+	const c2 = capture();
+	await runSandbox(["--list"], { env: envWith(root2), deps: c2.deps });
+	assert.match(c2.text(), /24h left/);
+});

--- a/worker/test/sandbox-store.test.mjs
+++ b/worker/test/sandbox-store.test.mjs
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { listSandboxes, makeSandboxReaper, pinSandbox, readManifest, retainJobDir, SANDBOX_MANIFEST } from "../src/sandbox-store.mjs";
+
+const HOUR = 3600000;
+const DAY = 86400000;
+
+/**
+ * A fake fs recording every mutation, so retention can be asserted without a disk. Paths are plain
+ * strings keyed into one map; `files` holds written contents and `dirs` the removed/renamed history.
+ */
+function fakeFs({ files = {}, failOn = null } = {}) {
+	const calls = { removed: [], renamed: [], made: [] };
+	return {
+		calls,
+		files,
+		lstatSync(p) {
+			if (!(p in files)) throw Object.assign(new Error(`ENOENT: ${p}`), { code: "ENOENT" });
+			return { isDirectory: () => files[p] === "<dir>" };
+		},
+		mkdirSync(p, opts) {
+			calls.made.push({ p, mode: opts?.mode });
+		},
+		readdirSync(p) {
+			if (!(p in files)) throw Object.assign(new Error(`ENOENT: ${p}`), { code: "ENOENT" });
+			return files[p] === "<dir>" ? Object.keys(files).filter((k) => k.startsWith(`${p}/`) && !k.slice(p.length + 1).includes("/")).map((k) => k.slice(p.length + 1)) : [];
+		},
+		readFileSync(p) {
+			if (!(p in files)) throw Object.assign(new Error(`ENOENT: ${p}`), { code: "ENOENT" });
+			return files[p];
+		},
+		renameSync(from, to) {
+			if (failOn === "rename") throw new Error("EXDEV: cross-device link");
+			calls.renamed.push([from, to]);
+			files[to] = "<dir>";
+			delete files[from];
+		},
+		rmSync(p) {
+			calls.removed.push(p);
+			for (const k of Object.keys(files)) if (k === p || k.startsWith(`${p}/`)) delete files[k];
+		},
+		writeFileSync(p, body, opts) {
+			if (failOn === "write") throw new Error("ENOSPC");
+			files[p] = body;
+			calls.made.push({ p, mode: opts?.mode });
+		},
+	};
+}
+
+const prepared = (over = {}) => ({
+	jobDir: "/jobs/job-xyz",
+	workspace: "/jobs/job-xyz/workspace",
+	sandbox: { jobId: "gh-1", kind: "github", image: "pi-job:latest" },
+	...over,
+});
+
+test("retention renames the per-job dir and records a manifest", () => {
+	const fs = fakeFs({ files: { "/jobs/job-xyz": "<dir>" } });
+	const manifest = retainJobDir(prepared(), { sandboxDir: "/sbx", fs, now: () => Date.parse("2026-08-01T10:00:00Z") });
+
+	assert.deepEqual(fs.calls.renamed, [["/jobs/job-xyz", "/sbx/gh-1"]], "renamed, never copied");
+	assert.equal(manifest.jobId, "gh-1");
+	assert.equal(manifest.image, "pi-job:latest");
+	assert.equal(manifest.createdAt, "2026-08-01T10:00:00.000Z");
+	assert.equal(manifest.keepUntil, null, "a fresh retention is never pinned");
+	// The forge workspace lived inside jobDir, so its recorded path must follow the rename.
+	assert.equal(manifest.workspace, "/sbx/gh-1/workspace");
+	assert.equal(fs.calls.made.find((m) => m.p === "/sbx/gh-1/manifest.json")?.mode, 0o600);
+	assert.equal(fs.calls.made.find((m) => m.p === "/sbx")?.mode, 0o700, "the retention root is not world-readable");
+});
+
+test("a local job's workspace is the operator's own folder and is recorded verbatim", () => {
+	const fs = fakeFs({ files: { "/jobs/job-xyz": "<dir>" } });
+	const manifest = retainJobDir(prepared({ workspace: "/home/rob/project", sandbox: { jobId: "local-1", kind: "local", image: "pi-job:latest" } }), {
+		sandboxDir: "/sbx",
+		fs,
+	});
+	assert.equal(manifest.workspace, "/home/rob/project", "a path outside jobDir was never ours to move");
+});
+
+test("the per-job transcript copy is deleted BEFORE the rename, never carried along", () => {
+	const fs = fakeFs({ files: { "/jobs/job-xyz": "<dir>", "/jobs/job-xyz/session/current.jsonl": "{}" } });
+	retainJobDir(prepared(), { sandboxDir: "/sbx", fs });
+
+	assert.equal(fs.calls.removed[0], "/jobs/job-xyz/session", "the session copy goes first, before anything can move it");
+	assert.ok(!Object.keys(fs.files).some((k) => k.includes("session")), "no transcript survives into the retained tree");
+	// Ordering is the assertion: a delete after the rename would target a path that no longer exists.
+	assert.ok(fs.calls.removed.indexOf("/jobs/job-xyz/session") < 0 || fs.calls.renamed.length === 1);
+});
+
+test("a retry reuses the job id, and the latest attempt wins", () => {
+	const fs = fakeFs({ files: { "/jobs/job-xyz": "<dir>", "/sbx/gh-1": "<dir>", "/sbx/gh-1/manifest.json": "{\"jobId\":\"gh-1\"}" } });
+	retainJobDir(prepared(), { sandboxDir: "/sbx", fs });
+	assert.ok(fs.calls.removed.includes("/sbx/gh-1"), "the previous attempt's directory is cleared before the rename");
+	assert.deepEqual(fs.calls.renamed, [["/jobs/job-xyz", "/sbx/gh-1"]]);
+});
+
+test("any retention failure falls back to deleting the job dir -- retention never leaves debris", () => {
+	const fs = fakeFs({ files: { "/jobs/job-xyz": "<dir>" }, failOn: "rename" });
+	const logged = [];
+	const manifest = retainJobDir(prepared(), { sandboxDir: "/sbx", fs, log: (e, d) => logged.push([e, d]) });
+
+	assert.equal(manifest, null, "a null tells the caller nothing was retained");
+	assert.ok(fs.calls.removed.includes("/jobs/job-xyz"), "the job dir is removed, exactly as cleanup would have");
+	assert.equal(logged.at(-1)?.[0], "sandbox_retain_failed");
+});
+
+test("no sandbox stamp and no sandboxDir both mean: delete, as before", () => {
+	for (const [opts, why] of [
+		[{ sandboxDir: null }, "retention unconfigured"],
+		[{ sandboxDir: "/sbx" }, "an unwired prepare stamped nothing"],
+	]) {
+		const fs = fakeFs({ files: { "/jobs/job-xyz": "<dir>" } });
+		const p = why === "retention unconfigured" ? prepared() : prepared({ sandbox: undefined });
+		assert.equal(retainJobDir(p, { ...opts, fs }), null);
+		assert.ok(fs.calls.removed.includes("/jobs/job-xyz"), why);
+		assert.equal(fs.calls.renamed.length, 0);
+	}
+});
+
+test("readManifest and listSandboxes are filename-keyed, and skip what cannot be read", () => {
+	const fs = fakeFs({
+		files: {
+			"/sbx": "<dir>",
+			"/sbx/gh-1": "<dir>",
+			"/sbx/gh-1/manifest.json": JSON.stringify({ jobId: "gh-1", createdAt: "2026-08-01T00:00:00Z" }),
+			"/sbx/gh-2": "<dir>",
+			"/sbx/gh-2/manifest.json": "{ not json",
+			"/sbx/gh-3": "<dir>",
+			"/sbx/gh-3/manifest.json": JSON.stringify({ jobId: "gh-3", createdAt: "2026-08-02T00:00:00Z" }),
+		},
+	});
+	assert.equal(readManifest({ sandboxDir: "/sbx", jobId: "gh-1", fs }).dir, "/sbx/gh-1");
+	assert.equal(readManifest({ sandboxDir: "/sbx", jobId: "nope", fs }), null);
+
+	const rows = listSandboxes({ sandboxDir: "/sbx", fs });
+	assert.deepEqual(rows.map((r) => r.jobId), ["gh-3", "gh-1"], "newest first; the unparseable one is skipped");
+	assert.deepEqual(listSandboxes({ sandboxDir: null, fs }), []);
+});
+
+test("a pin is a TIMESTAMP, never a boolean -- there is no keep-forever", () => {
+	const fs = fakeFs({ files: { "/sbx/gh-1/manifest.json": JSON.stringify({ jobId: "gh-1", createdAt: "2026-08-01T00:00:00Z" }) } });
+	const at = Date.parse("2026-08-01T12:00:00Z");
+	const result = pinSandbox({ sandboxDir: "/sbx", jobId: "gh-1", pinDays: 7, fs, now: () => at });
+
+	assert.equal(result.pinned, true);
+	assert.equal(result.keepUntil, new Date(at + 7 * DAY).toISOString());
+	const written = JSON.parse(fs.files["/sbx/gh-1/manifest.json"]);
+	assert.equal(written.keepUntil, result.keepUntil);
+	assert.equal(written.jobId, "gh-1", "the rest of the manifest survives the rewrite");
+	assert.equal(written.dir, undefined, "the derived dir is not persisted back into the file");
+
+	assert.deepEqual(pinSandbox({ sandboxDir: "/sbx", jobId: "gone", fs, pinDays: 7 }), { pinned: false, reason: "absent" });
+});
+
+/** A retention root holding `entries`, each `{ createdAt?, keepUntil? }` or the string "<bad>". */
+function sandboxDirWith(entries) {
+	const files = { "/sbx": "<dir>" };
+	for (const [id, body] of Object.entries(entries)) {
+		files[`/sbx/${id}`] = "<dir>";
+		if (body !== "<bad>") files[`/sbx/${id}/${SANDBOX_MANIFEST}`] = JSON.stringify({ jobId: id, ...body });
+	}
+	return fakeFs({ files });
+}
+
+test("the sweep expires on the manifest's createdAt, not on mtime a live sandbox would move", async () => {
+	const at = Date.parse("2026-08-02T00:00:00Z");
+	const fs = sandboxDirWith({
+		old: { createdAt: new Date(at - 30 * HOUR).toISOString() },
+		fresh: { createdAt: new Date(at - 2 * HOUR).toISOString() },
+	});
+	const logged = [];
+	await makeSandboxReaper({ sandboxDir: "/sbx", retentionHours: 24, fs, now: () => at, log: (e, d) => logged.push([e, d]) })();
+
+	assert.deepEqual(fs.calls.removed, ["/sbx/old"]);
+	assert.deepEqual(logged, [["reaped_sandbox", { entry: "old", reason: "window" }]]);
+});
+
+test("a pin outlives the base window, and expires on its own deadline", async () => {
+	const at = Date.parse("2026-08-10T00:00:00Z");
+	const fs = sandboxDirWith({
+		pinned: { createdAt: new Date(at - 200 * HOUR).toISOString(), keepUntil: new Date(at + DAY).toISOString() },
+		lapsed: { createdAt: new Date(at - 200 * HOUR).toISOString(), keepUntil: new Date(at - DAY).toISOString() },
+	});
+	await makeSandboxReaper({ sandboxDir: "/sbx", retentionHours: 24, fs, now: () => at })();
+	assert.deepEqual(fs.calls.removed, ["/sbx/lapsed"], "a live pin survives; a lapsed one does not linger");
+});
+
+test("retention off sweeps everything unpinned, and needs no special case to do it", async () => {
+	const at = Date.parse("2026-08-02T00:00:00Z");
+	const fs = sandboxDirWith({
+		recent: { createdAt: new Date(at - 60000).toISOString() },
+		pinned: { createdAt: new Date(at - 60000).toISOString(), keepUntil: new Date(at + DAY).toISOString() },
+	});
+	// 0 is the feature being OFF -- the opposite of the log/session sentinels, where 0 is keep-forever.
+	await makeSandboxReaper({ sandboxDir: "/sbx", retentionHours: 0, fs, now: () => at })();
+	assert.deepEqual(fs.calls.removed, ["/sbx/recent"], "turning retention off also cleans up what it retained");
+});
+
+test("a directory whose sandbox is RUNNING is never swept out from under the operator", async () => {
+	const at = Date.parse("2026-08-02T00:00:00Z");
+	const fs = sandboxDirWith({
+		"gh-1": { createdAt: new Date(at - 99 * HOUR).toISOString() },
+		"gh-2": { createdAt: new Date(at - 99 * HOUR).toISOString() },
+	});
+	await makeSandboxReaper({ sandboxDir: "/sbx", retentionHours: 24, fs, now: () => at, listRunning: async () => ["gh-1"] })();
+	assert.deepEqual(fs.calls.removed, ["/sbx/gh-2"], "the live one stays, however old it is");
+});
+
+test("a docker lookup that FAILS skips the whole sweep rather than sweeping blind", async () => {
+	const at = Date.parse("2026-08-02T00:00:00Z");
+	const fs = sandboxDirWith({ ancient: { createdAt: "2020-01-01T00:00:00Z" } });
+	const logged = [];
+	await makeSandboxReaper({
+		sandboxDir: "/sbx",
+		retentionHours: 24,
+		fs,
+		now: () => at,
+		listRunning: async () => {
+			throw new Error("daemon down");
+		},
+		log: (e, d) => logged.push([e, d]),
+	})();
+
+	assert.deepEqual(fs.calls.removed, [], "a directory kept one boot too long is the cheaper mistake");
+	assert.deepEqual(logged, [["sandbox_reaper_skipped", { reason: "daemon down" }]]);
+});
+
+test("an entry with no usable manifest is reaped -- it can never be resurrected", async () => {
+	const at = Date.parse("2026-08-02T00:00:00Z");
+	const fs = sandboxDirWith({ bad: "<bad>", undated: {} });
+	const logged = [];
+	await makeSandboxReaper({ sandboxDir: "/sbx", retentionHours: 24, fs, now: () => at, log: (e, d) => logged.push([e, d]) })();
+
+	assert.deepEqual(fs.calls.removed.sort(), ["/sbx/bad", "/sbx/undated"]);
+	assert.deepEqual(logged.map((l) => l[1].reason).sort(), ["no-created-at", "no-manifest"]);
+});
+
+test("a symlinked entry is refused by lstat rather than followed onto the host", async () => {
+	const at = Date.parse("2026-08-02T00:00:00Z");
+	const fs = sandboxDirWith({ real: { createdAt: new Date(at - 99 * HOUR).toISOString() } });
+	fs.files["/sbx/link"] = "<symlink>"; // lstatSync reports isDirectory() false, as it would for a link
+	await makeSandboxReaper({ sandboxDir: "/sbx", retentionHours: 24, fs, now: () => at })();
+	assert.ok(fs.calls.removed.includes("/sbx/link"), "a non-directory entry is removed, never descended into");
+});
+
+test("the sweep NEVER throws: a missing root, an unreadable entry, an unlink failure", async () => {
+	const at = Date.now();
+	await makeSandboxReaper({ sandboxDir: "/nope", retentionHours: 24, fs: fakeFs({ files: {} }), now: () => at })();
+
+	const fs = sandboxDirWith({ a: { createdAt: "2020-01-01T00:00:00Z" }, b: { createdAt: "2020-01-01T00:00:00Z" } });
+	fs.rmSync = (p) => {
+		if (p === "/sbx/a") throw new Error("EPERM");
+		fs.calls.removed.push(p);
+	};
+	const logged = [];
+	await makeSandboxReaper({ sandboxDir: "/sbx", retentionHours: 24, fs, now: () => at, log: (e, d) => logged.push([e, d]) })();
+	assert.deepEqual(fs.calls.removed, ["/sbx/b"], "one bad entry cannot abort the rest of the sweep");
+	assert.ok(logged.some(([e, d]) => e === "sandbox_reaper_skipped" && d.entry === "a"));
+
+	// And with no root configured at all it is simply inert.
+	await makeSandboxReaper({ sandboxDir: null, retentionHours: 24 })();
+});

--- a/worker/test/sandbox.test.mjs
+++ b/worker/test/sandbox.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ISOLATION_FLAGS } from "../src/docker-run.mjs";
+import { MINTED_TOKEN_VARS } from "../src/forges.mjs";
+import { buildSandboxRunArgs, listRunningSandboxes, parsePublish, resolveSandbox, sandboxContainerName, SANDBOX_NAME_PREFIX } from "../src/sandbox.mjs";
+
+const base = {
+	image: "pi-job:pinned",
+	name: "pi-sandbox-abc",
+	workspace: "/srv/sandboxes/abc/workspace",
+	jobDir: "/srv/sandboxes/abc",
+};
+
+test("an operator session carries every isolation flag -- the boundary is the same one", () => {
+	const args = buildSandboxRunArgs(base);
+	const s = args.join(" ");
+	// Imported, never retyped: a flag added to the boundary must reach BOTH container shapes, and a test
+	// with its own copy of the list would keep passing while the sandbox quietly lost one.
+	for (const flag of ISOLATION_FLAGS) {
+		assert.ok(args.includes(flag), `missing isolation flag: ${flag}`);
+	}
+	assert.ok(args.includes("--memory=4g") && args.includes("--cpus=2"), "resource limits apply to a sandbox too");
+	assert.ok(!s.includes("--ipc=host"), "--ipc=host shares the host IPC namespace");
+	assert.ok(!s.includes("--privileged"), "--privileged");
+	assert.ok(!s.includes("--pull=missing") && !s.includes("--pull=always"), "no argv may re-enable the fetch");
+});
+
+test("it is an interactive shell: -i -t, bash as the entrypoint, image still last", () => {
+	const args = buildSandboxRunArgs(base);
+	assert.ok(args.includes("-i") && args.includes("-t"), "an operator session needs a TTY");
+	const entry = args.indexOf("--entrypoint");
+	assert.ok(entry >= 0 && args[entry + 1] === "bash", "the runner entrypoint is replaced by a shell");
+	assert.equal(args.at(-1), base.image, "the image is the final argv element");
+	assert.ok(entry < args.length - 1, "--entrypoint must precede the image");
+});
+
+test("NO credential of any kind reaches a resurrected sandbox", () => {
+	const args = buildSandboxRunArgs({ ...base, term: "xterm-256color", idleSeconds: 1800 });
+	const s = args.join(" ");
+	// Every forge's minted variable names, from the table itself -- so a forge added later cannot leak in
+	// through a hand-maintained list that nobody updated.
+	for (const name of MINTED_TOKEN_VARS) {
+		assert.ok(!s.includes(name), `a sandbox must not carry ${name}`);
+	}
+	for (const name of ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN", "OPENAI_API_KEY", "PI_PROVIDER", "PI_MODEL"]) {
+		assert.ok(!s.includes(name), `a sandbox must not carry ${name}`);
+	}
+	// The whole env, positively: exactly the two terminal variables and nothing else.
+	const envValues = args.filter((a, i) => args[i - 1] === "-e");
+	assert.deepEqual(envValues.sort(), ["TERM=xterm-256color", "TMOUT=1800"]);
+});
+
+test("the mounts are the run's own, and only those", () => {
+	const args = buildSandboxRunArgs(base);
+	assert.ok(args.includes("/srv/sandboxes/abc:/job:ro"), "/job stays read-only, exactly as the run had it");
+	assert.ok(args.includes("/srv/sandboxes/abc/workspace:/workspace"), "/workspace is writable");
+	assert.ok(!args.some((a) => a.includes(":/outbox")), "no chain channel: no agent is running");
+	assert.ok(!args.some((a) => a.includes(":/session")), "no transcript: it is not carried into a sandbox");
+	assert.ok(!args.some((a) => a.includes("/opt/pi-global")), "no operator overlay: pi is not running");
+});
+
+test("an unset TERM and a disabled idle timeout emit nothing rather than empty strings", () => {
+	const args = buildSandboxRunArgs({ ...base, term: undefined, idleSeconds: 0 });
+	assert.ok(!args.includes("-e"), "no env pair at all when both are absent");
+	assert.ok(!args.join(" ").includes("TMOUT"), "idleSeconds 0 disables the idle logout");
+});
+
+test("the name namespace sits OUTSIDE the boot reaper's pi-job- filter", () => {
+	const name = sandboxContainerName("gh-12345");
+	assert.equal(name, "pi-sandbox-gh-12345");
+	// docker's `name=` filter is a SUBSTRING match, so this is the whole guarantee that a worker restart
+	// does not `docker rm -f` the shell an operator is sitting in.
+	assert.ok(!name.includes("pi-job-"), "a sandbox name must never contain the reaped prefix");
+	assert.ok(name.startsWith(SANDBOX_NAME_PREFIX));
+	// A scheduled id carries a colon, which is not legal in a docker name.
+	assert.equal(sandboxContainerName("repeat:sched:100"), "pi-sandbox-repeat_sched_100");
+});
+
+test("--publish is always bound to loopback, and an explicit bind address is refused", () => {
+	assert.deepEqual(parsePublish(["3000"]), ["-p", "127.0.0.1:3000:3000"]);
+	assert.deepEqual(parsePublish(["8080:3000"]), ["-p", "127.0.0.1:8080:3000"]);
+	assert.deepEqual(parsePublish(["3000", "9229"]), ["-p", "127.0.0.1:3000:3000", "-p", "127.0.0.1:9229:9229"]);
+	for (const bad of ["0.0.0.0:3000:3000", "3000:3000:3000", "0", "70000", "3000/tcp", "", "abc", "-1"]) {
+		assert.throws(() => parsePublish([bad]), /invalid --publish/, `must refuse ${JSON.stringify(bad)}`);
+	}
+	// Refusing is a config error, so the CLI's entry maps it to the policy exit code rather than retrying.
+	assert.throws(() => parsePublish(["0.0.0.0:3000:3000"]), (e) => e.piDispatchConfig === true);
+});
+
+test("a published port lands in the argv ahead of the image", () => {
+	const args = buildSandboxRunArgs({ ...base, publish: parsePublish(["3000"]) });
+	assert.ok(args.includes("127.0.0.1:3000:3000"));
+	assert.equal(args.at(-1), base.image);
+});
+
+test("resolveSandbox names the cause: retention off, swept, imageless, workspace gone", () => {
+	const manifest = { jobId: "j1", kind: "github", image: "pi-job:latest", workspace: "/w", createdAt: "2026-08-01T00:00:00Z" };
+	const fsWith = (m) => ({ readFileSync: () => JSON.stringify(m) });
+	const missing = { readFileSync: () => { throw new Error("ENOENT"); } };
+
+	assert.match(resolveSandbox({ jobId: "j1", sandboxDir: "/s", retentionHours: 0, fs: missing }).message, /PI_SANDBOX_RETENTION_HOURS/);
+	assert.match(resolveSandbox({ jobId: "j1", sandboxDir: "/s", retentionHours: 24, fs: missing }).message, /swept after 24h/);
+	assert.equal(resolveSandbox({ jobId: "", sandboxDir: "/s", retentionHours: 24, fs: missing }).refused, "no-job-id");
+	assert.equal(resolveSandbox({ jobId: "j1", sandboxDir: "/s", retentionHours: 24, fs: fsWith({ ...manifest, image: null }) }).refused, "no-image");
+
+	const gone = resolveSandbox({ jobId: "j1", sandboxDir: "/s", retentionHours: 24, fs: fsWith(manifest), fileExists: () => false });
+	assert.equal(gone.refused, "workspace-gone");
+	assert.match(gone.message, /\/w/, "the missing path IS the diagnosis, so it must appear");
+});
+
+test("resolveSandbox yields the manifest and the container name when the run is intact", () => {
+	const manifest = { jobId: "j1", kind: "local", image: "pi-job:latest", workspace: "/folder", createdAt: "2026-08-01T00:00:00Z" };
+	const resolved = resolveSandbox({
+		jobId: "j1",
+		sandboxDir: "/s",
+		retentionHours: 24,
+		fs: { readFileSync: () => JSON.stringify(manifest) },
+		fileExists: () => true,
+	});
+	assert.equal(resolved.refused, undefined);
+	assert.equal(resolved.name, "pi-sandbox-j1");
+	assert.equal(resolved.manifest.image, "pi-job:latest");
+	assert.equal(resolved.manifest.dir, "/s/j1", "the retained dir is what gets mounted /job:ro");
+});
+
+test("listRunningSandboxes returns ids, and THROWS rather than reporting an empty set it cannot vouch for", async () => {
+	const ids = await listRunningSandboxes({
+		execFn: async () => ({ stdout: "pi-sandbox-gh-1\npi-job-gh-2\n\npi-sandbox-local-3\n" }),
+	});
+	assert.deepEqual(ids, ["gh-1", "local-3"], "prefix stripped, and a job container is not a sandbox");
+
+	// The distinction the reaper depends on: it deletes directories, so "could not ask docker" must not
+	// arrive looking like "nothing is running".
+	await assert.rejects(() => listRunningSandboxes({ execFn: async () => { throw new Error("daemon down"); } }), /daemon down/);
+});

--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -31,7 +31,7 @@ function fakeHost(overrides = {}) {
 // Drive startWorker with injected fakes and capture the exact object handed to createWorker
 // (deps are nested under `deps`). No real Redis: createWorkerFn is faked. The real ioredis client
 // startWorker constructs via makeRedisClient is torn down so it leaves no dangling handle.
-async function runStart({ env = {}, makeAuth, makeHost, makeGitLabAuth, makeGitLabHost, makeReaper, makeLogSink, makeRecordWriter, makeLogReaper, makeRunContainer, order } = {}) {
+async function runStart({ env = {}, makeAuth, makeHost, makeGitLabAuth, makeGitLabHost, makeReaper, makeLogSink, makeRecordWriter, makeLogReaper, makeSandboxReaper, makeRunContainer, order } = {}) {
 	const calls = [];
 	const registered = {};
 	const createWorkerFn = (arg) => {
@@ -76,6 +76,17 @@ async function runStart({ env = {}, makeAuth, makeHost, makeGitLabAuth, makeGitL
 			logReaperCalls.push(args);
 			return () => {};
 		});
+	// The sandbox reaper is faked for the SAME reason as makeReaper above, and it is the stronger case of
+	// the two: this one asks docker which sandboxes are live before it sweeps, so a real one here would
+	// shell out to `docker ps` on every wiring test -- and block for as long as an unreachable daemon takes
+	// to answer. Ordering/threading tests inject their own.
+	const sandboxReaperCalls = [];
+	const sandboxReaper =
+		makeSandboxReaper ??
+		((args) => {
+			sandboxReaperCalls.push(args);
+			return async () => {};
+		});
 
 	// The container factory is faked for the same reason as the run-history ones: the wiring tests assert
 	// what boot HANDS it (image, overlay, staged packages), never a docker launch. It records its args and
@@ -104,6 +115,7 @@ async function runStart({ env = {}, makeAuth, makeHost, makeGitLabAuth, makeGitL
 			makeLogSink: logSink,
 			makeRecordWriter: recordWriter,
 			makeLogReaper: logReaper,
+			makeSandboxReaper: sandboxReaper,
 			makeRunContainer: runContainerFactory,
 			makeImagePreflight: (args) => (imagePreflightCalls.push(args), async () => ({ ok: true })),
 			...(makeGitLabAuth ? { makeGitLabAuth } : {}),
@@ -127,7 +139,7 @@ async function runStart({ env = {}, makeAuth, makeHost, makeGitLabAuth, makeGitL
 	});
 	// Expose the registration map under both names: `handlers` for the completed/failed handler tests,
 	// `registered` for the scheduler stall-guard test. Same object, one capture path.
-	return { captured, deps: captured?.deps, logs, handlers: registered, registered, logSinkCalls, recordWriterCalls, logReaperCalls, runContainerCalls, imagePreflightCalls };
+	return { captured, deps: captured?.deps, logs, handlers: registered, registered, logSinkCalls, recordWriterCalls, logReaperCalls, sandboxReaperCalls, runContainerCalls, imagePreflightCalls };
 }
 
 // Capture the JSON log lines a synchronous fn emits via process.stdout.write, then restore it.
@@ -386,6 +398,44 @@ test("run-history: the log reaper sweeps aged history BEFORE the worker starts d
 	assert.deepEqual(order, ["reapLogs", "createWorker"], "the log reaper must sweep before the worker is created");
 	assert.equal(reaperArgs.logsDir, "/tmp/pi-logs", "the log reaper must receive config.logsDir");
 	assert.equal(reaperArgs.retentionDays, 7, "the log reaper must receive config.logRetentionDays");
+});
+
+test("sandbox: the retention sweep runs BEFORE the worker drains, and is handed a way to ask docker", { skip }, async () => {
+	const order = [];
+	let reaperArgs;
+	const makeAuth = async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" });
+	const makeSandboxReaper = (args) => {
+		reaperArgs = args;
+		return async () => {
+			order.push("reapSandboxes");
+		};
+	};
+	const { deps } = await runStart({
+		env: { PI_SANDBOX_DIR: "/tmp/pi-sbx", PI_SANDBOX_RETENTION_HOURS: "6", PI_JOB_IMAGE: "pi-job:pinned" },
+		makeAuth,
+		makeHost: () => fakeHost(),
+		makeSandboxReaper,
+		order,
+	});
+	assert.deepEqual(order, ["reapSandboxes", "createWorker"], "retained directories are swept before the worker takes a job");
+	assert.equal(reaperArgs.sandboxDir, "/tmp/pi-sbx");
+	assert.equal(reaperArgs.retentionHours, 6);
+	// The one thing this reaper needs that its siblings do not: without it the sweep is blind and can
+	// delete a bind mount out from under a shell an operator is sitting in.
+	assert.equal(typeof reaperArgs.listRunning, "function", "the sweep must be able to ask which sandboxes are live");
+	assert.equal(typeof deps.cleanup, "function", "teardown is the retention-aware closure, not the bare rm");
+});
+
+test("sandbox: retention off still wires a cleanup, and it is the delete-only one", { skip }, async () => {
+	const makeAuth = async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" });
+	const { deps, logs } = await runStart({
+		env: { PI_SANDBOX_RETENTION_HOURS: "0" },
+		makeAuth,
+		makeHost: () => fakeHost(),
+	});
+	assert.equal(typeof deps.cleanup, "function");
+	// Boot says which way it is configured, so "why was nothing retained" is answerable from the log alone.
+	assert.equal(logs.find((l) => l.event === "worker_started")?.sandboxRetentionHours, 0);
 });
 
 // REQ-GLOBAL-PI-OVERLAY staged packages. The overlay dir EXISTS (config refuses a missing one at load)


### PR DESCRIPTION
Closes #55.

Maybe 5% of runs end on a question the run record cannot answer: *does the thing it built actually work?* Three separate facts made that unanswerable, and only one of them was incidental — `--rm` disposes the container at exit, stdin is `ignore` with no TTY so nothing could be typed into a live run either, and for a forge job `cleanup` deletes the directory the clone lives in. The first two are load-bearing and do not move.

So the container is not kept alive. It is made **reproducible**.

```bash
pi-dispatch sandbox --list                    # what is still re-openable, and for how long
pi-dispatch sandbox gh-12345 --publish 3000   # a shell in that run's workspace
```

Same image, same workspace, same isolation flags, **no credentials at all**. Also on the panel's RUN_DETAIL screen, key `b`. The job container is untouched — still `--rm`, no TTY, no published port, gone at exit — and with `PI_SANDBOX_RETENTION_HOURS=0` nothing is retained and teardown is the `rm -rf` it always was, so a deployment that wants none of this keeps today's behaviour exactly rather than a near-equivalent of it.

### Four decisions worth reviewing

**The isolation flags are inherited, not re-listed.** `buildSandboxRunArgs` calls `buildDockerRunArgs` through its `extraFlags` seam — documented since the beginning, unused in production until now — so `ISOLATION_FLAGS`, `--memory` and `--cpus` reach this container *by construction*. A leaner hand-written argv would be a second place for the boundary to live, and the copy that missed the next flag would be the one nobody was looking at. The test imports the array rather than retyping it.

**"No credentials" is structural, not careful.** `buildContainerEnv` is deliberately not reused: it writes the mint into that forge's variable names and *throws* when no provider credential resolves, so it has no credential-free output to produce. The sandbox env is `TERM` and `TMOUT`, and the test asserts against `MINTED_TOKEN_VARS` so a forge added later cannot leak in through a hand-maintained list.

**The retention unit is the per-job directory, for every job kind** — not just forge workspaces. One code path, and a local run keeps its `/job` inputs and `/outbox` too. The per-job `/session` copy is deleted **before** retention: `--pin` can extend this window and cannot extend `PI_SESSIONS_TTL_DAYS`, so carrying a transcript across would end-run that policy rather than merely weaken it.

**Expiry reads the manifest's `createdAt`, never mtime.** `makeLogReaper` calls mtime "the authority" and is right about an append-once log file. An operator working inside a sandbox moves it, so the window would never close — for exactly the directories most likely to be large.

### Three inversions that will look like bugs later, so they are on the record

**`PI_SANDBOX_RETENTION_HOURS=0` means OFF**, the opposite of `PI_LOG_RETENTION_DAYS` and `PI_SESSIONS_TTL_DAYS`, where `0` means keep-forever. There is deliberately no keep-forever value — one repository clone per run with no ceiling is a disk bomb. It also sweeps what an earlier setting retained, so turning it off turns it off.

**`listRunningSandboxes` throws when docker cannot be asked.** "None are running" and "I could not find out" must not arrive as the same empty array in front of an `rm -rf`; the reaper skips the whole sweep on a failed lookup. The CLI, which only draws a column, degrades on its own. It is also the one docker call here with a timeout, because it sits in front of a worker that has not started draining.

**`pi-sandbox-*` is outside the boot reaper's `name=pi-job-` filter** because docker matches that as a *substring* — a disjoint namespace, not an exemption granted in the reaper's code. That is what lets an operator's shell survive a worker restart, and a test pins it.

### The panel launches in place, and how that is possible

`ExtensionUIContext` has no terminal handoff — `select`/`confirm`/`input`/`notify`/`onRawInput`/`custom` and nothing else, and `execCommand` captures stdout rather than inheriting it. But the `custom` factory hands the component the real `TUI`, and `TUI.stop()`/`start()` are a symmetric suspend/resume pair that pi uses itself to launch `$EDITOR`. `ProcessTerminal.start`'s own comment — *"Refresh terminal dimensions — they may be stale after suspend/resume (SIGWINCH is lost while process is stopped)"* — is a sentence about being suspended across an external program.

So `b` does `tui.stop()` → spawn → `tui.start()` + `requestRender(true)`, with `start` in a `finally` so a failed launch cannot leave the panel suspended. `spawn`, never `spawnSync`, for the Windows console race pi's own comment records. Two things this corrected: pi renders **inline**, not on the alternate screen (`grep 1049` across pi-tui finds nothing), and because the component holds `tui` there is no overlay teardown — no `done({action})`, no reopen loop.

### Specs and SECURITY.md

`CONST-ISOLATION-CONTAINER-PER-JOB` is **amended**, in the entry rather than somewhere quieter. Its carve-out covers *pi running on the host* and its Acceptance is scoped *"Given any job"*, so neither reaches a container that is not a job container. Three of the carve-out's four tests are met and **the fourth explicitly is not** — a forge workspace is whatever a run made of an issue anyone could open. That is recorded as the accepted trade, on the grounds that opening a cap-dropped, resource-bounded, credential-free shell next to it is the same act every maintainer already performs when they check out a stranger's pull request.

New `INT-SANDBOX-CONTRACT` as a **sibling** of `INT-CONTAINER-RUNTIME-CONTRACT` — that one still says "No TTY (`-it` absent)" and still means it; IDs are permanent addresses, and `INT-GITLAB-PAYLOAD-SUBSET` set this precedent. Plus `REQ-RESURRECTABLE-SANDBOX`, `DES-SANDBOX-IS-A-FRESH-CONTAINER` (with the three alternatives #55 rejects: keeping the container alive, `docker exec`, `docker commit`), and `OQ-016`.

`SECURITY.md`'s trust table claimed `/outbox` was the container's **only** channel back to the host. That was already untrue — `INT-SESSION-STORE-CONTRACT` calls `/session` "the second agent-authored channel" and the table was never updated when it landed. Both rows are corrected, and the operator TTY is added as a third, the first one an operator opens rather than the agent.

### Two pre-existing findings, deliberately not fixed here

**`piVersion` never reaches the preparer.** `index.mjs:115` wraps `prepareWorkspace` as `(j, t) => deps.prepareWorkspace(j, t, { queueJobId: job.id })` — a two-arg wrapper. The processor calls it with `{ piVersion }`, which the wrapper drops, so the resumable-session version-mismatch cold start cannot fire in production. From #48; fixing it changes resume behaviour and wants its own change and its own test.

**A `sha-gone` refusal leaks its jobDir.** `prepareGithubWorkspace` returns `{ outcome: "policy", reason: "sha-gone" }` with no `jobDir`, so `cleanup`'s guard no-ops and the `mkdtemp` directory stays. Unrelated to retention — it predates it — but adjacent enough to be worth naming.

### Verification

**1387 tests, 0 failures, 9 skipped** (45 new). `wiring.test.mjs` and the cron integration test need a live Valkey and were not run; both behave identically on `main`.

**Not run end-to-end.** There is no docker daemon on the machine this was built on, so every live step is unrun: opening a real sandbox, `capsh --print` showing no capabilities, `env` showing no token, the published port, and the panel handoff. Same honesty as #65 and #63. The panel handoff in particular is `OQ-016` — verified by reading the pinned pi and by pi's own use of the same pair, not by having run it — and it is the first thing worth checking by hand.

`image/verify-image.sh` gains a `bash` check: without it, a third-party image named in `run.image` fails `--entrypoint bash` at exit 127, which is precisely the "fails silently or late" class that checklist exists for.
