### PR TITLE
Release pi-dispatch 0.4.0, and make release notes readable in five seconds

### DIFF
--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -1,24 +1,47 @@
 /**
- * AI-written GitHub Release notes for `@edgehero/pi-dispatch-admin`.
+ * AI-written GitHub Release notes, for whichever artifact is being released.
  *
- * Reads the commit list (COMMITS), the version (VERSION), and the key (ANTHROPIC_API_KEY) from the
- * environment, asks Claude for concise, grouped Markdown notes, and prints them to stdout. Exits NON-ZERO on
- * any failure so the release workflow falls back to a plain commit list — a missing key or a flaky API never
- * blocks the release. Model is overridable via RELEASE_MODEL (default: a current Sonnet).
+ * Reads the commit list (COMMITS), the version (VERSION), the subject (PRODUCT, PRODUCT_DESC) and the key
+ * (ANTHROPIC_API_KEY) from the environment, asks Claude for notes, and prints them to stdout. Exits
+ * NON-ZERO on any failure so the release workflow falls back to a plain commit list — a missing key or a
+ * flaky API never blocks a release. Model is overridable via RELEASE_MODEL (default: a current Sonnet).
+ *
+ * PRODUCT is READ rather than hard-coded because two workflows call this script: release.yml ships the
+ * admin extension (`admin-v*`) and repo-release.yml ships the whole tool (`v*`). It named the extension
+ * unconditionally, so every tool release asked the model to describe the operator extension and then
+ * handed it repo-wide commits to describe it with. The name is the caller's fact, not this file's.
+ *
+ * THE LENGTH CEILING IS IMPOSED HERE, NOT REQUESTED IN THE PROMPT. These notes are read in the few seconds
+ * between seeing a tag and deciding whether to upgrade; asking for "terse bullet points" produced 694 words
+ * of prose, section headings and a config sample at v0.3.0. So the prompt asks for the shape and `tighten`
+ * then enforces it — a prompt that asks for brevity is a request, and a slice is a guarantee. Detail is not
+ * lost, it is relocated: the workflow appends a compare link, which is what lets these stay short.
  */
+const MAX_BULLETS = 5;
+
 const key = process.env.ANTHROPIC_API_KEY;
 const commits = (process.env.COMMITS || "").trim();
 const version = process.env.VERSION || "";
+const product = process.env.PRODUCT || "pi-dispatch";
+const productDesc = process.env.PRODUCT_DESC || "a self-hosted service that runs pi coding-agent jobs";
 const model = process.env.RELEASE_MODEL || "claude-sonnet-5";
 
 if (!key) { console.error("release-notes: ANTHROPIC_API_KEY not set"); process.exit(1); }
 if (!commits) { console.error("release-notes: no commits provided"); process.exit(1); }
 
 const prompt = [
-	`Write GitHub Release notes in Markdown for \`@edgehero/pi-dispatch-admin\` ${version} — the operator`,
-	`extension (a pi coding-agent extension) for the pi-dispatch self-hosted agent service.`,
-	`Group changes under short bold headings (e.g. **Features**, **Fixes**, **Docs**) where relevant, as terse`,
-	`user-facing bullet points — not a raw commit dump. Drop chore/CI-only noise. No title line, no preamble.`,
+	`Write GitHub Release notes in Markdown for ${product} ${version} — ${productDesc}.`,
+	``,
+	`Someone reads these for about five seconds and decides whether to upgrade. Write for that reader.`,
+	``,
+	`Shape, exactly:`,
+	`- One opening line, bold, saying what this release IS in at most 20 words. Never "this release contains".`,
+	`- Then at most ${MAX_BULLETS} bullets, one line and at most 20 words each, most important first.`,
+	`- A bullet names a user-visible change, not a commit. Fold related commits into one bullet.`,
+	`- If something is opt-in or changes nothing unless configured, say so in the bullet — briefly.`,
+	`- Drop CI, chores, refactors, and docs-only or spec-only commits entirely.`,
+	``,
+	`No title, no preamble, no headings, no code blocks, no sub-bullets, no closing summary.`,
 	``,
 	`Commits since the last release:`,
 	commits,
@@ -29,7 +52,9 @@ try {
 	res = await fetch("https://api.anthropic.com/v1/messages", {
 		method: "POST",
 		headers: { "content-type": "application/json", "x-api-key": key, "anthropic-version": "2023-06-01" },
-		body: JSON.stringify({ model, max_tokens: 1200, messages: [{ role: "user", content: prompt }] }),
+		// Sized to the shape above rather than to the model's appetite: a headline and five one-line bullets
+		// do not need 1200 tokens, and a budget that cannot fit an essay cannot produce one.
+		body: JSON.stringify({ model, max_tokens: 400, messages: [{ role: "user", content: prompt }] }),
 	});
 } catch (err) {
 	console.error("release-notes: request failed:", err?.message ?? err);
@@ -42,4 +67,36 @@ if (!res.ok) {
 const data = await res.json();
 const text = data?.content?.find?.((b) => b.type === "text")?.text;
 if (!text) { console.error("release-notes: no text in response"); process.exit(1); }
-process.stdout.write(`${text.trim()}\n`);
+
+const notes = tighten(text);
+// An empty result means the model answered in a shape with nothing left after tightening (all headings, or
+// a fenced block and nothing else). Non-zero hands the workflow its commit-list fallback, which is worse
+// prose but is at least true — silently publishing an empty release body is the one outcome to avoid.
+if (notes === "") { console.error("release-notes: nothing left after tightening"); process.exit(1); }
+process.stdout.write(`${notes}\n`);
+
+/**
+ * The ceiling, imposed rather than asked for: drop fenced blocks and headings, keep the opening line and
+ * the first MAX_BULLETS top-level bullets, and stop at the first unindented prose line that follows them.
+ *
+ * Truncating the TAIL is the right thing to lose, because the prompt orders bullets most-important-first —
+ * so a model that ignores the count still yields the changes that mattered, in order, and the compare link
+ * the workflow appends carries anyone who wants the rest.
+ */
+function tighten(markdown) {
+	const stripped = markdown
+		.replace(/```[\s\S]*?```/g, "")
+		.replace(/^[ \t]*#{1,6} .*$/gm, "");
+
+	const out = [];
+	let bullets = 0;
+	for (const line of stripped.split("\n")) {
+		const isBullet = /^[ \t]*[-*] /.test(line);
+		if (isBullet && ++bullets > MAX_BULLETS) break;
+		// Once the list has started, an unindented prose line is the closing summary the prompt forbade.
+		// Blank lines and indented continuations of a wrapped bullet are kept, so nothing ends mid-sentence.
+		if (bullets > 0 && !isBullet && line.trim() !== "" && !/^[ \t]/.test(line)) break;
+		out.push(line);
+	}
+	return out.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,9 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           RELEASE_MODEL: ${{ vars.RELEASE_MODEL }}
+          # This pipeline ships the EXTENSION; repo-release.yml passes the tool's own name for the v* line.
+          PRODUCT: "@edgehero/pi-dispatch-admin"
+          PRODUCT_DESC: the operator console for pi-dispatch, shipped as a pi extension
         run: |
           PREV=$(git tag --list 'admin-v*' --sort=-v:refname | head -n1)
           RANGE=${PREV:+$PREV..HEAD}
@@ -93,7 +96,18 @@ jobs:
             echo "release notes: AI-written"
           else
             echo "release notes: AI unavailable ($(head -n1 /tmp/notes.err 2>/dev/null)) — using commit list"
-            { echo "### Changes"; echo; printf '%s\n' "$COMMITS"; } > /tmp/notes.md
+            # Capped like the AI notes are, and the remainder counted rather than dropped silently.
+            TOTAL=$(printf '%s\n' "$COMMITS" | wc -l | tr -d ' ')
+            {
+              echo "### Changes"; echo
+              printf '%s\n' "$COMMITS" | head -n 12
+              if [ "$TOTAL" -gt 12 ]; then printf -- '- …and %s more\n' "$((TOTAL - 12))"; fi
+            } > /tmp/notes.md
+          fi
+          # Appended on BOTH paths -- this link is what earns the brevity above.
+          if [ -n "$PREV" ]; then
+            printf '\n**Full changelog**: %s/%s/compare/%s...admin-v%s\n' \
+              "${{ github.server_url }}" "${{ github.repository }}" "$PREV" "${{ steps.v.outputs.version }}" >> /tmp/notes.md
           fi
 
       - name: Create GitHub Release

--- a/.github/workflows/repo-release.yml
+++ b/.github/workflows/repo-release.yml
@@ -58,6 +58,10 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           RELEASE_MODEL: ${{ vars.RELEASE_MODEL }}
+          # Which artifact is being described. release.yml passes its own — the script used to name the
+          # admin extension unconditionally, so every tool release described the wrong thing.
+          PRODUCT: pi-dispatch
+          PRODUCT_DESC: a self-hosted service that runs pi coding-agent jobs, one isolated container per job
         run: |
           # Range since the previous tool release (v*); the whole repo, not just one workspace.
           PREV=$(git tag --list 'v*' --sort=-v:refname | head -n1)
@@ -68,7 +72,21 @@ jobs:
             echo "release notes: AI-written"
           else
             echo "release notes: AI unavailable ($(head -n1 /tmp/notes.err 2>/dev/null)) — using commit list"
-            { echo "### Changes"; echo; printf '%s\n' "$COMMITS"; } > /tmp/notes.md
+            # Capped for the same reason the AI notes are: eighty commit subjects is a diff, not notes. The
+            # count is stated rather than trimmed silently — a truncated list that looks complete is worse
+            # than a long one.
+            TOTAL=$(printf '%s\n' "$COMMITS" | wc -l | tr -d ' ')
+            {
+              echo "### Changes"; echo
+              printf '%s\n' "$COMMITS" | head -n 12
+              if [ "$TOTAL" -gt 12 ]; then printf -- '- …and %s more\n' "$((TOTAL - 12))"; fi
+            } > /tmp/notes.md
+          fi
+          # The detail escape hatch, appended on BOTH paths. This link is what earns the brevity above:
+          # nothing is hidden, it is one click away instead of in the body.
+          if [ -n "$PREV" ]; then
+            printf '\n**Full changelog**: %s/%s/compare/%s...v%s\n' \
+              "${{ github.server_url }}" "${{ github.repository }}" "$PREV" "${{ steps.v.outputs.version }}" >> /tmp/notes.md
           fi
 
       - name: Create GitHub Release

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",


### PR DESCRIPTION
Four features have sat on `main` since v0.3.0 (29 July) with no release cut, and the extension on npm is
three merged PRs behind the panel in this repo. This cuts both, and fixes the notes generator first so the
release it produces is worth reading.

### Merging this publishes

- **`v0.4.0`** — a GitHub Release, tagged by `repo-release.yml` off the root `package.json`.
- **`admin-v0.1.5`** — a GitHub Release **and an npm publish** of `@edgehero/pi-dispatch-admin`, by
  `release.yml`. That one is not reversible; it is the reason this is a merge decision rather than a push.

Both are idempotent (each skips when its tag/version already exists), so a re-run is a no-op.

### Why the admin bump rides along

0.1.5 carries the sandbox launch key on `RUN_DETAIL` and the four-forge panel. Shipping a tool release
whose console does not know about half of it is the incoherent option.

### The notes generator was wrong in two ways

**It named the wrong artifact.** Both workflows call `release-notes.mjs`, but the prompt said
"`@edgehero/pi-dispatch-admin` — the operator extension" unconditionally. Every *tool* release asked the
model to describe the extension and then handed it repo-wide commits to do it with. `PRODUCT` and
`PRODUCT_DESC` now come from the caller.

**It had no length ceiling.** v0.3.0 ran to 694 words with section headings and a config sample; v0.2.0 ran
to 126. "Terse bullet points" was steering nothing. The prompt now asks for one bold headline plus at most
five one-line bullets, and `tighten()` **imposes** that shape — fences and headings stripped, bullets sliced
at five, trailing summary dropped. A prompt that asks for brevity is a request; a slice is a guarantee.
`max_tokens` drops 1200 → 400 so the budget cannot fit an essay either.

Tightening is deterministic rather than a second model call on purpose: it has to hold when the API is
degraded, which is exactly when a model stops following shape instructions. If tightening leaves nothing,
the script exits non-zero into the commit-list fallback — a malformed answer can never publish an empty
release body.

Nothing is hidden by the ceiling, only relocated. Both paths now append a **Full changelog** compare link,
which is what earns the brevity, and the no-key fallback is capped at 12 subjects with the remainder
counted rather than trimmed silently.

### Verification

- `tighten()` exercised against three shapes — well-formed, over-long with headings/fences/eight bullets/a
  closing paragraph, and a wrapped bullet. Headings and fences stripped, cut at five, wrapped bullets intact,
  nothing ends mid-sentence.
- `npm ci --dry-run` clean; `npm run test --workspace admin` 201 pass / 0 fail (the gate `release.yml` runs
  before publishing).
- No test asserts a version string.
- `package-lock.json` carries the three workspace version lines and nothing else. The generated update also
  rewrote a `bin` path and dropped `libc` constraints from five optional native deps — an artifact of the
  local npm, not of this bump, and those constraints are what select the right glibc/musl binary on the
  Linux runner.

**Not verified:** the AI path itself never ran — that needs `ANTHROPIC_API_KEY` in Actions. The real notes
land when this merges, and are worth a look before they are the thing people read.
