### PR TITLE
feat(admin): pure panel primitives for the costs surface — sparkline, typed cost formatting, line input, ASCII glyphs

### DIFF
--- a/admin/src/panel.mjs
+++ b/admin/src/panel.mjs
@@ -11,7 +11,7 @@
 // Custom: no box-drawing/meter primitive exists in deps -- ink/blessed/boxen are full TUI frameworks and
 // this dashboard is a handful of monochrome frames, so a thin pure module is the right size (library-first).
 
-/** Box-drawing + block glyphs. Swap to ASCII by aliasing this to `ASCII` for glyph-width-hostile terminals. */
+/** Box-drawing + block glyphs. Swap to ASCII via `setGlyphs(true)` for glyph-width-hostile terminals. */
 export const GLYPHS = {
   tl: "┌", // top-left corner
   tr: "┐", // top-right corner
@@ -24,6 +24,8 @@ export const GLYPHS = {
   full: "█", // filled meter cell
   empty: "░", // empty meter cell
   ellipsis: "…", // truncation marker
+  ramp: "▁▂▃▄▅▆▇█", // sparkline quantization ramp, lowest to full; all width-1 BMP so length == columns
+  gap: "·", // sparkline cell for an absent (null) value
 };
 
 /** Parallel ASCII fallback: same keys, no glyph-width risk. Single point of substitution for `GLYPHS`. */
@@ -39,9 +41,30 @@ export const ASCII = {
   full: "#",
   empty: ".",
   ellipsis: "...",
+  ramp: "_.:-=+*#", // same length as GLYPHS.ramp so the quantization math never shifts between tables
+  gap: ".",
 };
 
+// Custom: a runtime switch, not an environment read -- this module stays pure (asserted by the purity
+// test), and whether a terminal is glyph-width-hostile is the caller's knowledge, not this module's.
+// The extension entry point reads its own config once at startup and flips the switch; every renderer
+// below reads the active table so the whole panel swaps together.
+let active = GLYPHS;
+
+/** Select the ASCII glyph table (`setGlyphs(true)`) or restore the box-drawing default (`setGlyphs(false)`). */
+export function setGlyphs(ascii) {
+  active = ascii ? ASCII : GLYPHS;
+}
+
 const MIN_WIDTH = 8;
+
+// eslint-disable-next-line no-control-regex -- defensive strip of C0/C1 control chars from untrusted input
+const CONTROL_CHARS = /[\x00-\x1f\x7f-\x9f]/g;
+
+/** Remove C0/C1 control characters (shared by `clip` and `makeLineInput`). */
+function stripControls(s) {
+  return String(s ?? "").replace(CONTROL_CHARS, "");
+}
 
 /**
  * Truncate `line` to `w` display columns, appending an ellipsis glyph when content is cut. Control
@@ -50,11 +73,11 @@ const MIN_WIDTH = 8;
  */
 export function clip(line, w) {
   const width = Math.max(0, Math.trunc(w) || 0);
-  // eslint-disable-next-line no-control-regex -- defensive strip of C0/C1 control chars from untrusted input
-  const clean = String(line ?? "").replace(/[\x00-\x1f\x7f-\x9f]/g, "");
+  const clean = stripControls(line);
   if (clean.length <= width) return clean;
-  if (width <= 1) return GLYPHS.ellipsis.slice(0, width);
-  return clean.slice(0, width - 1) + GLYPHS.ellipsis;
+  const ell = active.ellipsis;
+  if (width <= ell.length) return ell.slice(0, width);
+  return clean.slice(0, width - ell.length) + ell;
 }
 
 /** `clip` to `w`, then right-pad with spaces to exactly `w` columns. */
@@ -77,10 +100,10 @@ export function box({ title = "", sections = [], footer, width = 40 } = {}) {
   // Top border: `+- title -...-+`, title clipped so the border never overflows `w`.
   const titleText = title ? ` ${clip(title, Math.max(0, inner - 2))} ` : "";
   const topFill = Math.max(0, w - 2 - 1 - titleText.length); // corners + one leading `h`
-  lines.push(GLYPHS.tl + GLYPHS.h + titleText + GLYPHS.h.repeat(topFill) + GLYPHS.tr);
+  lines.push(active.tl + active.h + titleText + active.h.repeat(topFill) + active.tr);
 
-  const framed = (text) => `${GLYPHS.v} ${pad(text, inner)} ${GLYPHS.v}`;
-  const rule = () => GLYPHS.ml + GLYPHS.h.repeat(w - 2) + GLYPHS.mr;
+  const framed = (text) => `${active.v} ${pad(text, inner)} ${active.v}`;
+  const rule = () => active.ml + active.h.repeat(w - 2) + active.mr;
 
   sections.forEach((section, i) => {
     if (i > 0) lines.push(rule());
@@ -93,7 +116,7 @@ export function box({ title = "", sections = [], footer, width = 40 } = {}) {
     lines.push(framed(footer));
   }
 
-  lines.push(GLYPHS.bl + GLYPHS.h.repeat(w - 2) + GLYPHS.br);
+  lines.push(active.bl + active.h.repeat(w - 2) + active.br);
   return lines;
 }
 
@@ -115,6 +138,177 @@ export function meter(reserved, cap, width = 24, state = "ok") {
   const label = ` ${r}/${cap}${tag}`;
   const barCells = Math.max(0, Math.trunc(width) - label.length - 2); // "[" + cells + "]" + label
   const filled = Math.min(barCells, Math.round((Math.min(r, cap) / cap) * barCells));
-  const bar = `[${GLYPHS.full.repeat(filled)}${GLYPHS.empty.repeat(barCells - filled)}]`;
+  const bar = `[${active.full.repeat(filled)}${active.empty.repeat(barCells - filled)}]`;
   return clip(bar + label, width);
+}
+
+/**
+ * A one-line cost history: `values` (oldest -> newest, number|null) quantized onto the ramp glyphs and
+ * fitted to `width` columns. Negatives clamp to 0 (a cost cannot be negative); null/non-finite entries
+ * render the gap glyph. Returns a plain string of at most `width` columns: cells repeat
+ * `max(1, floor(width / values.length))` times and the total never exceeds `width`.
+ *
+ * Custom: quantization is ZERO-BASED, never min-max -- min-max scaling exaggerates cheap-day noise into
+ * full-height bars, and money proportions must stay truthful: half the ceiling reads as half a bar. The
+ * ceiling is `opts.max` when finite and positive (a shared scale so sparklines are comparable across
+ * rows), else the max of the finite values; with no positive ceiling there is nothing truthful to draw,
+ * so the cell reads "no data".
+ *
+ * Custom: 0 renders `ramp[0]` and null renders the gap glyph -- a zero-cost day is a fact, an absent day
+ * is unknown, and the two must never look alike. `ramp[0]` is reserved for exact zero: any positive value
+ * starts at `ramp[1]`, so a tiny-but-nonzero day never collapses into the zero baseline either.
+ *
+ * `opts.paint(cellText, value)` (optional; value is null for gaps) wraps each cell run after
+ * quantization. It exists so style.mjs can color cells without duplicating this geometry -- color stays
+ * post-layout, and an identity paint returns byte-identical output.
+ */
+export function sparkline(values, width = 24, opts = {}) {
+  const w = Math.max(0, Math.trunc(width) || 0);
+  if (w === 0) return "";
+  const norm = (Array.isArray(values) ? values : []).map((v) => (Number.isFinite(v) ? Math.max(0, v) : null));
+  const finite = norm.filter((v) => v !== null);
+  const ceiling = Number.isFinite(opts?.max) && opts.max > 0 ? opts.max : Math.max(0, ...finite);
+  if (finite.length === 0 || ceiling <= 0) return clip("no data", w);
+
+  // Custom: when there are more values than columns, each column takes its bucket's MAX, never an
+  // average -- peaks matter for cost, and an averaged-away spike is exactly the day an operator
+  // needs to see. A bucket with no finite value at all stays a gap.
+  let cells = norm;
+  if (norm.length > w) {
+    cells = [];
+    for (let i = 0; i < w; i++) {
+      const bucket = norm.slice(Math.floor((i * norm.length) / w), Math.floor(((i + 1) * norm.length) / w));
+      const present = bucket.filter((v) => v !== null);
+      cells.push(present.length > 0 ? Math.max(...present) : null);
+    }
+  }
+
+  const rep = Math.max(1, Math.floor(w / cells.length));
+  const top = active.ramp.length - 1;
+  const paint = typeof opts?.paint === "function" ? opts.paint : (text) => text;
+  let out = "";
+  let cols = 0;
+  for (const v of cells) {
+    const run = Math.min(rep, w - cols);
+    if (run <= 0) break;
+    const glyph = v === null ? active.gap : v === 0 ? active.ramp[0] : active.ramp[Math.min(top, Math.ceil((v / ceiling) * top))];
+    out += paint(glyph.repeat(run), v);
+    cols += run;
+  }
+  return out;
+}
+
+/**
+ * Compact USD for tight cells, at most 7 characters at any magnitude: `$0.0042`, `$0.42`, `$4.12`,
+ * `$41.20`, `$412`, `$4.1k`, `$412k`, `$4.1M`. Sub-cent costs are real money and render at four
+ * decimals; below what four decimals can show meaningfully the honest fallback is `<1¢` -- never
+ * `$0.00`, which would misread as free. Non-finite and negative input (this ladder renders costs;
+ * a negative cost is malformed) degrade to `-`.
+ */
+export function fmtUsd(n) {
+  if (!Number.isFinite(n) || n < 0) return "-";
+  if (n === 0) return "$0";
+  if (n < 0.0005) return "<1¢";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  if (n < 100) return `$${n.toFixed(2)}`;
+  if (n < 1000) return `$${Math.round(n)}`;
+  if (n < 100000) return `$${(n / 1000).toFixed(1)}k`;
+  if (n < 1e6) return `$${Math.round(n / 1000)}k`;
+  if (n < 1e8) return `$${(n / 1e6).toFixed(1)}M`;
+  return `$${Math.round(n / 1e6)}M`;
+}
+
+/**
+ * THE single renderer of the typed cost value `{ usd, class, floor, coverage, planId }` -- every money
+ * surface funnels here.
+ *
+ * Custom: the class system exists so an estimate CANNOT be mislabeled as truth by a rendering path.
+ * Each class has a distinct, non-overlapping shape: metered is a bare dollar figure (`≥`-prefixed when
+ * only a floor is known), plan is `plan:<planId>` and never a dollar amount (a covered run must never
+ * read as $0.00), zero-rated is `$0 (unrated)` and never the word "free", estimated is `~` + figure +
+ * ` est.`, seeded is `~~` + figure + ` seeded`, unknown is an em dash. Nullish or malformed input also
+ * degrades to the em dash rather than guessing a class.
+ */
+export function fmtCost(cost) {
+  if (!cost || typeof cost !== "object") return "—";
+  const floor = cost.floor ? "≥" : "";
+  switch (cost.class) {
+    case "metered":
+      return floor + fmtUsd(cost.usd);
+    case "plan":
+      return `plan:${cost.planId ?? "?"}`;
+    case "zero-rated":
+      return "$0 (unrated)";
+    case "estimated":
+      return `~${floor}${fmtUsd(cost.usd)} est.`;
+    case "seeded":
+      return `~~${fmtUsd(cost.usd)} seeded`;
+    default:
+      return "—";
+  }
+}
+
+/**
+ * Sentinel pair `render` wraps around the cursor cell when focused. Both are C0 control characters on
+ * purpose: the monochrome path funnels every line through `clip`, whose control strip drops them to
+ * nothing (a plain box simply shows no cursor), while style.mjs replaces the pair with an inverse-video
+ * cell. Either path yields exactly the render width in visible columns.
+ */
+export const LINE_INPUT_CURSOR = ["\x01", "\x02"];
+
+/**
+ * A pure single-line text-input state machine. No key decoding lives here -- the caller decodes raw
+ * input (keys.mjs) and calls the edit methods, which keeps this module free of the pi-tui resolver and
+ * keeps every transition a plain value-in/value-out step a test can drive directly.
+ *
+ * `render(width, { focused })` windows the value around the cursor when it outgrows `width - 1` (the
+ * cursor needs one cell past the last character) and always returns exactly `width` visible columns;
+ * when focused, the cursor cell is wrapped in `LINE_INPUT_CURSOR` (see above).
+ */
+export function makeLineInput(initial = "") {
+  let value = stripControls(initial);
+  let cursor = value.length;
+  return {
+    value: () => value,
+    cursor: () => cursor,
+    /** Insert a printable char -- or a whole pasted string -- at the cursor; control chars are stripped first. */
+    insert(ch) {
+      const clean = stripControls(ch);
+      if (clean.length === 0) return;
+      value = value.slice(0, cursor) + clean + value.slice(cursor);
+      cursor += clean.length;
+    },
+    backspace() {
+      if (cursor === 0) return;
+      value = value.slice(0, cursor - 1) + value.slice(cursor);
+      cursor -= 1;
+    },
+    del() {
+      if (cursor < value.length) value = value.slice(0, cursor) + value.slice(cursor + 1);
+    },
+    left() {
+      if (cursor > 0) cursor -= 1;
+    },
+    right() {
+      if (cursor < value.length) cursor += 1;
+    },
+    home() {
+      cursor = 0;
+    },
+    end() {
+      cursor = value.length;
+    },
+    setValue(s) {
+      value = stripControls(s);
+      cursor = value.length;
+    },
+    render(width, { focused = true } = {}) {
+      const w = Math.max(1, Math.trunc(width) || 1);
+      const start = value.length > w - 1 ? Math.max(0, cursor - (w - 1)) : 0;
+      const text = value.slice(start, start + w).padEnd(w);
+      if (!focused) return text;
+      const rel = cursor - start; // 0..w-1 by construction: the window never scrolls past the cursor
+      return text.slice(0, rel) + LINE_INPUT_CURSOR[0] + text[rel] + LINE_INPUT_CURSOR[1] + text.slice(rel + 1);
+    },
+  };
 }

--- a/admin/src/style.mjs
+++ b/admin/src/style.mjs
@@ -8,13 +8,16 @@
  *     framing or the `width:"75%"` overlay clamp.
  *   - This module is OVERLAY-ONLY. `render.mjs`/`panel.mjs` deliberately stay plain because they also feed
  *     `pi.sendMessage` (the model-visible channel) and the untrusted `.log` tail's `clip` escape-strip.
- *     Nothing here is imported by those paths.
+ *     Nothing here is imported by those paths; the dependency runs one way (this module imports panel's
+ *     pure primitives to color them, never the reverse).
  *
  * `theme` is the instance pi hands the `ctx.ui.custom` factory. It is injected (pi-tui is not importable
  * from here — nested, non-hoisted), so every helper takes a styler bound to that instance. `makeStyler`
  * accepts a null theme (tests / no-TUI) and degrades to plain text with the SAME plain layout, so a test
  * can assert both the plain content and the width math without a real terminal.
  */
+
+import { sparkline as plainSparkline, fmtCost as plainFmtCost, LINE_INPUT_CURSOR } from "./panel.mjs";
 
 // Strip SGR (and OSC-8 hyperlink) escapes to recover the visible text / column count. Content is
 // ASCII + box-drawing + a handful of width-1 glyphs, so post-strip `.length` is a safe column proxy.
@@ -40,13 +43,31 @@ export const PLAIN_THEME = {
   strikethrough: (t) => t,
 };
 
+// The styler's own glyph twins, inline rather than imported from panel's tables: panel's runtime glyph
+// switch (`setGlyphs`) must not restyle overlays behind a styler's back, so the overlay opts in per
+// styler instance via `makeStyler(theme, { ascii })`. (The sparkline ramp is the one exception -- its
+// quantization geometry lives only in panel.mjs, so `styler.sparkline` follows panel's active table.)
+const OVERLAY_GLYPHS = { tl: "┌", tr: "┐", bl: "└", br: "┘", ml: "├", mr: "┤", h: "─", v: "│", full: "█", empty: "░", ellipsis: "…" };
+const OVERLAY_ASCII = { tl: "+", tr: "+", bl: "+", br: "+", ml: "+", mr: "+", h: "-", v: "|", full: "#", empty: ".", ellipsis: "..." };
+
+/** Per-class colors for `fmtCost`: an estimate must LOOK provisional, and plan coverage must not look free. */
+const COST_COLORS = {
+  metered: "text",
+  plan: "accent",
+  "zero-rated": "dim",
+  estimated: "warning",
+  seeded: "warning",
+};
+
 /**
  * Bind the color helpers to a `theme` instance (or PLAIN_THEME). Every helper computes layout on plain
  * text and applies color last, so the returned strings have a KNOWN visible width equal to their plain
- * width.
+ * width. `ascii: true` swaps the styler's frame/meter/divider glyphs (and the cell ellipsis) for their
+ * ASCII twins with identical geometry.
  */
-export function makeStyler(theme) {
+export function makeStyler(theme, { ascii = false } = {}) {
   const th = theme ?? PLAIN_THEME;
+  const G = ascii ? OVERLAY_ASCII : OVERLAY_GLYPHS;
 
   /** Color `text` with a theme color, or return it unchanged when `color` is falsy. */
   const fg = (color, text) => (color ? th.fg(color, String(text)) : String(text));
@@ -59,7 +80,7 @@ export function makeStyler(theme) {
   const cell = (text, width, { color = null, align = "left", strong = false } = {}) => {
     const w = Math.max(0, Math.trunc(width) || 0);
     let plain = String(text ?? "");
-    if (plain.length > w) plain = w <= 1 ? plain.slice(0, w) : plain.slice(0, w - 1) + "…";
+    if (plain.length > w) plain = w <= G.ellipsis.length ? plain.slice(0, w) : plain.slice(0, w - G.ellipsis.length) + G.ellipsis;
     plain = align === "right" ? plain.padStart(w) : plain.padEnd(w);
     let out = color ? fg(color, plain) : plain;
     return strong ? bold(out) : out;
@@ -90,8 +111,8 @@ export function makeStyler(theme) {
     const filled = Math.min(barCells, Math.round((Math.min(r, cap) / cap) * barCells));
     // Build colored, keep track of visible width == w exactly.
     const open = fg("dim", "[");
-    const fillPart = filled > 0 ? fg(stateColor, "█".repeat(filled)) : "";
-    const emptyPart = barCells - filled > 0 ? fg("dim", "░".repeat(barCells - filled)) : "";
+    const fillPart = filled > 0 ? fg(stateColor, G.full.repeat(filled)) : "";
+    const emptyPart = barCells - filled > 0 ? fg("dim", G.empty.repeat(barCells - filled)) : "";
     const close = fg("dim", "]");
     const labelPart = fg(stateColor, label);
     return open + fillPart + emptyPart + close + labelPart;
@@ -107,7 +128,7 @@ export function makeStyler(theme) {
     const met = String(meta ?? "");
     const ruleLen = Math.max(1, w - lab.length - met.length - (met ? 2 : 1));
     const labPart = lab ? bold(fg("muted", lab)) + " " : "";
-    const rulePart = fg("border", "─".repeat(ruleLen));
+    const rulePart = fg("border", G.h.repeat(ruleLen));
     const metPart = met ? " " + fg("dim", met) : "";
     return labPart + rulePart + metPart;
   };
@@ -118,7 +139,59 @@ export function makeStyler(theme) {
    */
   const joinCells = (cells, sep = "  ") => cells.join(sep);
 
-  return { theme: th, fg, bold, cell, badge, meter, divider, joinCells, stripAnsi, visibleLen };
+  /**
+   * Colored twin of panel's `sparkline`: the SAME function composes the plain cells (so the geometry
+   * cannot drift), and color arrives as its per-cell `paint` hook, applied after quantization. Cells
+   * at/above `opts.warnAbove` take "warning", the rest "accent", gaps "dim". Under PLAIN_THEME the
+   * output is byte-identical to the plain sparkline.
+   */
+  const sparkline = (values, width, opts = {}) => {
+    const { warnAbove, ...rest } = opts ?? {};
+    const warn = Number.isFinite(warnAbove) ? warnAbove : null;
+    const paint = (text, v) => (v === null ? fg("dim", text) : fg(warn !== null && v >= warn ? "warning" : "accent", text));
+    return plainSparkline(values, width, { ...rest, paint });
+  };
+
+  /**
+   * Colored twin of panel's `fmtCost`: the plain renderer owns the shape, this only colors it per class
+   * (unknown/malformed share "dim"). With a `width` the result is a fixed `cell` of exactly that visible
+   * width; without one the visible width equals the plain string's length.
+   */
+  const fmtCost = (cost, width) => {
+    const plain = plainFmtCost(cost);
+    const color = (cost && typeof cost === "object" && COST_COLORS[cost.class]) || "dim";
+    return width == null ? fg(color, plain) : cell(plain, width, { color });
+  };
+
+  /**
+   * Render a `makeLineInput` at `width` with the cursor cell in inverse video. panel's focused render
+   * marks the cursor by wrapping one cell in the C0 `LINE_INPUT_CURSOR` pair; here that pair becomes an
+   * inverse-video cell (monochrome callers instead funnel the render through `clip`, which strips the
+   * sentinels). Either way the visible width is exactly `width`.
+   */
+  const lineInput = (input, width) => {
+    const raw = input.render(width, { focused: true });
+    const [open, close] = LINE_INPUT_CURSOR;
+    const i = raw.indexOf(open);
+    const j = raw.indexOf(close, i + 1);
+    if (i < 0 || j < 0) return raw;
+    const cursorCell = raw.slice(i + 1, j);
+    const inverse = typeof th.inverse === "function" ? th.inverse(cursorCell) : cursorCell;
+    return raw.slice(0, i) + inverse + raw.slice(j + 1);
+  };
+
+  /**
+   * Wrap `text` in an OSC-8 hyperlink to `url` when a real theme is attached. Under PLAIN_THEME the text
+   * passes through unchanged -- plain output (tests, no-TUI) must carry no escape bytes. `stripAnsi` /
+   * `visibleLen` already strip OSC-8 (the regex above), so a linked cell measures exactly its text width.
+   */
+  const link = (text, url) => {
+    const t = String(text ?? "");
+    if (th === PLAIN_THEME) return t;
+    return `\x1b]8;;${String(url ?? "")}\x07${t}\x1b]8;;\x07`;
+  };
+
+  return { theme: th, glyphs: G, fg, bold, cell, badge, meter, divider, joinCells, sparkline, fmtCost, lineInput, link, stripAnsi, visibleLen };
 }
 
 /**
@@ -130,15 +203,16 @@ export function makeStyler(theme) {
 export function frame(styler, { title = "", width = 40, lines = [], footer = null } = {}) {
   const w = Math.max(8, Math.trunc(width) || 8);
   const inner = w - 4;
+  const G = styler.glyphs ?? OVERLAY_GLYPHS;
   const B = (s) => styler.fg("border", s);
   const out = [];
 
-  const titleText = title ? ` ${clipPlain(title, Math.max(0, inner - 2))} ` : "";
+  const titleText = title ? ` ${clipPlain(title, Math.max(0, inner - 2), G.ellipsis)} ` : "";
   const topFill = Math.max(0, w - 2 - 1 - titleText.length);
-  out.push(B("┌─") + styler.bold(styler.fg("accent", titleText)) + B("─".repeat(topFill) + "┐"));
+  out.push(B(G.tl + G.h) + styler.bold(styler.fg("accent", titleText)) + B(G.h.repeat(topFill) + G.tr));
 
-  const side = (content) => B("│") + " " + content + " " + B("│");
-  const rule = () => B("├" + "─".repeat(w - 2) + "┤");
+  const side = (content) => B(G.v) + " " + content + " " + B(G.v);
+  const rule = () => B(G.ml + G.h.repeat(w - 2) + G.mr);
 
   for (const line of lines) {
     if (line === RULE) out.push(rule());
@@ -150,7 +224,7 @@ export function frame(styler, { title = "", width = 40, lines = [], footer = nul
     out.push(side(padVisible(styler, footer, inner)));
   }
 
-  out.push(B("└" + "─".repeat(w - 2) + "┘"));
+  out.push(B(G.bl + G.h.repeat(w - 2) + G.br));
   return out;
 }
 
@@ -165,8 +239,8 @@ function padVisible(styler, line, width) {
 }
 
 /** Plain clip to `width` columns with an ellipsis (used for the title only; content is pre-sized). */
-function clipPlain(s, width) {
+function clipPlain(s, width, ellipsis = "…") {
   const plain = String(s ?? "");
   if (plain.length <= width) return plain;
-  return width <= 1 ? plain.slice(0, width) : plain.slice(0, width - 1) + "…";
+  return width <= ellipsis.length ? plain.slice(0, width) : plain.slice(0, width - ellipsis.length) + ellipsis;
 }

--- a/admin/test/panel.test.mjs
+++ b/admin/test/panel.test.mjs
@@ -2,7 +2,20 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { GLYPHS, clip, pad, box, meter } from "../src/panel.mjs";
+import {
+  GLYPHS,
+  ASCII,
+  setGlyphs,
+  clip,
+  pad,
+  box,
+  meter,
+  sparkline,
+  fmtUsd,
+  fmtCost,
+  makeLineInput,
+  LINE_INPUT_CURSOR,
+} from "../src/panel.mjs";
 
 test("panel.mjs is pure: no fs, no require, no node:fs import", () => {
   const src = readFileSync(fileURLToPath(new URL("../src/panel.mjs", import.meta.url)), "utf8");
@@ -96,4 +109,190 @@ test("pad clips long input to width", () => {
   const out = pad("abcdefghij", 4);
   assert.equal(out.length, 4);
   assert.ok(out.endsWith(GLYPHS.ellipsis));
+});
+
+test("GLYPHS and ASCII stay in key parity; ramp and gap are equal-length pairs", () => {
+  assert.deepEqual(Object.keys(ASCII).sort(), Object.keys(GLYPHS).sort(), "every glyph key has an ASCII twin");
+  assert.equal(ASCII.ramp.length, GLYPHS.ramp.length, "the quantization math must not shift between tables");
+  assert.equal(ASCII.gap.length, GLYPHS.gap.length);
+  assert.equal(GLYPHS.gap.length, 1, "sparkline cells are single columns");
+});
+
+test("setGlyphs(true) swaps box, meter, and clip to ASCII; setGlyphs(false) restores the default", () => {
+  try {
+    setGlyphs(true);
+    const out = box({ title: "S", sections: [{ lines: ["x"] }], width: 20 });
+    assert.match(out[0], /^\+-/, "ASCII corners");
+    assert.doesNotMatch(out.join("\n"), new RegExp(GLYPHS.v), "no box-drawing glyph leaks through");
+    assert.match(meter(3, 10, 24), /#/);
+    assert.doesNotMatch(meter(3, 10, 24), new RegExp(GLYPHS.full));
+    const clipped = clip("abcdefghij", 5);
+    assert.equal(clipped.length, 5, "the 3-char ASCII ellipsis still lands on exactly width");
+    assert.ok(clipped.endsWith(ASCII.ellipsis));
+  } finally {
+    setGlyphs(false);
+  }
+  assert.match(meter(3, 10, 24), new RegExp(GLYPHS.full), "the switch restores cleanly");
+});
+
+test("sparkline repeats cells to fill width and never exceeds it", () => {
+  assert.equal(sparkline([1, 2, 3, 4], 8).length, 8, "repeat factor 2 fills the width evenly");
+  assert.equal(sparkline([1, 2, 3], 8).length, 6, "repeat factor floors -- at most width, never padded past the data");
+  assert.equal(sparkline([1, 2, 3, 4, 5], 2).length, 2, "more values than columns still fits");
+  const doubled = sparkline([1, 4], 4);
+  assert.equal(doubled[0], doubled[1], "each cell repeats as a run");
+  assert.equal(doubled[2], doubled[3]);
+});
+
+test("sparkline renders zero as the lowest ramp glyph and null as the gap glyph", () => {
+  // A zero-cost day is a fact, an absent day is unknown -- the two must never look alike.
+  const out = sparkline([0, 8, null, 0.1], 4, { max: 8 });
+  assert.equal(out[0], GLYPHS.ramp[0], "exact zero takes the reserved baseline glyph");
+  assert.equal(out[1], GLYPHS.ramp.at(-1), "the ceiling takes the full glyph");
+  assert.equal(out[2], GLYPHS.gap, "null is a gap, not a bar");
+  assert.notEqual(out[3], GLYPHS.ramp[0], "tiny-but-nonzero never collapses into the zero baseline");
+  assert.notEqual(out[3], GLYPHS.gap);
+});
+
+test("sparkline opts.max pins a shared ceiling so bars are comparable across series", () => {
+  assert.equal(sparkline([5], 1), GLYPHS.ramp.at(-1), "own max scales to full height");
+  assert.equal(sparkline([5], 1, { max: 10 }), GLYPHS.ramp[4], "half the shared ceiling reads as half a bar, not full");
+  assert.equal(sparkline([20], 1, { max: 10 }), GLYPHS.ramp.at(-1), "over the ceiling clamps to full");
+});
+
+test("sparkline downsamples by bucket max, never an average -- a spike must survive", () => {
+  const out = sparkline([0, 9, 0, 0], 2);
+  assert.equal(out.length, 2);
+  assert.equal(out[0], GLYPHS.ramp.at(-1), "the 9 spike survives its bucket");
+  assert.equal(out[1], GLYPHS.ramp[0], "the flat bucket stays at the zero baseline");
+  const gaps = sparkline([null, null, 3, 3], 2);
+  assert.equal(gaps[0], GLYPHS.gap, "an all-null bucket stays a gap");
+  assert.equal(gaps[1], GLYPHS.ramp.at(-1));
+});
+
+test("sparkline renders 'no data' when nothing positive exists to scale against", () => {
+  assert.equal(sparkline([], 10), "no data");
+  assert.equal(sparkline([null, null], 10), "no data");
+  assert.equal(sparkline([0, 0, 0], 10), "no data", "all-zero with no shared ceiling has no truthful scale");
+  assert.equal(sparkline([], 4), clip("no data", 4), "the note clips like any other cell");
+  assert.match(sparkline([0, 0], 10, { max: 5 }), new RegExp(`^${GLYPHS.ramp[0]}+$`), "an explicit ceiling makes flat zero a fact worth drawing");
+});
+
+test("sparkline swaps to the ASCII ramp under setGlyphs(true) with identical geometry", () => {
+  const uni = sparkline([1, 2, null, 4], 8);
+  try {
+    setGlyphs(true);
+    const asc = sparkline([1, 2, null, 4], 8);
+    assert.equal(asc.length, uni.length, "the geometry is glyph-table independent");
+    for (let i = 0; i < asc.length; i++) {
+      const expected = uni[i] === GLYPHS.gap ? ASCII.gap : ASCII.ramp[GLYPHS.ramp.indexOf(uni[i])];
+      assert.equal(asc[i], expected, `column ${i} keeps its ramp index across tables`);
+    }
+  } finally {
+    setGlyphs(false);
+  }
+});
+
+test("fmtUsd compacts any magnitude into at most 7 characters", () => {
+  const table = [
+    [0, "$0"],
+    [0.0001, "<1¢"],
+    [0.0042, "$0.0042"],
+    [0.42, "$0.42"],
+    [4.12, "$4.12"],
+    [41.2, "$41.20"],
+    [412, "$412"],
+    [4120, "$4.1k"],
+    [412000, "$412k"],
+    [4200000, "$4.2M"],
+    [NaN, "-"],
+    [Infinity, "-"],
+    [-3, "-"],
+  ];
+  for (const [n, expected] of table) {
+    assert.equal(fmtUsd(n), expected, `fmtUsd(${n})`);
+    assert.ok(fmtUsd(n).length <= 7, `fmtUsd(${n}) stays within 7 chars`);
+  }
+});
+
+test("fmtCost renders each cost class with a distinct, non-overlapping shape", () => {
+  assert.equal(fmtCost({ usd: 4.12, class: "metered" }), "$4.12");
+  assert.equal(fmtCost({ usd: 4.12, class: "metered", floor: true }), "≥$4.12", "a floor is marked, not silently rounded");
+  assert.equal(fmtCost({ class: "plan", planId: "max-5x" }), "plan:max-5x", "plan coverage is never a dollar amount");
+  assert.equal(fmtCost({ usd: 0, class: "zero-rated" }), "$0 (unrated)");
+  assert.equal(fmtCost({ usd: 4.12, class: "estimated" }), "~$4.12 est.");
+  assert.equal(fmtCost({ usd: 4.12, class: "estimated", floor: true }), "~≥$4.12 est.", "the floor rule applies inside an estimate");
+  assert.equal(fmtCost({ usd: 0.42, class: "seeded" }), "~~$0.42 seeded");
+  assert.equal(fmtCost({ class: "unknown" }), "—");
+});
+
+test("fmtCost refuses to guess on nullish or malformed input", () => {
+  assert.equal(fmtCost(null), "—");
+  assert.equal(fmtCost(undefined), "—");
+  assert.equal(fmtCost(42), "—");
+  assert.equal(fmtCost({}), "—");
+  assert.equal(fmtCost({ usd: 4.12, class: "billed" }), "—", "an unrecognized class is never rendered as money");
+});
+
+test("makeLineInput edits round-trip: insert, cursor moves, backspace, del, setValue", () => {
+  const li = makeLineInput();
+  for (const ch of "abc") li.insert(ch);
+  assert.equal(li.value(), "abc");
+  assert.equal(li.cursor(), 3);
+  li.left();
+  li.insert("X");
+  assert.equal(li.value(), "abXc");
+  assert.equal(li.cursor(), 3);
+  li.backspace();
+  assert.equal(li.value(), "abc");
+  assert.equal(li.cursor(), 2);
+  li.del();
+  assert.equal(li.value(), "ab");
+  li.home();
+  assert.equal(li.cursor(), 0);
+  li.left();
+  assert.equal(li.cursor(), 0, "left clamps at the start");
+  li.end();
+  assert.equal(li.cursor(), 2);
+  li.right();
+  assert.equal(li.cursor(), 2, "right clamps at the end");
+  li.backspace();
+  assert.equal(li.value(), "a", "backspace at the end removes the last char");
+  li.setValue("hello");
+  assert.equal(li.value(), "hello");
+  assert.equal(li.cursor(), 5, "setValue parks the cursor at the end");
+});
+
+test("makeLineInput strips control characters on the way in, typed or pasted", () => {
+  const li = makeLineInput("a\x00b");
+  assert.equal(li.value(), "ab", "the initial value is stripped too");
+  li.insert("\x07");
+  assert.equal(li.value(), "ab", "a lone control char inserts nothing");
+  li.insert("cd\x1bef");
+  assert.equal(li.value(), "abcdef", "a pasted string is stripped, then inserted whole");
+  li.insert(LINE_INPUT_CURSOR[0] + "x" + LINE_INPUT_CURSOR[1]);
+  assert.equal(li.value(), "abcdefx", "the cursor sentinels are C0 controls and can never enter the value");
+});
+
+test("makeLineInput render is exactly width columns and windows around the cursor", () => {
+  const li = makeLineInput("abcdefghij");
+  assert.equal(li.render(6, { focused: false }), "fghij ", "cursor at the end -> the tail plus the cursor's pad cell");
+  li.home();
+  assert.equal(li.render(6, { focused: false }), "abcdef", "cursor at the start -> the head");
+  for (let i = 0; i < 7; i++) li.right();
+  assert.equal(li.render(6, { focused: false }), "cdefgh", "a mid-value cursor scrolls just far enough to stay visible");
+  const short = makeLineInput("hi");
+  assert.equal(short.render(6, { focused: false }), "hi    ", "short values right-pad to width");
+});
+
+test("makeLineInput marks the cursor cell with the sentinels only when focused; clip drops them", () => {
+  const li = makeLineInput("abc");
+  const [open, close] = LINE_INPUT_CURSOR;
+  const focused = li.render(6);
+  assert.equal(focused, "abc" + open + " " + close + "  ", "the cursor sits on the pad cell after the value");
+  const unfocused = li.render(6, { focused: false });
+  assert.ok(!unfocused.includes(open) && !unfocused.includes(close), "unfocused render carries no sentinel bytes");
+  assert.equal(clip(focused, 6), unfocused, "clip strips the sentinels down to the exact plain render");
+  const long = makeLineInput("abcdefghij");
+  assert.equal(clip(long.render(6), 6).length, 6, "a windowed focused render is still exactly width after the strip");
 });

--- a/admin/test/style.test.mjs
+++ b/admin/test/style.test.mjs
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { makeStyler, frame, RULE, PLAIN_THEME, stripAnsi, visibleLen } from "../src/style.mjs";
+import { sparkline, fmtCost, makeLineInput, LINE_INPUT_CURSOR, GLYPHS } from "../src/panel.mjs";
 
-// A theme whose fg/bold emit REAL SGR (so the module's stripAnsi recovers the visible text) and RECORD
-// every (color,text) request, so we can assert both the width invariant and the color choices.
+// A theme whose fg/bold/inverse emit REAL SGR (so the module's stripAnsi recovers the visible text) and
+// RECORD every (color,text) request, so we can assert both the width invariant and the color choices.
 function spyTheme() {
   const calls = [];
   return {
@@ -14,6 +15,9 @@ function spyTheme() {
     },
     bold(text) {
       return `\x1b[1m${text}\x1b[22m`;
+    },
+    inverse(text) {
+      return `\x1b[7m${text}\x1b[27m`;
     },
     bg: (_c, t) => t,
   };
@@ -96,4 +100,88 @@ test("frame degrades to plain glyphs under PLAIN_THEME but keeps the same geomet
   const inner = 30 - 4;
   const framed = frame(s, { title: "x", width: 30, lines: [s.cell("hi", inner)] });
   for (const line of framed) assert.equal(line.length, 30); // no ANSI, so .length === visible width
+});
+
+test("makeStyler ascii option swaps frame/meter/divider glyphs with identical geometry", () => {
+  const s = makeStyler(PLAIN_THEME, { ascii: true });
+  const framed = frame(s, { title: "x", width: 30, lines: [s.cell("hi", 26)], footer: s.cell("f", 26) });
+  for (const line of framed) assert.equal(line.length, 30, "the ASCII frame keeps the exact geometry");
+  assert.match(framed[0], /^\+- x -+\+$/);
+  assert.match(framed.at(-1), /^\+-+\+$/);
+  assert.doesNotMatch(framed.join("\n"), /[─│┌┐├┤└┘]/, "no box-drawing glyph leaks through");
+  assert.match(s.meter(3, 10, 24), /#/);
+  assert.doesNotMatch(s.meter(3, 10, 24), new RegExp(GLYPHS.full));
+  assert.equal(visibleLen(s.divider("a", "", 20)), 20);
+  assert.doesNotMatch(s.divider("a", "", 20), new RegExp(GLYPHS.h));
+  assert.equal(s.cell("abcdefgh", 5), "ab...", "the 3-char ellipsis still lands on exactly width");
+});
+
+test("styler.sparkline under PLAIN_THEME is byte-identical to the plain sparkline", () => {
+  const s = makeStyler(PLAIN_THEME);
+  const values = [0, 1, null, 4, 2];
+  assert.equal(s.sparkline(values, 10), sparkline(values, 10));
+  assert.equal(s.sparkline(values, 10, { max: 8 }), sparkline(values, 10, { max: 8 }));
+  assert.equal(s.sparkline(values, 10, { max: 8, warnAbove: 2 }), sparkline(values, 10, { max: 8 }), "warnAbove is color-only, never geometry");
+  assert.equal(s.sparkline([null, null], 10), sparkline([null, null], 10), "the no-data path stays plain");
+});
+
+test("styler.sparkline colors cells by warnAbove without touching the geometry", () => {
+  const spy = spyTheme();
+  const s = makeStyler(spy);
+  const values = [1, 5, null];
+  const out = s.sparkline(values, 6, { max: 5, warnAbove: 4 });
+  const plain = sparkline(values, 6, { max: 5 });
+  assert.equal(visibleLen(out), plain.length, "color adds nothing to the visible width");
+  assert.equal(stripAnsi(out), plain, "the plain cells are unchanged under color");
+  assert.ok(spy.calls.some((c) => c.color === "warning"), "the cell at/above warnAbove is a warning");
+  assert.ok(spy.calls.some((c) => c.color === "accent"), "the cell below warnAbove is accent");
+  assert.ok(spy.calls.some((c) => c.color === "dim"), "the gap is dim");
+});
+
+test("styler.fmtCost colors per class and keeps the plain twin's geometry", () => {
+  const metered = { usd: 4.12, class: "metered" };
+  assert.equal(makeStyler(PLAIN_THEME).fmtCost(metered), fmtCost(metered), "PLAIN passthrough is byte-identical");
+  const spy = spyTheme();
+  const colored = makeStyler(spy).fmtCost(metered);
+  assert.equal(stripAnsi(colored), fmtCost(metered));
+  assert.equal(visibleLen(colored), fmtCost(metered).length);
+  for (const [cost, color] of [
+    [metered, "text"],
+    [{ class: "plan", planId: "max-5x" }, "accent"],
+    [{ usd: 0, class: "zero-rated" }, "dim"],
+    [{ usd: 1, class: "estimated" }, "warning"],
+    [{ usd: 1, class: "seeded" }, "warning"],
+    [{ class: "unknown" }, "dim"],
+    [null, "dim"],
+  ]) {
+    const perSpy = spyTheme();
+    makeStyler(perSpy).fmtCost(cost);
+    assert.ok(perSpy.calls.some((c) => c.color === color), `${cost?.class ?? "malformed"} colors ${color}`);
+  }
+  const celled = makeStyler(spy).fmtCost(metered, 12);
+  assert.equal(visibleLen(celled), 12, "an explicit width renders as a fixed cell");
+  assert.equal(stripAnsi(celled), fmtCost(metered).padEnd(12));
+});
+
+test("styler.lineInput paints the cursor cell inverse at exactly the render width", () => {
+  const spy = spyTheme();
+  const li = makeLineInput("abc");
+  const out = makeStyler(spy).lineInput(li, 6);
+  assert.equal(visibleLen(out), 6);
+  assert.match(out, /\x1b\[7m/, "the cursor cell is inverse video");
+  assert.equal(stripAnsi(out), "abc   ", "plain content and padding are unchanged");
+  assert.ok(!out.includes(LINE_INPUT_CURSOR[0]) && !out.includes(LINE_INPUT_CURSOR[1]), "no sentinel byte survives into the colored render");
+  const plain = makeStyler(PLAIN_THEME).lineInput(li, 6);
+  assert.equal(plain, "abc   ", "PLAIN_THEME degrades to the sentinel-free plain render");
+  const windowed = makeStyler(spy).lineInput(makeLineInput("abcdefghij"), 6);
+  assert.equal(visibleLen(windowed), 6, "a scrolled window keeps the exact width");
+});
+
+test("styler.link is a plain passthrough under PLAIN_THEME and an OSC-8 hyperlink under a real theme", () => {
+  const plain = makeStyler(PLAIN_THEME);
+  assert.equal(plain.link("runs", "https://example.test/runs"), "runs", "no escape bytes in plain output");
+  const linked = makeStyler(spyTheme()).link("runs", "https://example.test/runs");
+  assert.equal(linked, "\x1b]8;;https://example.test/runs\x07runs\x1b]8;;\x07");
+  assert.equal(visibleLen(linked), 4, "the OSC-8 wrapper is invisible to width math");
+  assert.equal(stripAnsi(linked), "runs");
 });


### PR DESCRIPTION
Part of #53 (gaps 4 and 5 groundwork). Four pure building blocks the COSTS view will compose, shipped ahead of it so that PR is wiring, not invention. No view changes; each primitive carries its own `Custom:` build-decision comment in the `panel.mjs` tradition, and the design-spec amendment lands with the consuming view.

- **`sparkline(values, width, opts)`** — zero-based quantization (min–max scaling exaggerates cheap-day noise; money proportions must be truthful). `ramp`/`gap` glyphs added to **both** glyph tables as equal-length pairs. Three-way honesty: `0` renders the lowest ramp cell (a zero-cost day is a fact), `null` renders the gap glyph (an absent day is unknown), and any positive value quantizes to at least `ramp[1]` so tiny-but-nonzero never collapses into the zero baseline. Oversized series downsample by per-bucket **max** — an averaged-away spike is exactly the day an operator needs to see. `opts.max` gives multi-row views one shared scale.
- **`fmtUsd` + `fmtCost`** — the single renderer of the typed cost value `{usd, class, floor, coverage, planId}`: `$4.12` / `≥$4.12` (floors), `plan:<id>` (never a dollar amount — a covered run must never read as $0.00), `$0 (unrated)` (never the word *free*), `~$4.12 est.`, `~~$0.42 seeded`, `—`. The class system makes a mislabeled estimate structurally impossible: every money cell funnels here.
- **`makeLineInput()`** — pure key-state editor (insert/backspace/del/left/right/home/end, C0/C1 strip, cursor windowing, exact-width render). The caller decodes keys, so `panel.mjs` stays free of the pi-tui resolver; the cursor is marked with C0 sentinels the styler renders inverse-video and `clip` plainly strips on the monochrome path. Unlocks the what-if type-to-filter and tail search in the follow-up PRs.
- **`setGlyphs(ascii)`** — runtime switch flipping the active glyph table for every panel primitive, mirrored by `makeStyler(theme, {ascii})` for the overlay's inline glyphs. A runtime switch and not an env read: panel stays pure (its purity regex still bans `process.env`); the env decision belongs to the extension entry point, wired in the view PR.
- **`styler.link(text, url)`** — OSC-8 hyperlinks under a real theme, byte-identical passthrough under `PLAIN_THEME`; the ANSI strip regex already covered OSC-8, so `visibleLen` was correct all along.

**Tests:** panel 26 (purity regex first and green on the grown file), style 15 (spyTheme gained a real-SGR inverse), whole admin suite 229/229. Notable pins: ramp equal-length in both tables; PLAIN twin equality for every colored twin is structural (shared per-cell paint hook), not coincidental; zero/null/tiny render distinctly.

Stacked context: independent of #73/#74 (rooted at main); consumed by the COSTS view PR next.