### PR TITLE
feat: pi-dispatch up + doctor --fix — the consented bootstrap (issue #80)

### DIFF
--- a/specs/design.md
+++ b/specs/design.md
@@ -527,6 +527,29 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
 - **Traces to**: `CONST-BUDGET-BEFORE-TOKENS`, `DES-ADMIN-VIA-PI-EXTENSION`, `DES-AI-TRIGGER-FLOW-GATE`,
   `DES-JOB-OUTBOX-CHAINING`, `REQ-LOCAL-JOB-VISIBILITY`
 
+## DES-CLI-SURFACE
+
+- **Decision**: The workspace CLI (`pi-dispatch`, bin of the worker package) is the deployment's
+  operator surface, and its subcommands sit on an explicit gate ladder. **Read-only / always safe**:
+  `doctor`, `status`. **Operator-typed, ungated**: `run`, `pause`, `resume`, `sandbox`, `import-pi`
+  (each is its own gate — typing it is the approval, `REQ-ADMIN-VIA-PI-EXTENSION`'s ladder top).
+  **Create-only, contractually non-destructive**: `init` (idempotent scaffolds; an existing file is
+  never touched). **Consented host mutations**: `up` and `doctor --fix` — each concrete action (a
+  docker pull of the deployment's *own default* image, a loopback Valkey start, an overlay
+  `auth.json` delete, an `import-pi` restage) is shown verbatim and runs only on an explicit y/N
+  accept, defaulting to No, including on non-TTY stdin. The receiver's `pi-dispatch-receiver` bin is
+  a sibling on the same ladder (serve = the operator typed it).
+- **Why**: `init` and `doctor` grew organically with no recorded surface; issue #80 adds subcommands
+  that *mutate the host*, and an unrecorded gate ladder is how a later "helpful" flag erodes a trust
+  property nobody wrote down. Recording which tier each subcommand sits on makes "may this be
+  automated?" a lookup instead of a debate.
+- **The never-tier is load-bearing**: no subcommand, flag, or fix path may rewrite malformed config
+  (fail-loud/keep-last-good is doctrine), write triggers/pause-windows *content*, pull a
+  trigger-named `run.image` (each image is a separate per-flow trust posture — only the deployment's
+  default is ever offered, and the consent keypress is the "pulled it onto this host yourself" act
+  `SECURITY.md` requires), guess a semantic env value, or touch branch protection on a forge.
+- **Traces to**: `REQ-DEPLOYMENT-BOOTSTRAP`, `DES-CLI-TRIGGER-FOR-LOCAL`, `CONST-BUDGET-BEFORE-TOKENS`
+
 ## DES-WORKER-ON-HOST
 
 - **Decision**: The worker runs **on the host** (a Node process, `pi-dispatch worker` / `npm start`), not
@@ -561,6 +584,10 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   longer runs everything; the operator also runs `pi-dispatch worker`. That is the honest price of
   local-folder jobs working on Windows/macOS/Linux without fragile path math. The receiver is Node too,
   so it is one install story (`npm ci`), with Docker running Valkey and the job containers.
+  Since issue #80, `pi-dispatch up` *sequences* the surrounding chores (image pull+tag, Valkey start,
+  scaffold, preflight) behind explicit per-action consent — the price above is unchanged (the worker is
+  still a host process the operator runs); only the amount of typing shrank
+  (`REQ-DEPLOYMENT-BOOTSTRAP`).
 - **Evidence**: verified first-hand this session — `docker context` (`npipe` endpoint, `linux/x86_64`
   daemon) · `moby/for-win#14271` (VM prefix `/run/desktop/mnt/host/…`) and `docker/compose#5563`
   (older `/host_mnt/…`), i.e. the prefix moved · `docker/compose#4240`
@@ -1497,6 +1524,7 @@ a tunnel.
 
 | Date | Change |
 |---|---|
+| 2026-08-02 | The CLI surface gets a recorded gate ladder (issue #80). Added **DES-CLI-SURFACE**: read-only (`doctor`, `status`) / operator-typed-ungated (`run`, `pause`, `resume`, `sandbox`, `import-pi`) / create-only (`init`) / consented host mutations (`up`, `doctor --fix` — each action shown verbatim, y/N default No incl. non-TTY), plus the load-bearing never-tier (no malformed-config rewrites, no triggers/pause-windows content, no trigger-named `run.image` pulls — only the deployment default, where the consent keypress is SECURITY.md's "pulled it yourself" act). `init`/`doctor` had no recorded surface at all, and the ladder makes "may this be automated?" a lookup. **DES-WORKER-ON-HOST amended** (Accepted cost): `up` sequences the surrounding chores behind consent; the price — the worker is a host process the operator runs — is unchanged, only the typing shrank. **DES-CLI-TRIGGER-FOR-LOCAL UNCHANGED, checked**: `up` is not a producer; it enqueues nothing. **INT-CONFIG-OVERLAY-CONTRACT UNCHANGED, checked**: its repair-write precedent is cited by the fix-tier reasoning, not extended — `--fix` never rewrites an invalid overlay; that stays the admin write path's documented repair. |
 | 2026-08-01 | **`DES-ADMIN-VIA-PI-EXTENSION` amended** (dashboard polish): run targets render as OSC-8 hyperlinks **only when the URL is derivable from id-only fields** (github `repo#N`; other forges' instance hosts are unknowable from the record, so no URL is ever guessed) — display-only escapes, byte-identical passthrough under the plain theme, and `visibleLen` already strips OSC-8. `y`/`Y` in RUN_DETAIL copy the job id / target URL via a new injected `copyText` seam whose OSC-52 emission lives in index.ts (the dashboard stays I/O-free); operator-initiated, id-only strings, nothing read back — recorded in SECURITY.md. LIVE_TAIL gains `/` search over the captured tail (a line-input layer above the view, popping on the established one-Esc-per-layer discipline; matches jump and suspend follow exactly as manual scrolling does; **untrusted bytes still pass only through `clip`** — the match highlight colors post-clip). The LIST and COSTS frames become height-aware through an injected `terminalRows` seam: sections collapse to their divider-plus-count by fixed priority (pause windows → settings → triggers → spend; COSTS: by-model → plans → daily), the cursor's section and the verdict block never collapse, and an absent seam renders byte-identically to before. The fs ban and every width invariant **UNCHANGED, checked**. |
 | 2026-08-01 | **`DES-ADMIN-VIA-PI-EXTENSION` amended** (issue #53, `REQ-COST-ANALYTICS`): the overlay gains its fifth view, **COSTS** (`c`) — verdict-first analytics over one `DES-COST-FOLD-BY-SCAN` fold: per-plan verdicts with the API-rate comparison line, a daily sparkline, by-flow/by-model tables whose money cells all funnel through the typed-cost formatter, plan blocks with amortized $/run and peak-window facts (never burn-down), a provenance footer naming the pi-ai pin, and the keyboard what-if (`w` shortlist cycle; `/` type-to-filter over the full priced catalog via the line-input primitive — the long tail lives in the TUI now that the primitive exists, and in `/dispatch costs whatif` for scripting). The costs data path is lazy and throttled (view entry + window change + stale-tick refresh): the fold is cheap, but a per-second full-directory scan is the quiet load a dashboard must not add. `/dispatch costs [7d\|30d\|mtd]` renders the same fold plain for the degraded path; `dispatch_costs` returns it as JSON with `class` on every monetary value, so the model-facing surface cannot launder an estimate any more than the human-facing one. `PI_DISPATCH_ASCII=1` flips every panel/overlay glyph table to the ASCII twins at extension load (the switch the primitives shipped; the env decision lives at the entry point, keeping panel.mjs pure). The dashboard's source-regex fs ban is **UNCHANGED, checked** — the costs data arrives through `createDashboardDeps` seams over the read-model, like every other byte the overlay renders. |
 | 2026-08-01 | **`DES-ADMIN-VIA-PI-EXTENSION` amended** (issue #71, dashboard usability): the LIST runs list becomes a cursor-following 10-row viewport over the read model's 50-record window with `↑/↓ N more` edge markers (raising the fetch from 10 to 50 without growing the frame); `Tab` jumps between the trigger and run section heads; `o` cycles the runs sort (time → tokens → cost → outcome — absent numbers sort last because a pre-metering record is unknown, not cheap, and Enter opens the row the sorted list shows because cursor and renderer share one rows model); the long-advertised-but-unbound `l` now opens the live tail of the active job and stays inert without one; LIVE_TAIL opens pinned to the bottom in follow mode (scroll-up pauses, bottom re-arms, footer names the state — it previously opened ~180 lines behind the head at the top of the tail window); RUN_DETAIL gains `←`/`→` in-place record walking with the LIST cursor following; a cron trigger row in LIST carries the amber `⚠ overdue`/`⚠ stalled` badge previously visible only in TRIGGER_DETAIL; and `x` delete arms an in-frame y/n whose `y` alone signals `deleteTrigger` with `confirmed: true`, letting `deleteTriggerEntry` skip the duplicate `ctx.ui.confirm` while still writing through the shared validator — the dialog path is unchanged for the model-initiated `dispatch_trigger_delete` tool, whose `confirmedWrite` gate is **UNCHANGED, checked**. The fallback `matchesKey` in `keys.mjs` learned `left`/`right`/`home`/`end`/`backspace` so the overlays' new keys cannot be silently eaten when pi-tui is unresolvable. No new read-model surface, no new fs access; the dashboard's source-regex fs ban is **UNCHANGED, checked**. |

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -942,6 +942,37 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   spends nothing. Given a failure enqueueing replica *k*, then the receiver answers 503 with replicas
   `1..k-1` queued, and the redelivery converges on exactly *n* jobs rather than *n + k − 1*.
 
+## REQ-DEPLOYMENT-BOOTSTRAP
+
+- **Statement**: The CLI shall take a fresh machine to a preflighted deployment through **create-only
+  scaffolds and per-action consented host mutations** — `pi-dispatch init` (scaffold), `pi-dispatch
+  doctor [--fix]` (preflight; offered fixes), `pi-dispatch up [--yes]` (the consented sequence:
+  default-image pull+tag, loopback Valkey start, scaffold, preflight) — and shall never perform an
+  unshown host mutation, never touch an existing config value, and never spend a token.
+- **Scope**: Deployment setup and repair on the operator's own host. Not job execution, not forge-side
+  configuration (webhooks, branch protection, App installation), not process supervision (a later
+  slice), not the admin extension.
+- **Why**: The quickstart was five hand-typed infra chores whose commands were already fixed strings —
+  automation removes typing, not decisions. The decisions stay human: every mutating action is printed
+  verbatim and runs only on an explicit accept (y/N, default No, No on non-TTY), because "pulled onto
+  that host yourself" (`SECURITY.md`) is a trust property the consent keypress preserves and a silent
+  bootstrap would erase. Fix tiers are closed sets (`DES-CLI-SURFACE`): silent = init's create-only
+  scaffolds + `mkdir` of env-declared paths; prompted = the deployment's own default image, the
+  loopback Valkey, an overlay `auth.json` delete, an `import-pi` restage under its own gates; never =
+  malformed-config rewrites, triggers/pause-windows content, trigger-named images, semantic env
+  guesses. `up` may set `WEBHOOK_SECRET` in a scaffolded `.env` **only when the key is empty** — a
+  generated secret is never printed and an operator's value is never replaced.
+- **Traces to**: `DES-CLI-SURFACE`, `CONST-BUDGET-BEFORE-TOKENS`, `SECURITY.md` (pull-it-yourself),
+  `REQ-GLOBAL-PI-OVERLAY` (doctor's existing obligations)
+- **Acceptance**: Given `up` with every prompt declined, then no docker command runs, init reports its
+  usual kept/written lines, doctor renders, and the summary names each skipped action. Given `--yes`,
+  then exactly the shown commands run, in order. Given a `.env` whose `WEBHOOK_SECRET` has a value,
+  then `up` leaves the byte untouched. Given `doctor --fix` on non-TTY stdin, then every prompt-tier
+  fix is skipped as declined. Given a failing check with no fix action (malformed JSON, a missing
+  trigger-named image), then `--fix` prints today's fix line and offers nothing. Given any `up` run,
+  then no path reserves budget, enqueues a job, or reads a provider key beyond doctor's existing
+  presence checks.
+
 ## Notes (not requirements)
 
 **Capacity and cost.** ~1.5–2.5 GB RAM per job (pi + dev server + headless Chromium) and roughly
@@ -960,6 +991,7 @@ wait-list working as designed, not a failure — see `README.md`.
 
 | Date | Change |
 |---|---|
+| 2026-08-02 | Consented bootstrap (issue #80). Added **REQ-DEPLOYMENT-BOOTSTRAP**: `pi-dispatch up [--yes]` and `doctor --fix` take a fresh machine to a preflighted deployment through create-only scaffolds and per-action consented host mutations — every mutating command printed verbatim, y/N default No (No on non-TTY), closed fix tiers with an explicit never-set (malformed-config rewrites, triggers/pause-windows content, trigger-named `run.image`, semantic env guesses), `WEBHOOK_SECRET` set only when empty and never printed. Automation removes typing, never decisions: the consent keypress preserves SECURITY.md's "pulled onto that host yourself" property that a silent bootstrap would erase. **CONST-BUDGET-BEFORE-TOKENS UNCHANGED, checked**: no bootstrap path reserves budget, enqueues, or spends — `up` ends at doctor, not at a job. **REQ-GLOBAL-PI-OVERLAY UNCHANGED, checked**: doctor's overlay obligations are cited by the new REQ, not moved; `--fix`'s overlay actions (auth.json delete, import-pi restage) re-execute existing gates. |
 | 2026-08-02 | Doctor grows the missing receiver-side preflight (issue #80). **REQ-BRANCH-PROTECTION-PRECONDITION** amended: `doctor` now states at setup time that github branch protection cannot be preflighted statically (github triggers take their repo from each delivery — `run.repository` is azure-only) and names the actual enforcement point, per job pre-spend; a read-only capped `gh api` preflight helper ships for when repos are statically known, warn-never-fail, never offering to enable protection. Doctor also warns on the receiver-boot hard-requirements it previously ignored (WEBHOOK_SECRET; Forgejo and Azure credentials mirroring the existing GitLab block), gated on which forges the triggers file actually names, preserving warn-not-fail ("a deployment can legitimately be mid-setup") and presence-only secret checks. **REQ-TRIGGER-AUTHOR-GATE UNCHANGED, checked**: every new check reads state; none writes or gates anything. **CONST-MERGE-NEVER-AUTOMATIC UNCHANGED, checked**: the preflight surfaces the backstop's precondition earlier; the backstop itself is untouched. |
 | 2026-08-01 | Added **`REQ-COST-ANALYTICS`** (issue #53): the COSTS view, `/dispatch costs` (+`whatif`), and the `dispatch_costs` read tool over one retention-bounded fold — per-flow/per-model/per-day spend, subscription verdicts with the API-rate comparison, and what-if re-pricing through the pricing façade. The **labeling rules are requirements, not conventions**: every dollar carries its class through one shared formatter; plan-covered runs never render `$0.00` and uncovered zero-rate runs render `$0 (unrated)`, never "free"; estimates are always marked and demote any sum they enter, with coverage; floors keep their `≥`; undisclosed quota limits produce facts only, never burn-down; seeding is measured-median-first with the `OQ-002` band as the labeled last resort, always a band; the surface names its window and retention bound. The screen informs and changes nothing — no auto-switching, no new network surface, no database. **`REQ-ADMIN-VIA-PI-EXTENSION` amended**: `costs` joins the command inventory and `dispatch_costs` the read tools; the confirm-gate posture is **UNCHANGED, checked** (costs is a read; the write gates neither grew nor moved). `CONST-BUDGET-BEFORE-TOKENS` **UNCHANGED, checked**: analytics reads what enforcement recorded and touches no reservation path. |
 | 2026-08-01 | **`REQ-TOKEN-ACCOUNTING-AND-CAPS` amended** (issue #53, gap 1): obligation (a) grows the per-(provider,model) **ledger** — the meter keeps the full cache split (`cacheRead`/`cacheWrite`/`cacheWrite1h`/`reasoning`) per model that the flat totals collapse, emits it as the exit line's `usage` block (8 named rows max + an `other` row absorbing overflow and model-less calls; rows sum to `total`; stamped with the pricing pi-ai's version), and the worker persists it beside host-effective `provider`/`model` on every terminal path. The statement records the two honesty rules: a model-less call lands on `other`, **never guessed onto a model**, and the fallback meter keeps **no** ledger — `usage: null` is the reader's signal, not an error. Enforcement (`maxTokens`, `dailyTokenCap`) is **UNCHANGED, checked**: the ledger is accounting only, and the number `recordTokenSpend` charges is still the flat billed total. |

--- a/worker/src/cli.mjs
+++ b/worker/src/cli.mjs
@@ -9,7 +9,8 @@ import { gitDirty } from "./git-dirty.mjs";
 const USAGE = `pi-dispatch — run pi coding-agent flows on your own folders
 
   pi-dispatch init         scaffold .env + triggers.json + pause-windows.json + pi-packages.json + subscriptions.json here
-  pi-dispatch doctor       preflight Docker, Valkey, the job image, and your provider key
+  pi-dispatch doctor [--fix]  preflight Docker, Valkey, the job image, and your provider key; --fix offers to run each fix (y/N per action)
+  pi-dispatch up [--yes]   one consented pass: pull+tag the job image, start Valkey, init, doctor
   pi-dispatch import-pi    stage your host pi setup (models/skills/persona) into a global overlay
                            [--no-extensions] [--with-packages] [--packages-file <path>]
                            [--from <agentDir>] [--to <overlayDir>]
@@ -40,7 +41,13 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
 
 	if (cmd === "doctor") {
 		const { runDoctor } = await import("./doctor.mjs");
-		return runDoctor(env);
+		// `fix` rides in the deps position (runDoctor(env, depsOrOpts)) — one options bag, no third arg.
+		return runDoctor(env, { fix: argv.slice(1).includes("--fix") });
+	}
+
+	if (cmd === "up") {
+		const { runUp } = await import("./up.mjs");
+		return runUp(argv.slice(1), { env });
 	}
 
 	if (cmd === "import-pi") {

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -35,10 +35,19 @@
  * a manifest naming a staged dir that is gone, and a trigger that explicitly requires packages nobody staged.
  * Both end the same way -- pi skips an absent local source with no error, and the flow exits 0 without the
  * tools it was written for.
+ *
+ * `doctor --fix` (issue #80, REQ-DEPLOYMENT-BOOTSTRAP) turns SOME fix lines into offers, per failing check.
+ * The tier ladder is deliberate: a silent tier for the two fixes whose decision the operator already made
+ * (init's create-only scaffolds; mkdir of a directory an env var already names), a prompt tier (y/N,
+ * default No, the exact command shown first) for the rest, and a never tier for everything doctor could
+ * only fix by guessing -- see the fixAction comment at its first use below. Offering fixes changes NOTHING
+ * about severity: a --fix run still exits by the same failed/ok logic, warns stay warns, and the fix pass
+ * happens at most once (check, fix, re-check -- never a loop).
  */
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { spawn as nodeSpawn } from "node:child_process";
 import { defaultSandboxDir, globalExtensionsEnabled } from "./config.mjs";
 import { isForgeKind } from "./forges.mjs";
@@ -60,6 +69,12 @@ const PROVIDER_KEYS = {
 // gh login scopes that reach well past what a job should ever hold — called out by name in the fix line.
 const BROAD_SCOPES = ["admin:org", "delete_repo", "workflow"];
 
+// The loopback Valkey, as one docker argv. Mirrors deploy/docker-compose.yml exactly: AOF on (the
+// wait-list must survive a reboot, REQ-QUEUE-BURST-NO-DROP), bound to 127.0.0.1 only (the queue is not a
+// public surface), restart unless-stopped, data on a named volume. Container and volume names are
+// pi-dispatch-prefixed so compose's own `valkey`/`valkey-data` never collide with these.
+const VALKEY_RUN = ["run", "-d", "--name", "pi-dispatch-valkey", "--restart", "unless-stopped", "-p", "127.0.0.1:6379:6379", "-v", "pi-dispatch-valkey-data:/data", "valkey/valkey:8", "valkey-server", "--appendonly", "yes"];
+
 export async function runDoctor(env = process.env, deps = {}) {
 	const {
 		cwd = process.cwd(),
@@ -68,7 +83,120 @@ export async function runDoctor(env = process.env, deps = {}) {
 		probeValkey = defaultProbeValkey,
 		fileExists = existsSync,
 		nodeVersion = process.versions.node,
+		// --fix (REQ-DEPLOYMENT-BOOTSTRAP): offer to run the exact fixes doctor already prints. The prompt
+		// is injectable so tests drive consent hermetically; the default is a readline y/N that answers No
+		// on empty input AND on non-TTY stdin -- a piped or CI `doctor --fix` runs nothing from the prompt
+		// tier, because nobody was at the keyboard to consent.
+		fix = false,
+		promptFn = defaultPromptFn,
+		// fs seams for the fixActions, injectable for the same hermetic-test reason as fileExists.
+		mkdir = mkdirSync,
+		chmod = chmodSync,
+		rm = rmSync,
 	} = deps;
+	const seams = { cwd, out, spawn, probeValkey, fileExists, nodeVersion, mkdir, chmod, rm };
+
+	let checks = await collectChecks(env, seams);
+	let failed = render(checks, out);
+
+	if (fix) {
+		const ran = await applyFixes(checks, seams, promptFn);
+		if (ran > 0) {
+			// Converge-to-green: the probes are idempotent and cheap, so ONE full re-collect answers "did
+			// the fixes take" without bookkeeping about which probe fed which check. At most once,
+			// structurally -- the re-check never re-enters the fix pass, so a fix that did not take is
+			// reported still-failing rather than retried forever.
+			checks = await collectChecks(env, seams);
+			const passing = checks.filter((c) => c.ok).length;
+			out(`\nre-check after fixes: ${passing} of ${checks.length} checks pass\n`);
+			for (const c of checks.filter((c) => !c.ok)) {
+				out(`${c.warn ? "⚠" : "✗"} ${c.label}\n    → ${c.fix}\n`);
+			}
+			// Recomputed with the SAME failed/ok logic as the first pass (warn-not-fail): --fix changes
+			// what doctor does, never how it judges. A converged run exits 0 because the checks pass now,
+			// not because attempting fixes earns credit.
+			failed = checks.some((c) => !c.ok && !c.warn);
+		}
+	}
+
+	out(failed ? "\ndoctor: some checks failed — fix the above, then re-run.\n" : "\ndoctor: ready. Start the worker with `pi-dispatch worker`.\n");
+	return failed ? 1 : 0;
+}
+
+/** The ✓/⚠/✗ lines plus each failure's fix, exactly as doctor has always printed them. Returns whether
+ *  any HARD check failed (a ⚠ never fails doctor). */
+function render(checks, out) {
+	let failed = false;
+	for (const c of checks) {
+		out(`${c.ok ? "✓" : c.warn ? "⚠" : "✗"} ${c.label}\n`);
+		if (!c.ok) {
+			out(`    → ${c.fix}\n`);
+			if (!c.warn) failed = true;
+		}
+	}
+	return failed;
+}
+
+/**
+ * The --fix pass (REQ-DEPLOYMENT-BOOTSTRAP): walk the rendered checks IN ORDER and act on each failing one
+ * that carries a fixAction. Returns how many fixes actually RAN -- a declined offer counts for nothing, so
+ * a decline-everything run re-checks nothing and ends exactly like a fix-less one.
+ */
+async function applyFixes(checks, seams, promptFn) {
+	let ran = 0;
+	for (const c of checks) {
+		if (c.ok || !c.fixAction) continue;
+		const fa = c.fixAction;
+		if (fa.tier === "prompt") {
+			// The exact command first, then consent, default No. The same philosophy that runs jobs with
+			// --pull=never holds here: nothing is fetched or started implicitly -- the y keypress IS the
+			// operator running the command themselves, and doctor only saves the retyping after it.
+			seams.out(`\nfix available: ${c.label}\n    $ ${fa.describe}\n`);
+			if (!(await promptFn("run this? [y/N] "))) {
+				seams.out(`skipped: ${c.label}\n`);
+				continue;
+			}
+		}
+		ran++;
+		let res;
+		try {
+			res = await fa.run(seams);
+		} catch (e) {
+			res = { ok: false, note: e?.message ?? String(e) };
+		}
+		seams.out(`${res.ok ? "fixed" : "fix failed"}: ${c.label}${res.note ? ` — ${res.note}` : ""}\n`);
+	}
+	return ran;
+}
+
+/**
+ * The default --fix consent prompt: y/N over readline, No unless the operator typed y/yes. Two refusals
+ * are load-bearing: EMPTY input is No (plain enter must never consent), and NON-TTY stdin is No without
+ * reading at all -- a piped or CI `doctor --fix` has nobody at the keyboard, so the prompt tier must
+ * execute nothing there. Streams are injectable and the function exported so tests exercise both refusals
+ * without owning the process's real stdin.
+ */
+export async function defaultPromptFn(question, { input = process.stdin, output = process.stdout } = {}) {
+	if (!input.isTTY) return false;
+	const { createInterface } = await import("node:readline/promises");
+	const rl = createInterface({ input, output });
+	try {
+		const answer = (await rl.question(question)).trim().toLowerCase();
+		return answer === "y" || answer === "yes";
+	} finally {
+		rl.close();
+	}
+}
+
+/**
+ * Run every probe and return the check list without rendering -- runDoctor renders it, and under --fix
+ * collects it a second time for the converge re-check. Exported for the never-tier doctrine pin in the
+ * tests (githubProtectionPreflight's precedent): the test walks the returned array and fails on any check
+ * that grows a `fixAction` outside the allowed set, so the never tier stays a tested contract rather than
+ * a comment.
+ */
+export async function collectChecks(env, seams) {
+	const { cwd, spawn, probeValkey, fileExists, nodeVersion } = seams;
 
 	const jobImage = env.PI_JOB_IMAGE ?? "pi-job:latest";
 	const valkeyUrl = env.VALKEY_URL ?? "redis://127.0.0.1:6379";
@@ -82,6 +210,28 @@ export async function runDoctor(env = process.env, deps = {}) {
 		warn: true, // advisory: env may be supplied by a service manager instead of a file
 		label: ".env present",
 		fix: "run `pi-dispatch init` to scaffold one (or supply env via your service manager)",
+		// `fixAction` -- what `doctor --fix` may offer for a failing check (REQ-DEPLOYMENT-BOOTSTRAP):
+		// { tier: "silent"|"prompt", describe: <the exact command>, run(seams) }. Silent runs unprompted
+		// and is reported after; ONLY two fixes qualify, because in both the operator already made the
+		// decision and only the mechanical remainder is left: (1) THIS one, delegating absent config files
+		// to init, which is create-only by contract (init.mjs header) and so can overwrite nothing; and
+		// (2) mkdir -p + chmod 700 of a directory an env var already names (the session store, below).
+		// Prompt shows the exact command and defaults to No. EVERY other check deliberately carries no
+		// fixAction -- the never tier: doctor never rewrites malformed JSON, never touches triggers or
+		// pause-windows CONTENT, never guesses a semantic env value (PI_GLOBAL_ALLOW_EXTENSIONS and kin),
+		// never touches branch protection, and never pulls a trigger-named run.image -- each custom image
+		// is a per-flow trust posture the operator chose, so only the deployment's OWN default image ever
+		// gains an offer. Fail loud and let the operator decide; the plain fix line still prints as before.
+		fixAction: {
+			tier: "silent",
+			describe: "pi-dispatch init",
+			run: async ({ out }) => {
+				// Lazy import: a doctor run without --fix (or without this failure) never loads init.
+				const { runInit } = await import("./init.mjs");
+				const code = runInit(cwd, { out });
+				return { ok: code === 0, note: "scaffolded by `pi-dispatch init` (create-only: existing files were kept)" };
+			},
+		},
 	});
 
 	const dockerCode = await runCmd(spawn, "docker", ["info"]);
@@ -103,6 +253,24 @@ export async function runDoctor(env = process.env, deps = {}) {
 		ok: imageCode === 0,
 		label: `Job image present (${jobImage})`,
 		fix: "docker pull ghcr.io/edgehero/pi-job:latest && docker tag ghcr.io/edgehero/pi-job:latest pi-job:latest  (or build image/Dockerfile)",
+		// Prompt tier, and ONLY for the deployment default: a PI_JOB_IMAGE the operator overrode is a trust
+		// choice this command cannot honestly satisfy (pulling ghcr's pi-job would not make THEIR image
+		// exist), so an overridden name keeps the plain fix line -- the same never-tier reasoning as the
+		// trigger-named run.image checks below. Jobs run with --pull=never and that stays true: the y
+		// keypress IS the operator pulling the repo's own image themselves.
+		...(jobImage === "pi-job:latest"
+			? {
+					fixAction: {
+						tier: "prompt",
+						describe: "docker pull ghcr.io/edgehero/pi-job:latest && docker tag ghcr.io/edgehero/pi-job:latest pi-job:latest",
+						run: async ({ spawn }) => {
+							if ((await runCmd(spawn, "docker", ["pull", "ghcr.io/edgehero/pi-job:latest"])) !== 0) return { ok: false, note: "docker pull failed" };
+							if ((await runCmd(spawn, "docker", ["tag", "ghcr.io/edgehero/pi-job:latest", "pi-job:latest"])) !== 0) return { ok: false, note: "docker tag failed" };
+							return { ok: true };
+						},
+					},
+				}
+			: {}),
 	});
 
 	// Issue #41: every DISTINCT image a trigger names in run.image, minus the deployment default already
@@ -360,6 +528,22 @@ export async function runDoctor(env = process.env, deps = {}) {
 		ok: await probeValkey(valkeyUrl),
 		label: `Valkey reachable (${valkeyUrl})`,
 		fix: "docker compose -f deploy/docker-compose.yml up -d",
+		// Prompt tier, and only for a LOOPBACK url (the shipped default): starting a local container cannot
+		// make a remote VALKEY_URL reachable, so a pointed-elsewhere deployment keeps the plain fix line
+		// rather than an offer that would mask the real problem. The argv mirrors the compose file's
+		// semantics exactly (VALKEY_RUN above).
+		...(/^redis:\/\/(127\.0\.0\.1|localhost)(:6379)?\/?$/.test(valkeyUrl)
+			? {
+					fixAction: {
+						tier: "prompt",
+						describe: `docker ${VALKEY_RUN.join(" ")}`,
+						run: async ({ spawn }) =>
+							(await runCmd(spawn, "docker", VALKEY_RUN)) === 0
+								? { ok: true }
+								: { ok: false, note: "docker run failed (is a container named pi-dispatch-valkey already present? `docker start pi-dispatch-valkey`)" },
+					},
+				}
+			: {}),
 	});
 
 	const keys = PROVIDER_KEYS[provider] ?? [`${provider.toUpperCase()}_API_KEY`];
@@ -411,10 +595,22 @@ export async function runDoctor(env = process.env, deps = {}) {
 		const dirOk = fileExists(overlay);
 		checks.push({ ok: dirOk, label: `Global overlay dir exists (${overlay})`, fix: "run `pi-dispatch import-pi`, or fix PI_GLOBAL_PI_DIR" });
 		if (dirOk) {
+			const overlayAuth = join(overlay, "auth.json");
 			checks.push({
-				ok: !fileExists(join(overlay, "auth.json")),
+				ok: !fileExists(overlayAuth),
 				label: "Overlay is credential-free (no auth.json)",
 				fix: "delete auth.json from the overlay — the provider key belongs in env, never a mounted file",
+				// Prompt, not silent, even though deleting it is always right for the OVERLAY: the file may
+				// be the operator's only copy of a credential they meant to keep elsewhere, and doctor
+				// deleting an operator's file unasked is a line not worth crossing for one saved keypress.
+				fixAction: {
+					tier: "prompt",
+					describe: `rm ${overlayAuth}`,
+					run: async ({ rm }) => {
+						rm(overlayAuth);
+						return { ok: true };
+					},
+				},
 			});
 			const modelsPath = join(overlay, "models.json");
 			let modelsOk = true;
@@ -457,12 +653,29 @@ export async function runDoctor(env = process.env, deps = {}) {
 			// prints nothing here.
 			const packagesDir = join(overlay, PACKAGES_SUBDIR);
 			if (fileExists(packagesDir)) {
+				// The restage offer shared by the two staleness checks below (prompt tier: it fetches and
+				// runs npm on this host). A child process through the injected spawn rather than an
+				// in-process call, so import-pi's own gates run unmodified -- the literal-secret abort, the
+				// admin-extension block, the printed-names vetting -- and its output is forwarded so the
+				// operator still reads the names of exactly what will load into their job containers.
+				const restageFixAction = {
+					tier: "prompt",
+					describe: `pi-dispatch import-pi --with-packages --to ${overlay}`,
+					run: async ({ spawn, out }) => {
+						const cli = fileURLToPath(new URL("./cli.mjs", import.meta.url));
+						// npm staging can be slow, so 10 minutes rather than runCmdCapture's default 30s.
+						const res = await runCmdCapture(spawn, process.execPath, [cli, "import-pi", "--with-packages", "--to", overlay], { env, cwd, timeoutMs: 600000 });
+						if (res.output) out(res.output);
+						return { ok: res.code === 0 };
+					},
+				};
 				const manifest = readStageManifest({ globalPiDir: overlay, readFile: (p) => readFileSync(p, "utf8"), fileExists });
 				if (!manifest) {
 					checks.push({
 						ok: false,
 						label: `Staged packages manifest readable (${PACKAGES_SUBDIR}/packages.json)`,
 						fix: "re-run `pi-dispatch import-pi --with-packages` -- without the manifest nothing knows what is staged, so no package is ever loaded",
+						fixAction: restageFixAction,
 					});
 				} else {
 					// A manifest entry whose dir is gone loads nothing, and pi reports no error for a package
@@ -472,6 +685,7 @@ export async function runDoctor(env = process.env, deps = {}) {
 						ok: missing.length === 0,
 						label: `Staged packages present (${manifest.packages.map((p) => `${p.name}@${p.version}`).join(", ")})`,
 						fix: `staged dir missing for ${missing.join(", ")} -- re-run \`pi-dispatch import-pi --with-packages\` to restage`,
+						fixAction: restageFixAction,
 					});
 					// The admin extension's twin, and blocked for the same reason import-pi blocks that one.
 					const admin = manifest.packages.filter((p) => ADMIN_RE.test(p.name) || ADMIN_RE.test(p.dir)).map((p) => p.name);
@@ -534,6 +748,18 @@ export async function runDoctor(env = process.env, deps = {}) {
 				ok: exists,
 				label: `Session store ${exists ? "exists" : "does not exist"} (${sessionsDir})`,
 				fix: `create it: mkdir -p ${sessionsDir} && chmod 700 ${sessionsDir}`,
+				// Silent tier: setting PI_SESSIONS_DIR WAS the decision, and it has already been made -- the
+				// mkdir is the mechanical remainder, creates only the path the env var names, and 0700 is
+				// the mode the fix line already prescribes (transcripts are PII-bearing, host-only).
+				fixAction: {
+					tier: "silent",
+					describe: `mkdir -p ${sessionsDir} && chmod 700 ${sessionsDir}`,
+					run: async ({ mkdir, chmod }) => {
+						mkdir(sessionsDir, { recursive: true });
+						chmod(sessionsDir, 0o700);
+						return { ok: true, note: "mode 0700" };
+					},
+				},
 			});
 			// Not a failure -- a warning, because it is a disclosure the operator may have accepted
 			// knowingly. A transcript holds tool output, file contents and the agent's own reasoning, which
@@ -585,16 +811,7 @@ export async function runDoctor(env = process.env, deps = {}) {
 		}
 	}
 
-	let failed = false;
-	for (const c of checks) {
-		out(`${c.ok ? "✓" : c.warn ? "⚠" : "✗"} ${c.label}\n`);
-		if (!c.ok) {
-			out(`    → ${c.fix}\n`);
-			if (!c.warn) failed = true;
-		}
-	}
-	out(failed ? "\ndoctor: some checks failed — fix the above, then re-run.\n" : "\ndoctor: ready. Start the worker with `pi-dispatch worker`.\n");
-	return failed ? 1 : 0;
+	return checks;
 }
 
 /**
@@ -772,14 +989,15 @@ function runCmd(spawn, cmd, args) {
  * Like runCmd but collects stdout+stderr into one combined string — gh moves its human output between
  * the two across versions, so callers get both. Resolves `{code, output}`; `code: null` when the command
  * could not be launched or overran the timeout (default 30s, so a hung docker daemon cannot stall doctor).
- * `opts.env` is passed through to the spawn so secrets can travel via env instead of argv.
+ * `opts.env` is passed through to the spawn so secrets can travel via env instead of argv; `opts.cwd`
+ * likewise, for the child-process fixActions that must run where doctor's own cwd seam points.
  */
 function runCmdCapture(spawn, cmd, args, opts = {}) {
 	const { timeoutMs = 30000 } = opts;
 	return new Promise((resolve) => {
 		let child;
 		try {
-			child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"], ...(opts.env ? { env: opts.env } : {}) });
+			child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"], ...(opts.env ? { env: opts.env } : {}), ...(opts.cwd ? { cwd: opts.cwd } : {}) });
 		} catch {
 			resolve({ code: null, output: "" });
 			return;

--- a/worker/src/env-file.mjs
+++ b/worker/src/env-file.mjs
@@ -1,0 +1,93 @@
+/**
+ * Single-key, never-clobber edits to a dotenv-style file.
+ *
+ * Exists for `pi-dispatch up`, which fills WEBHOOK_SECRET into a scaffolded .env without asking the
+ * operator to hand-run `openssl rand -hex 32`; the github setup flow (PR 6) will reuse it for the same
+ * reason. It is init's contract applied to a single key instead of a whole file: init never overwrites
+ * an existing file, and this never overwrites an existing VALUE — a key the operator already set is
+ * sacrosanct, because a tool that "helpfully" rotates a live webhook secret breaks every configured
+ * forge hook at once, silently. When the key is already set the input text is returned UNCHANGED
+ * (byte-identical), so callers can compare identity to know nothing happened.
+ *
+ * Deliberately dependency-free (node:fs only, and only in the thin wrapper): it must stay importable
+ * from any future setup command without dragging worker config or queue deps along.
+ */
+import { chmodSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+
+/**
+ * Pure transform over .env TEXT: set `key` to `value` only where nothing is set yet.
+ *
+ *   - `KEY=` (empty value, whitespace-only counts)      → that line becomes `KEY=value`, in place
+ *   - no set line, but a commented `# KEY=…` line       → the comment becomes `KEY=value`, in place
+ *   - no KEY line at all                                → `KEY=value` appended at the end
+ *   - `KEY=something` (any non-empty value, anywhere)   → text returned UNCHANGED
+ *
+ * Every other byte is preserved: lines are only ever replaced whole, CRLF endings survive on the
+ * replaced line, and the untouched remainder is never re-serialized. Ambiguity resolves to "do not
+ * touch" — a value like `KEY= # tbd` trims to a non-empty string and therefore counts as set, because
+ * the cost of wrongly leaving a key alone (operator sets it by hand) is a fraction of the cost of
+ * wrongly overwriting one.
+ */
+export function setEnvKeyIfEmpty(text, key, value) {
+	const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const setRe = new RegExp(`^\\s*${escaped}\\s*=(.*)$`);
+	const commentRe = new RegExp(`^\\s*#\\s*${escaped}\\s*=`);
+
+	const lines = text.split("\n");
+	// Replace a line wholesale, keeping a CRLF file's trailing \r so the file stays one convention.
+	const replaceLine = (i) => {
+		lines[i] = `${key}=${value}${lines[i].endsWith("\r") ? "\r" : ""}`;
+		return lines.join("\n");
+	};
+
+	// Pass 1: set lines. ANY non-empty value anywhere means the key is set — return the input text
+	// itself (not a copy) so callers can detect "unchanged" by identity. Otherwise remember the FIRST
+	// empty set line; a later commented duplicate must not win over it.
+	let firstEmpty = -1;
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i].endsWith("\r") ? lines[i].slice(0, -1) : lines[i];
+		const m = line.match(setRe);
+		if (!m) continue;
+		if (m[1].trim() !== "") return text;
+		if (firstEmpty === -1) firstEmpty = i;
+	}
+	if (firstEmpty !== -1) return replaceLine(firstEmpty);
+
+	// Pass 2: a commented-out `# KEY=` line (only reachable when no set line exists at all).
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i].endsWith("\r") ? lines[i].slice(0, -1) : lines[i];
+		if (commentRe.test(line)) return replaceLine(i);
+	}
+
+	// Pass 3: no trace of the key — append at the end, on its own line.
+	const base = text === "" || text.endsWith("\n") ? text : `${text}\n`;
+	return `${base}${key}=${value}\n`;
+}
+
+/**
+ * Read → setEnvKeyIfEmpty → write back ATOMICALLY (tmp + rename, the same shape as the admin's
+ * writeTriggers), so a watcher or a concurrent reader never sees a half-written .env. When the
+ * transform is a no-op the file is not touched at all — no tmp, no rename, no mtime churn — and
+ * `{ changed: false }` is returned so callers can say so.
+ *
+ * Mode: a .env at 0o600 (an operator who locked their secrets down) stays 0o600 — chmod on the tmp
+ * BEFORE the rename, so no window exists where the secret-bearing file is wider than it was. Any
+ * other mode is left to the platform default; this helper preserves a hardening choice, it does not
+ * impose one.
+ */
+export function updateEnvFile(path, key, value, deps = {}) {
+	const { fs = { readFileSync, writeFileSync, renameSync, statSync, chmodSync } } = deps;
+	const text = fs.readFileSync(path, "utf8");
+	const next = setEnvKeyIfEmpty(text, key, value);
+	if (next === text) return { changed: false };
+	const tmp = `${path}.tmp`;
+	fs.writeFileSync(tmp, next);
+	try {
+		if ((fs.statSync(path).mode & 0o777) === 0o600) fs.chmodSync(tmp, 0o600);
+	} catch {
+		// The file vanished between read and write, or the fs cannot stat: leave the tmp's default
+		// mode rather than failing an edit that is otherwise sound.
+	}
+	fs.renameSync(tmp, path);
+	return { changed: true };
+}

--- a/worker/src/up.mjs
+++ b/worker/src/up.mjs
@@ -1,0 +1,315 @@
+/**
+ * `pi-dispatch up` — the quickstart as ONE consented pass (issue #80). The README's five hand-typed
+ * chores (pull the job image, remember the re-tag, start Valkey, init, doctor) become a sequence, but
+ * every host mutation keeps a human in front of it: the EXACT command is printed, then a y/N prompt
+ * that defaults to No (`--yes` accepts them all, and the commands are still printed — consent is
+ * skippable, visibility is not).
+ *
+ * Doctrine this module must never drift from:
+ *   - init's never-clobber is contractual: up always calls runInit, and it always leaves existing
+ *     files (and an existing WEBHOOK_SECRET value) untouched — see env-file.mjs.
+ *   - up only ever pulls the repo's OWN default image (ghcr.io/edgehero/pi-job:latest, re-tagged
+ *     pi-job:latest). NEVER a trigger-named run.image: those are operator-declared and doctor's
+ *     presence check covers them — a setup convenience must not become "pull whatever the triggers
+ *     file happens to name" (the same reasoning as jobs running with --pull=never).
+ *   - no secrets printed: the generated WEBHOOK_SECRET is announced, never echoed.
+ *
+ * Converge-style, not transactional: a declined or failed step is reported and the pass continues, so
+ * one flaky pull does not hide the doctor report that says what else is missing. Exit code mirrors
+ * doctor's: 0 unless the docker daemon was unreachable up front (nothing else can be probed, so up
+ * stops there with 1) or doctor itself returned nonzero (its code is returned verbatim).
+ */
+import { randomBytes } from "node:crypto";
+import { spawn as nodeSpawn } from "node:child_process";
+import { chmodSync, existsSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { connect as netConnect } from "node:net";
+import { join } from "node:path";
+import { updateEnvFile } from "./env-file.mjs";
+
+// The one image up may ever fetch, and the local name jobs run under. Literal on purpose (not
+// env.PI_JOB_IMAGE): an operator who pointed PI_JOB_IMAGE elsewhere has outgrown the quickstart, and
+// up pulling an arbitrary configured name would break the only-our-own-image doctrine above.
+const UPSTREAM_IMAGE = "ghcr.io/edgehero/pi-job:latest";
+const LOCAL_IMAGE = "pi-job:latest";
+const PULL_ARGS = ["pull", UPSTREAM_IMAGE];
+const TAG_ARGS = ["tag", UPSTREAM_IMAGE, LOCAL_IMAGE];
+
+// deploy/docker-compose.yml's Valkey service, reproduced as one docker run: same image, AOF on
+// (REQ-QUEUE-BURST-NO-DROP), bound to localhost only (the queue is not a public surface), same
+// healthcheck, restart unless-stopped, and a named volume standing in for the compose volume.
+const VALKEY_VOLUME_ARGS = ["volume", "create", "pi-dispatch-valkey-data"];
+const VALKEY_RUN_ARGS = [
+	"run",
+	"-d",
+	"--name",
+	"pi-dispatch-valkey",
+	"--restart",
+	"unless-stopped",
+	"-p",
+	"127.0.0.1:6379:6379",
+	"-v",
+	"pi-dispatch-valkey-data:/data",
+	"--health-cmd",
+	"valkey-cli ping",
+	"--health-interval",
+	"10s",
+	"--health-timeout",
+	"3s",
+	"--health-retries",
+	"5",
+	"valkey/valkey:8",
+	"valkey-server",
+	"--appendonly",
+	"yes",
+];
+
+export async function runUp(argv = [], deps = {}) {
+	const {
+		env = process.env,
+		spawn = nodeSpawn,
+		out = (s) => process.stdout.write(s),
+		prompt = defaultPrompt,
+		fs = { existsSync, readFileSync, writeFileSync, renameSync, statSync, chmodSync },
+		probeTcp = defaultProbeTcp,
+		cwd = process.cwd(),
+		// Injected so tests can assert the secret never reaches output without fishing it back out of
+		// the written file. 32 bytes hex, matching doctor's `openssl rand -hex 32` fix line.
+		randomHex = () => randomBytes(32).toString("hex"),
+	} = deps;
+	let { runInitFn, runDoctorFn } = deps;
+	const yes = argv.includes("--yes");
+	const summary = [];
+
+	out("pi-dispatch up — one pass over the quickstart; every docker action asks first (--yes accepts)\n\n");
+
+	// (a) docker binary + daemon, before anything is offered: every mutation below runs through the
+	// docker CLI, so with the daemon down the prompts would only collect consent for failures.
+	// Distinguishes not-on-PATH from daemon-down exactly as doctor does (spawn error vs nonzero exit).
+	const dockerCode = await runCmd(spawn, "docker", ["version"]);
+	if (dockerCode !== 0) {
+		out(dockerCode === null ? "✗ Docker not found\n    → install Docker — `docker` was not found on PATH\n" : "✗ Docker daemon not responding\n    → start Docker (the daemon is not responding)\n");
+		out("\nup: cannot continue without Docker — fix the above, then re-run `pi-dispatch up`.\n");
+		return 1;
+	}
+	out("✓ Docker daemon reachable\n");
+
+	// (b) the default job image. Presence first, so the happy path re-run prompts for nothing.
+	if (await runCmd(spawn, "docker", ["image", "inspect", LOCAL_IMAGE]) === 0) {
+		out(`✓ Job image present (${LOCAL_IMAGE})\n`);
+		summary.push(["job image", `already present (${LOCAL_IMAGE})`]);
+	} else {
+		const accepted = await consent(
+			`The default job image (${LOCAL_IMAGE}) is not on this host. up would run:`,
+			[`docker ${PULL_ARGS.join(" ")}`, `docker ${TAG_ARGS.join(" ")}`],
+			{ yes, out, prompt },
+		);
+		if (!accepted) {
+			out("skipped — pull it later with the two commands above (or build image/Dockerfile yourself)\n");
+			summary.push(["job image", "skipped (declined) — jobs run with --pull=never, so nothing fetches it later"]);
+		} else if (await runStreamed(spawn, "docker", PULL_ARGS, out) !== 0) {
+			out("✗ docker pull failed — continuing; doctor below will re-check the image\n");
+			summary.push(["job image", "pull FAILED — re-run `pi-dispatch up`, or pull by hand"]);
+		} else if (await runStreamed(spawn, "docker", TAG_ARGS, out) !== 0) {
+			out("✗ docker tag failed — continuing; doctor below will re-check the image\n");
+			summary.push(["job image", `pulled, but tagging as ${LOCAL_IMAGE} FAILED — re-run the tag command by hand`]);
+		} else {
+			out(`✓ pulled and tagged ${LOCAL_IMAGE}\n`);
+			summary.push(["job image", `pulled ${UPSTREAM_IMAGE} and tagged it ${LOCAL_IMAGE}`]);
+		}
+	}
+
+	// (c) Valkey. A bare TCP probe of the default bind, not a redis PING: dependency-free, and the
+	// honest claim is only "something is listening". If our own compose-named container is up, docker
+	// can say so; if a listener exists that we cannot name, up must NOT offer a second Valkey — the
+	// port is taken, and `docker run` would only fail after consent.
+	if (await probeTcp("127.0.0.1", 6379)) {
+		const ps = await runCmdCapture(spawn, "docker", ["ps", "--filter", "name=pi-dispatch-valkey", "--format", "{{.Names}}"]);
+		const ours = ps.code === 0 && ps.output.split("\n").map((l) => l.trim()).includes("pi-dispatch-valkey");
+		out(`✓ something is listening on 6379 — assuming your Valkey${ours ? " (it is the pi-dispatch-valkey container)" : ""}\n`);
+		summary.push(["valkey", ours ? "container pi-dispatch-valkey already running" : "port 6379 already has a listener — left alone"]);
+	} else {
+		const accepted = await consent(
+			"Nothing is listening on 127.0.0.1:6379. up would start Valkey (same semantics as deploy/docker-compose.yml):",
+			[`docker ${VALKEY_VOLUME_ARGS.join(" ")}`, `docker ${quoteArgs(VALKEY_RUN_ARGS)}`],
+			{ yes, out, prompt },
+		);
+		if (!accepted) {
+			out("skipped — start it later with `docker compose -f deploy/docker-compose.yml up -d`\n");
+			summary.push(["valkey", "skipped (declined) — the queue needs it before `pi-dispatch worker` can drain"]);
+		} else if (await runStreamed(spawn, "docker", VALKEY_VOLUME_ARGS, out) !== 0) {
+			out("✗ docker volume create failed — continuing; doctor below will re-check Valkey\n");
+			summary.push(["valkey", "volume create FAILED — `docker compose -f deploy/docker-compose.yml up -d` is the fallback"]);
+		} else if (await runStreamed(spawn, "docker", VALKEY_RUN_ARGS, out) !== 0) {
+			out("✗ docker run failed — continuing; doctor below will re-check Valkey\n");
+			summary.push(["valkey", "container start FAILED — `docker compose -f deploy/docker-compose.yml up -d` is the fallback"]);
+		} else {
+			out("✓ started Valkey (container pi-dispatch-valkey, AOF on, bound to 127.0.0.1)\n");
+			summary.push(["valkey", "started container pi-dispatch-valkey (durable: --appendonly yes, restart unless-stopped)"]);
+		}
+	}
+
+	// (d) init — always, and unconditionally safe to re-run: its never-clobber is contractual, so an
+	// existing file is only ever reported, never overwritten. No consent gate for the same reason —
+	// nothing the operator wrote can be lost here.
+	out("\ninit (never overwrites — an existing file is reported and kept):\n");
+	runInitFn ??= (await import("./init.mjs")).runInit;
+	runInitFn(cwd, { out });
+	summary.push(["init", "ran — existing files were kept untouched, missing ones scaffolded"]);
+
+	// (e) WEBHOOK_SECRET, only into a .env that exists (init just scaffolded one unless the operator
+	// keeps env elsewhere — a service-manager deployment gets no file invented for it). Same
+	// never-clobber contract at key granularity: a value the operator set survives. The value itself
+	// is NEVER printed — a webhook secret in a scrollback is a webhook secret in a pastebin.
+	const envPath = join(cwd, ".env");
+	if (fs.existsSync(envPath)) {
+		if (updateEnvFile(envPath, "WEBHOOK_SECRET", randomHex(), { fs }).changed) {
+			out("\n✓ generated WEBHOOK_SECRET into .env (32 random bytes, hex — value not shown)\n");
+			summary.push(["WEBHOOK_SECRET", "generated into .env (value not shown; the receiver verifies deliveries with it)"]);
+		} else {
+			out("\n✓ WEBHOOK_SECRET already set in .env — left untouched\n");
+			summary.push(["WEBHOOK_SECRET", "already set — left untouched"]);
+		}
+	} else {
+		summary.push(["WEBHOOK_SECRET", "no .env here — skipped (set it wherever your env lives)"]);
+	}
+
+	// (f) doctor — always, verbatim: up converges what it can, doctor is the judge of what remains
+	// (provider key, forge env, overlay …), and its verdict is up's exit code.
+	out("\ndoctor:\n");
+	runDoctorFn ??= (await import("./doctor.mjs")).runDoctor;
+	const doctorCode = await runDoctorFn(env, { out });
+
+	// (g) the summary: what ran, what was skipped, what was already there — then the two commands
+	// that actually start work, so "up is green" flows straight into the first job.
+	out("\nup: summary\n");
+	for (const [name, note] of summary) {
+		out(`  ${name.padEnd(15)} ${note}\n`);
+	}
+	out(`
+Next:
+  edit ${envPath}
+      set ANTHROPIC_API_KEY (or your provider's key) — already logged into pi? leave it blank
+  pi-dispatch worker
+      drain the queue (keep it running in its own terminal, or as a service)
+  pi-dispatch run ./my-project --task "add type hints to utils.py"
+      queue your first job from another terminal
+`);
+	return doctorCode;
+}
+
+/**
+ * Show the exact commands, then ask. Printing happens with or without `--yes`: consent is what the
+ * flag waives, never visibility — every host mutation is on screen before it runs. The prompt
+ * defaults to No; only an explicit y/yes (any case) accepts.
+ */
+async function consent(intro, commands, { yes, out, prompt }) {
+	out(`\n${intro}\n`);
+	for (const c of commands) out(`  ${c}\n`);
+	if (yes) {
+		out("--yes: accepted\n");
+		return true;
+	}
+	const answer = await prompt("Proceed? [y/N] ");
+	return /^y(es)?$/i.test(String(answer ?? "").trim());
+}
+
+/** Re-join an argv array for display, quoting the args that contain spaces (e.g. "valkey-cli ping"). */
+function quoteArgs(args) {
+	return args.map((a) => (a.includes(" ") ? `"${a}"` : a)).join(" ");
+}
+
+/** Exit code of a spawned command; null when it could not launch (not on PATH) — mirrors doctor. */
+function runCmd(spawn, cmd, args) {
+	return new Promise((resolve) => {
+		let child;
+		try {
+			child = spawn(cmd, args, { stdio: "ignore" });
+		} catch {
+			resolve(null);
+			return;
+		}
+		child.on("error", () => resolve(null)); // ENOENT etc. — the binary is not available
+		child.on("close", (code) => resolve(code));
+	});
+}
+
+/**
+ * Run a CONSENTED command with its stdout+stderr streamed to `out` as it happens — a docker pull's
+ * progress is the operator's confirmation that the thing they approved is the thing running.
+ */
+function runStreamed(spawn, cmd, args, out) {
+	return new Promise((resolve) => {
+		let child;
+		try {
+			child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+		} catch {
+			resolve(null);
+			return;
+		}
+		child.stdout?.on("data", (d) => out(String(d)));
+		child.stderr?.on("data", (d) => out(String(d)));
+		child.on("error", () => resolve(null));
+		child.on("close", (code) => resolve(code));
+	});
+}
+
+/** Like runCmd but with stdout+stderr captured, for read-only lookups (docker ps). */
+function runCmdCapture(spawn, cmd, args) {
+	return new Promise((resolve) => {
+		let child;
+		try {
+			child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+		} catch {
+			resolve({ code: null, output: "" });
+			return;
+		}
+		let output = "";
+		child.stdout?.on("data", (d) => (output += d));
+		child.stderr?.on("data", (d) => (output += d));
+		child.on("error", () => resolve({ code: null, output }));
+		child.on("close", (code) => resolve({ code, output }));
+	});
+}
+
+/**
+ * Is anything listening on host:port? A plain TCP connect, deliberately not a redis PING: up needs
+ * "occupied or free", and a protocol probe would add a dependency only to answer a question doctor
+ * already answers properly right afterwards.
+ */
+function defaultProbeTcp(host, port, timeoutMs = 1500) {
+	return new Promise((resolve) => {
+		const socket = netConnect({ host, port });
+		const done = (result) => {
+			socket.destroy();
+			resolve(result);
+		};
+		socket.setTimeout(timeoutMs, () => done(false));
+		socket.on("connect", () => done(true));
+		socket.on("error", () => done(false));
+	});
+}
+
+/**
+ * Interactive y/N question on the real terminal; tests inject their own `prompt` instead.
+ *
+ * Non-TTY stdin is an immediate decline WITHOUT touching readline: against an already-ended stream
+ * (`up < /dev/null`, CI) `rl.question()`'s promise never settles and holds no handle, so Node would
+ * drain the event loop and exit 0 MID-SEQUENCE — silently skipping init and doctor while looking
+ * like success. The decline is printed so the transcript shows the question was asked and defaulted.
+ * A closed-mid-question readline (ctrl-D on a real terminal) declines the same way.
+ */
+export async function defaultPrompt(question, { input = process.stdin, output = process.stdout, isTTY = process.stdin.isTTY } = {}) {
+	if (!isTTY) {
+		output.write(`${question}(no interactive stdin — defaulting to No)\n`);
+		return "";
+	}
+	const { createInterface } = await import("node:readline/promises");
+	const rl = createInterface({ input, output });
+	try {
+		return await rl.question(question);
+	} catch {
+		return ""; // readline closed before an answer -- same contract as an empty answer: No
+	} finally {
+		rl.close();
+	}
+}

--- a/worker/test/doctor.test.mjs
+++ b/worker/test/doctor.test.mjs
@@ -1,9 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { githubProtectionPreflight, runDoctor } from "../src/doctor.mjs";
+import { PassThrough } from "node:stream";
+import { collectChecks, defaultPromptFn, githubProtectionPreflight, runDoctor } from "../src/doctor.mjs";
 
 // A fake `spawn`: plan keys are command-line prefixes ("docker info", "docker image", "docker run",
 // "gh auth status", "gh auth token") mapped to a canned exit code, a `{code, output}` pair (output is
@@ -724,4 +725,443 @@ test("githubProtectionPreflight: an unresolvable repo warns per repo, and the lo
 	assert.equal(checks.length, 6, "the cap line plus one warn per checked repo");
 	assert.ok(checks.slice(1).every((c) => !c.ok && c.warn && /could not resolve the default branch/.test(c.label)));
 	assert.ok(!calls.some((c) => c.args?.join(" ").includes("octo/r6")), "the sixth repo is never queried");
+});
+
+// -- doctor --fix (issue #80, REQ-DEPLOYMENT-BOOTSTRAP): offers, tiers, and the never-tier pin --------
+
+/** A y/N prompt recorder. `answer` is the canned reply (or a fn of the call count). */
+function promptRecorder(answer = false) {
+	const calls = [];
+	const fn = async (q) => {
+		calls.push(q);
+		return typeof answer === "function" ? answer(calls.length) : answer;
+	};
+	return { fn, calls };
+}
+
+/** A validating triggers file whose one cron trigger sets run.resume (REQ-RESUMABLE-SESSION). */
+function resumeTriggersFile() {
+	const path = join(mkdtempSync(join(tmpdir(), "pi-triggers-resume-")), "triggers.json");
+	const run = { kind: "local", folder: "/srv/repo", flow: "review", task: "nightly review", resume: true };
+	writeFileSync(path, JSON.stringify({ triggers: [{ on: { type: "cron", id: "nightly", pattern: "0 3 * * *" }, run }] }));
+	return path;
+}
+
+test("doctor: without --fix, a fixAction-bearing failure prints exactly the old fix line and asks nothing", async () => {
+	// The non-adopter byte-identity guard for --fix: same lines, same fixes, and the injected prompt is
+	// never consulted -- offering is strictly opt-in behavior.
+	const { fn: promptFn, calls: prompts } = promptRecorder(true);
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x" },
+		{ out, cwd: tmpdir(), spawn: fakeSpawn({ "docker info": 0, "docker image": 1 }), probeValkey: async () => false, fileExists: () => true, nodeVersion: "22.19.0", promptFn },
+	);
+	assert.equal(code, 1);
+	assert.match(
+		text(),
+		/✗ Job image present \(pi-job:latest\)\n    → docker pull ghcr\.io\/edgehero\/pi-job:latest && docker tag ghcr\.io\/edgehero\/pi-job:latest pi-job:latest {2}\(or build image\/Dockerfile\)\n/,
+	);
+	assert.match(text(), /✗ Valkey reachable \(redis:\/\/127\.0\.0\.1:6379\)\n    → docker compose -f deploy\/docker-compose\.yml up -d\n/);
+	assert.equal(prompts.length, 0, "no --fix, no prompt -- even with a promptFn injected");
+	assert.doesNotMatch(text(), /fix available|run this\?|skipped:|fixed:|re-check after fixes/);
+});
+
+test("doctor --fix: declining every offer runs nothing and leaves the exit code alone", async () => {
+	const calls = [];
+	const { fn: promptFn, calls: prompts } = promptRecorder(false);
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x" },
+		{ out, cwd: tmpdir(), spawn: fakeSpawn({ "docker info": 0, "docker image": 1 }, calls), probeValkey: async () => false, fileExists: () => true, nodeVersion: "22.19.0", fix: true, promptFn },
+	);
+	assert.equal(code, 1, "warn-not-fail doctrine: offering fixes changes nothing about severity");
+	// The EXACT command is shown before each prompt -- consent is to a command, not to a vibe.
+	assert.match(text(), /fix available: Job image present \(pi-job:latest\)\n {4}\$ docker pull ghcr\.io\/edgehero\/pi-job:latest && docker tag ghcr\.io\/edgehero\/pi-job:latest pi-job:latest\n/);
+	assert.match(
+		text(),
+		/fix available: Valkey reachable \(redis:\/\/127\.0\.0\.1:6379\)\n {4}\$ docker run -d --name pi-dispatch-valkey --restart unless-stopped -p 127\.0\.0\.1:6379:6379 -v pi-dispatch-valkey-data:\/data valkey\/valkey:8 valkey-server --appendonly yes\n/,
+	);
+	assert.match(text(), /skipped: Job image present \(pi-job:latest\)/);
+	assert.match(text(), /skipped: Valkey reachable/);
+	assert.deepEqual(prompts, ["run this? [y/N] ", "run this? [y/N] "]);
+	assert.ok(!calls.some((c) => ["pull", "tag", "run"].includes(c.args[0])), "no spawn beyond the probes: a declined offer executes nothing");
+	assert.doesNotMatch(text(), /re-check after fixes/, "nothing ran, so nothing is re-checked");
+});
+
+test("doctor --fix: accepting the image offer runs exactly docker pull then docker tag", async () => {
+	const calls = [];
+	const { out, text } = capture();
+	await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x" },
+		{
+			out,
+			cwd: tmpdir(),
+			spawn: fakeSpawn({ "docker info": 0, "docker image": 1, "docker pull": 0, "docker tag": 0 }, calls),
+			probeValkey: async () => true,
+			fileExists: () => true,
+			nodeVersion: "22.19.0",
+			fix: true,
+			promptFn: async () => true,
+		},
+	);
+	const acts = calls.filter((c) => ["pull", "tag"].includes(c.args[0]));
+	assert.deepEqual(
+		acts.map((c) => [c.cmd, ...c.args]),
+		[
+			["docker", "pull", "ghcr.io/edgehero/pi-job:latest"],
+			["docker", "tag", "ghcr.io/edgehero/pi-job:latest", "pi-job:latest"],
+		],
+		"exactly the printed command, as two argv arrays, in order",
+	);
+	assert.match(text(), /fixed: Job image present \(pi-job:latest\)/);
+});
+
+test("doctor --fix: the converge re-check reruns the probes once and reports green", async () => {
+	const calls = [];
+	const plan = { "docker info": 0, "docker image": 1, "docker pull": 0, "docker tag": 0 };
+	const inner = fakeSpawn(plan, calls);
+	// Once the tag lands, the next inspect finds the image -- the probes are idempotent, so the single
+	// re-collect is what honestly turns the report green.
+	const spawn = (cmd, args, opts) => {
+		const child = inner(cmd, args, opts);
+		if (cmd === "docker" && args[0] === "tag") plan["docker image"] = 0;
+		return child;
+	};
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x", GITHUB_AUTH_SOURCE: "pat" },
+		{ out, cwd: tmpdir(), spawn, probeValkey: async () => true, fileExists: () => true, nodeVersion: "22.19.0", fix: true, promptFn: async () => true },
+	);
+	assert.match(text(), /✗ Job image present \(pi-job:latest\)/, "the first pass reported the failure as always");
+	assert.match(text(), /re-check after fixes: \d+ of \d+ checks pass/);
+	assert.match(text(), /\ndoctor: ready\. Start the worker with `pi-dispatch worker`\.\n/);
+	assert.equal(code, 0, "converge-to-green: the exit code judges the re-checked list by the same failed/ok logic");
+});
+
+test("doctor --fix: accepting the valkey offer runs the exact loopback docker run argv, and converges", async () => {
+	const calls = [];
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x", GITHUB_AUTH_SOURCE: "pat" },
+		{
+			out,
+			cwd: tmpdir(),
+			spawn: fakeSpawn({ "docker info": 0, "docker image": 0, "docker run": 0 }, calls),
+			// Reachable exactly once the container has been started: the converge pass flips to ✓ only
+			// because the fix actually ran, not because fixing earns credit.
+			probeValkey: async () => calls.some((c) => c.cmd === "docker" && c.args[0] === "run"),
+			fileExists: () => true,
+			nodeVersion: "22.19.0",
+			fix: true,
+			promptFn: async () => true,
+		},
+	);
+	const run = calls.find((c) => c.cmd === "docker" && c.args[0] === "run");
+	assert.deepEqual(run.args, [
+		"run",
+		"-d",
+		"--name",
+		"pi-dispatch-valkey",
+		"--restart",
+		"unless-stopped",
+		"-p",
+		"127.0.0.1:6379:6379",
+		"-v",
+		"pi-dispatch-valkey-data:/data",
+		"valkey/valkey:8",
+		"valkey-server",
+		"--appendonly",
+		"yes",
+	]);
+	assert.match(text(), /fixed: Valkey reachable \(redis:\/\/127\.0\.0\.1:6379\)/);
+	assert.match(text(), /re-check after fixes/);
+	assert.equal(code, 0);
+});
+
+test("doctor --fix: the declared-but-absent session store is created silently -- mkdir -p, chmod 700, no prompt", async () => {
+	const sessionsDir = "/srv/pi-sessions";
+	const made = [];
+	const modes = [];
+	const { fn: promptFn, calls: prompts } = promptRecorder(true);
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x", PI_SESSIONS_DIR: sessionsDir, PI_TRIGGERS_FILE: resumeTriggersFile(), GITHUB_AUTH_SOURCE: "pat" },
+		{
+			out,
+			spawn: fakeSpawn(green),
+			probeValkey: async () => true,
+			nodeVersion: "22.19.0",
+			fix: true,
+			promptFn,
+			// The store exists once mkdir ran -- everything else exists throughout.
+			fileExists: (p) => (p === sessionsDir ? made.length > 0 : true),
+			mkdir: (p, o) => made.push([p, o]),
+			chmod: (p, m) => modes.push([p, m]),
+		},
+	);
+	assert.equal(prompts.length, 0, "silent tier: setting PI_SESSIONS_DIR was the decision -- no prompt for the mechanical mkdir");
+	assert.deepEqual(made, [[sessionsDir, { recursive: true }]]);
+	assert.deepEqual(modes, [[sessionsDir, 0o700]], "0700 exactly -- transcripts are PII-bearing");
+	assert.match(text(), /fixed: Session store does not exist \(\/srv\/pi-sessions\) — mode 0700/);
+	assert.match(text(), /re-check after fixes/);
+	assert.equal(code, 0, "the converge pass re-probes the now-existing store");
+});
+
+test("doctor --fix: a missing .env is delegated to init's create-only scaffolds, silently", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-fix-init-"));
+	const { fn: promptFn, calls: prompts } = promptRecorder(true);
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x", GITHUB_AUTH_SOURCE: "pat" },
+		{ out, cwd, spawn: fakeSpawn(green), probeValkey: async () => true, nodeVersion: "22.19.0", fix: true, promptFn },
+	);
+	assert.equal(prompts.length, 0, "scaffold delegation is silent -- init is create-only by contract and can overwrite nothing");
+	assert.ok(existsSync(join(cwd, ".env")), "init created the .env");
+	assert.match(text(), /created \.env {2,}from \.env\.example/, "init's own report is forwarded");
+	assert.match(text(), /fixed: \.env present — scaffolded by `pi-dispatch init` \(create-only: existing files were kept\)/);
+	assert.doesNotMatch(text().split("re-check after fixes")[1], /\.env present/, "the converge pass no longer lists it");
+	assert.equal(code, 0);
+});
+
+test("doctor --fix: accepting the overlay auth.json offer deletes the file and converges credential-free", async () => {
+	const dir = overlay({ auth: true });
+	const cwd = mkdtempSync(join(tmpdir(), "pi-fix-auth-"));
+	const { fn: promptFn, calls: prompts } = promptRecorder(true);
+	const { out, text } = capture();
+	const code = await runDoctor(overlayEnv(dir, { GITHUB_AUTH_SOURCE: "pat" }), {
+		out,
+		cwd,
+		spawn: fakeSpawn(green),
+		probeValkey: async () => true,
+		nodeVersion: "22.19.0",
+		fix: true,
+		promptFn,
+	});
+	assert.deepEqual(prompts, ["run this? [y/N] "], "prompt tier: deleting an operator's file always gets a look first");
+	assert.ok(text().includes(`    $ rm ${join(dir, "auth.json")}\n`), "the exact rm is shown before consent");
+	assert.ok(!existsSync(join(dir, "auth.json")), "the credential file is gone");
+	assert.match(text(), /fixed: Overlay is credential-free \(no auth\.json\)/);
+	assert.doesNotMatch(text().split("re-check after fixes")[1], /credential-free/, "the converge pass finds the overlay clean");
+	assert.equal(code, 0);
+});
+
+test("doctor --fix: accepting the restage offer re-runs import-pi as a child through the injected spawn", async () => {
+	const dir = overlay({ packages: [pkg(), pkg({ name: "pi-lint", version: "0.4.0", dir: "pi-lint", stage: false })] });
+	const cwd = mkdtempSync(join(tmpdir(), "pi-fix-restage-"));
+	const calls = [];
+	const env = overlayEnv(dir, { GITHUB_AUTH_SOURCE: "pat" });
+	const { fn: promptFn, calls: prompts } = promptRecorder(true);
+	const { out, text } = capture();
+	await runDoctor(env, {
+		out,
+		cwd,
+		spawn: fakeSpawn({ ...green, [process.execPath]: { code: 0, output: "restage-run-output\n" } }, calls),
+		probeValkey: async () => true,
+		nodeVersion: "22.19.0",
+		fix: true,
+		promptFn,
+	});
+	assert.deepEqual(prompts, ["run this? [y/N] "]);
+	assert.ok(text().includes(`    $ pi-dispatch import-pi --with-packages --to ${dir}\n`), "the offer names the exact command");
+	const child = calls.find((c) => c.cmd === process.execPath);
+	assert.ok(child, "import-pi runs as a child process, so its own gates and printed-names vetting run unmodified");
+	assert.ok(child.args[0].endsWith("cli.mjs"), "spawned through the real CLI entry");
+	assert.deepEqual(child.args.slice(1), ["import-pi", "--with-packages", "--to", dir]);
+	assert.equal(child.opts.env, env, "the child inherits doctor's env (PI_PACKAGES_FILE, PI_CODING_AGENT_DIR)");
+	assert.equal(child.opts.cwd, cwd, "and doctor's cwd seam, where pi-packages.json lives");
+	assert.match(text(), /restage-run-output/, "import-pi's own output is forwarded");
+	assert.match(text(), /fixed: Staged packages present \(pi-fmt@1\.2\.3, pi-lint@0\.4\.0\)/);
+	// The converge pass re-probes the real dirs; the fake spawn staged nothing, so the check honestly
+	// stays failing -- running a fix is reported, convergence is measured.
+	assert.match(text().split("re-check after fixes")[1], /✗ Staged packages present/);
+});
+
+test("doctor --fix: the default prompt answers No on non-TTY stdin and on plain enter", async () => {
+	// Non-TTY is refused without reading at all -- a piped/CI --fix run must execute nothing prompt-tier.
+	assert.equal(await defaultPromptFn("run this? [y/N] ", { input: new PassThrough(), output: new PassThrough() }), false);
+
+	// Plain enter on a TTY-shaped stream is No: consent is only ever an explicit y.
+	const emptyIn = new PassThrough();
+	emptyIn.isTTY = true;
+	const emptyAnswer = defaultPromptFn("run this? [y/N] ", { input: emptyIn, output: new PassThrough() });
+	emptyIn.write("\n");
+	assert.equal(await emptyAnswer, false);
+
+	const yesIn = new PassThrough();
+	yesIn.isTTY = true;
+	const yesAnswer = defaultPromptFn("run this? [y/N] ", { input: yesIn, output: new PassThrough() });
+	yesIn.write("y\n");
+	assert.equal(await yesAnswer, true);
+});
+
+test("doctor --fix: piped stdin executes nothing from the prompt tier, end to end", async () => {
+	const calls = [];
+	const { out, text } = capture();
+	const code = await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x" },
+		{
+			out,
+			cwd: tmpdir(),
+			spawn: fakeSpawn({ "docker info": 0, "docker image": 1 }, calls),
+			probeValkey: async () => true,
+			fileExists: () => true,
+			nodeVersion: "22.19.0",
+			fix: true,
+			promptFn: (q) => defaultPromptFn(q, { input: new PassThrough(), output: new PassThrough() }),
+		},
+	);
+	assert.equal(code, 1);
+	assert.match(text(), /skipped: Job image present/);
+	assert.ok(!calls.some((c) => c.args[0] === "pull"), "default-No: nothing was pulled");
+});
+
+test("doctor --fix: secret values still never reach output", async () => {
+	const { out, text } = capture();
+	await runDoctor(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-secret-value", WEBHOOK_SECRET: "wh_secret_val_9", PI_TRIGGERS_FILE: forgeTriggersFile("github") },
+		{
+			out,
+			cwd: tmpdir(),
+			spawn: fakeSpawn({ ...green, "gh auth status": { code: 0, output: ghStatusOutput }, "gh auth token": { code: 0, output: "gho_secret_mint\n" }, "docker run": 0 }),
+			probeValkey: async () => false,
+			fileExists: () => true,
+			nodeVersion: "22.19.0",
+			fix: true,
+			promptFn: async () => true,
+		},
+	);
+	assert.doesNotMatch(text(), /sk-secret-value|gho_secret_mint|wh_secret_val_9/, "--fix changes nothing about secrets-and-pii");
+});
+
+// -- the never-tier doctrine pin: which checks may carry a fixAction, exactly, and no more ------------
+
+// The allowed set, by label and tier. THIS list is the doctrine (REQ-DEPLOYMENT-BOOTSTRAP): a future
+// check that grows a fixAction fails assertFixActionDoctrine by default, until someone deliberately adds
+// it here and answers for the trust ladder it sits on.
+const ALLOWED_FIXACTIONS = [
+	[/^\.env present$/, "silent"],
+	[/^Session store (exists|does not exist) \(/, "silent"],
+	[/^Job image present \(pi-job:latest\)$/, "prompt"],
+	[/^Valkey reachable \(redis:\/\/(127\.0\.0\.1|localhost)(:6379)?\/?\)$/, "prompt"],
+	[/^Overlay is credential-free \(no auth\.json\)$/, "prompt"],
+	[/^Staged packages manifest readable \(/, "prompt"],
+	[/^Staged packages present \(/, "prompt"],
+];
+
+/** Walk a check list; fail on any fixAction outside the allowed set. Returns the carrying labels. */
+function assertFixActionDoctrine(checks) {
+	const carried = [];
+	for (const c of checks) {
+		if (!c.fixAction) continue;
+		carried.push(c.label);
+		const allowed = ALLOWED_FIXACTIONS.find(([re]) => re.test(c.label));
+		assert.ok(allowed, `check "${c.label}" carries a fixAction outside the allowed set -- the never tier is doctrine`);
+		assert.equal(c.fixAction.tier, allowed[1], `check "${c.label}" carries the wrong tier`);
+		assert.equal(typeof c.fixAction.describe, "string", "every offer must show an exact command");
+		assert.equal(typeof c.fixAction.run, "function");
+	}
+	return carried;
+}
+
+const collectSeams = (plan, extra = {}) => ({
+	cwd: mkdtempSync(join(tmpdir(), "pi-fix-doctrine-")),
+	out: () => {},
+	spawn: fakeSpawn(plan),
+	probeValkey: async () => false,
+	fileExists: existsSync,
+	nodeVersion: "20.10.0",
+	...extra,
+});
+
+/** One validating triggers file that names every forge, a custom image, resume, and replicas. */
+function fullyBrokenTriggersFile() {
+	const path = join(mkdtempSync(join(tmpdir(), "pi-triggers-broken-")), "triggers.json");
+	const triggers = [
+		{ on: { type: "cron", id: "nightly", pattern: "0 3 * * *" }, run: { kind: "local", folder: "/srv/repo", flow: "review", task: "t", image: "custom-img:1", resume: true } },
+		{ on: { type: "label", any: ["pi:fix"] }, run: { kind: "github", flow: "fix", replicas: 2 } },
+		{ on: { type: "label", any: ["pi:fix"] }, run: { kind: "gitlab", flow: "fix" } },
+		{ on: { type: "label", any: ["pi:fix"] }, run: { kind: "forgejo", flow: "fix" } },
+		{ on: { type: "label", any: ["pi:fix"] }, run: { kind: "azure", flow: "fix", repository: "webapp" } },
+	];
+	writeFileSync(path, JSON.stringify({ triggers }));
+	return path;
+}
+
+test("doctor --fix doctrine: from a fully-broken env, no check outside the allowed set carries a fixAction", async () => {
+	// Everything that can fail does: old node, no .env, absent images (default AND trigger-named), gh
+	// missing, valkey down, no provider key, a poisoned overlay (auth.json, malformed models.json, a
+	// missing staged dir, an admin-alike package), a malformed extensions knob, all four forges
+	// misconfigured, and a declared-but-absent session store.
+	const dir = overlay({
+		auth: true,
+		models: "{not json",
+		extensions: true,
+		packages: [pkg(), pkg({ name: "pi-lint", version: "0.4.0", dir: "pi-lint", stage: false }), pkg({ name: "dispatch-admin", version: "0.1.0", dir: "dispatch-admin" })],
+	});
+	const env = {
+		PI_PROVIDER: "anthropic",
+		PI_AUTH_FROM_PI: "0",
+		PI_TRIGGERS_FILE: fullyBrokenTriggersFile(),
+		PI_GLOBAL_PI_DIR: dir,
+		PI_GLOBAL_ALLOW_EXTENSIONS: "maybe",
+		PI_SESSIONS_DIR: join(mkdtempSync(join(tmpdir(), "pi-sessions-parent-")), "absent"),
+		RECEIVER_PORT: "http",
+		AZURE_WEBHOOK_MODE: "hmac",
+	};
+	const checks = await collectChecks(env, collectSeams({ "docker info": 0, "docker image": 1, "gh auth": "enoent" }));
+	const carried = assertFixActionDoctrine(checks);
+	// The fixture must actually reach every eligible check -- a triggers-parse regression swallowed to
+	// zeroes would otherwise hollow this pin out silently.
+	for (const expected of [/^\.env present$/, /^Job image present \(pi-job:latest\)$/, /^Valkey reachable/, /^Overlay is credential-free/, /^Staged packages present/, /^Session store does not exist/]) {
+		assert.ok(carried.some((l) => expected.test(l)), `fixture failed to produce a fixAction for ${expected}`);
+	}
+	assert.equal(carried.length, 6, "exactly the eligible checks carry one, no more");
+	// The nevers, by name: each of these IS failing here and still gets no offer.
+	const never = (re, why) => {
+		const c = checks.find((x) => re.test(x.label));
+		assert.ok(c, `fixture lost the check ${re}`);
+		assert.ok(!c.ok, `the pinned check ${re} is expected to be failing here`);
+		assert.equal(c.fixAction, undefined, why);
+	};
+	never(/^Trigger job image present \(custom-img:1\)$/, "a trigger-named image is a per-flow trust posture -- never pulled for the operator");
+	never(/^PI_GLOBAL_ALLOW_EXTENSIONS is/, "a semantic env value is never guessed");
+	never(/^Overlay models\.json is credential-free$/, "malformed JSON is never rewritten");
+	never(/^Staged package looks like the dispatch admin/, "removing staged code is the operator's call");
+	never(/^Node ≥/, "doctor does not upgrade the host runtime");
+	never(/but WEBHOOK_SECRET is unset/, "secrets are never minted or set");
+	never(/AZURE_WEBHOOK_MODE is/, "an undefaulted mode must stay a chosen thing");
+	never(/GITHUB_AUTH_SOURCE is gh but/, "auth posture is never changed behind the operator");
+});
+
+test("doctor --fix doctrine: a missing manifest offers restage; overridden image and remote valkey never gain offers", async () => {
+	const dir = overlay({ packagesNoManifest: true });
+	const env = {
+		PI_PROVIDER: "anthropic",
+		ANTHROPIC_API_KEY: "sk-x",
+		PI_GLOBAL_PI_DIR: dir,
+		PI_JOB_IMAGE: "acme/pi-job:2",
+		VALKEY_URL: "redis://queue.internal:6379",
+	};
+	const checks = await collectChecks(env, collectSeams({ "docker info": 0, "docker image": 1, "gh auth": "enoent" }, { nodeVersion: "22.19.0" }));
+	assertFixActionDoctrine(checks);
+	const manifest = checks.find((c) => /^Staged packages manifest readable/.test(c.label));
+	assert.ok(manifest && !manifest.ok);
+	assert.equal(manifest.fixAction.tier, "prompt");
+	assert.equal(manifest.fixAction.describe, `pi-dispatch import-pi --with-packages --to ${dir}`);
+	const img = checks.find((c) => c.label === "Job image present (acme/pi-job:2)");
+	assert.ok(img && !img.ok);
+	assert.equal(img.fixAction, undefined, "an overridden PI_JOB_IMAGE is the operator's trust choice -- pulling the default could not honor it");
+	const valkey = checks.find((c) => c.label === "Valkey reachable (redis://queue.internal:6379)");
+	assert.ok(valkey && !valkey.ok);
+	assert.equal(valkey.fixAction, undefined, "a remote VALKEY_URL cannot be fixed by starting a local container");
+
+	// A trigger demanding packages nobody staged is a declaration problem, never auto-restaged: with an
+	// empty pi-packages.json a restage would 'succeed' into the same silent package-less job.
+	const c2 = await collectChecks(
+		{ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x", PI_GLOBAL_PI_DIR: overlay({}), PI_TRIGGERS_FILE: triggersFile(true) },
+		collectSeams(green, { nodeVersion: "22.19.0" }),
+	);
+	const req = c2.find((c) => /require staged packages/.test(c.label));
+	assert.ok(req && !req.ok);
+	assert.equal(req.fixAction, undefined, "which packages a flow needs is a semantic decision, never guessed");
 });

--- a/worker/test/env-file.test.mjs
+++ b/worker/test/env-file.test.mjs
@@ -1,0 +1,169 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { setEnvKeyIfEmpty, updateEnvFile } from "../src/env-file.mjs";
+
+// -- setEnvKeyIfEmpty: pure transform, table-driven over the text shapes it must handle ---------------
+//
+// `expected: null` means "byte-identical input back" — asserted by identity (===), because the wrapper
+// relies on identity to skip the write entirely, and a re-serialized equal COPY would defeat that.
+
+const cases = [
+	{
+		name: "empty value is filled in place",
+		text: "A=1\nWEBHOOK_SECRET=\nB=2\n",
+		expected: "A=1\nWEBHOOK_SECRET=s3cr3t\nB=2\n",
+	},
+	{
+		name: "whitespace around = and a whitespace-only value still count as empty",
+		text: "A=1\nWEBHOOK_SECRET =   \nB=2\n",
+		expected: "A=1\nWEBHOOK_SECRET=s3cr3t\nB=2\n",
+	},
+	{
+		name: "a commented line is uncommented in place when no set line exists",
+		text: "A=1\n# WEBHOOK_SECRET=\nB=2\n",
+		expected: "A=1\nWEBHOOK_SECRET=s3cr3t\nB=2\n",
+	},
+	{
+		name: "a commented line without the space after # also counts",
+		text: "#WEBHOOK_SECRET=old-note\nB=2\n",
+		expected: "WEBHOOK_SECRET=s3cr3t\nB=2\n",
+	},
+	{
+		name: "no trace of the key appends at the end",
+		text: "A=1\nB=2\n",
+		expected: "A=1\nB=2\nWEBHOOK_SECRET=s3cr3t\n",
+	},
+	{
+		name: "appending to text without a trailing newline first completes the last line",
+		text: "A=1",
+		expected: "A=1\nWEBHOOK_SECRET=s3cr3t\n",
+	},
+	{
+		name: "appending to empty text yields just the one line",
+		text: "",
+		expected: "WEBHOOK_SECRET=s3cr3t\n",
+	},
+	{
+		name: "an already-set value is NEVER clobbered",
+		text: "A=1\nWEBHOOK_SECRET=operator-chose-this\nB=2\n",
+		expected: null,
+	},
+	{
+		name: "an empty set line wins over a commented duplicate (the comment stays a comment)",
+		text: "# WEBHOOK_SECRET=doc note\nWEBHOOK_SECRET=\n",
+		expected: "# WEBHOOK_SECRET=doc note\nWEBHOOK_SECRET=s3cr3t\n",
+	},
+	{
+		name: "a non-empty set line wins over a later empty one (the key IS set)",
+		text: "WEBHOOK_SECRET=real\nWEBHOOK_SECRET=\n",
+		expected: null,
+	},
+	{
+		name: "ambiguity resolves to untouched: a value that is only a trailing comment counts as set",
+		text: "WEBHOOK_SECRET= # tbd\n",
+		expected: null,
+	},
+	{
+		name: "a key that merely prefixes another name does not match it",
+		text: "WEBHOOK_SECRET_OLD=x\n",
+		expected: "WEBHOOK_SECRET_OLD=x\nWEBHOOK_SECRET=s3cr3t\n",
+	},
+	{
+		name: "CRLF endings survive on the replaced line and everywhere else",
+		text: "A=1\r\nWEBHOOK_SECRET=\r\nB=2\r\n",
+		expected: "A=1\r\nWEBHOOK_SECRET=s3cr3t\r\nB=2\r\n",
+	},
+	{
+		name: "surrounding comments and blank lines are preserved byte-for-byte",
+		text: "# header comment\n\nA=1   \n# trailing note\nWEBHOOK_SECRET=\n\n# footer\n",
+		expected: "# header comment\n\nA=1   \n# trailing note\nWEBHOOK_SECRET=s3cr3t\n\n# footer\n",
+	},
+];
+
+for (const { name, text, expected } of cases) {
+	test(`setEnvKeyIfEmpty: ${name}`, () => {
+		const result = setEnvKeyIfEmpty(text, "WEBHOOK_SECRET", "s3cr3t");
+		if (expected === null) {
+			assert.equal(result, text, "unchanged means the INPUT text back, identically");
+		} else {
+			assert.equal(result, expected);
+		}
+	});
+}
+
+test("setEnvKeyIfEmpty: the unchanged case returns the same string object (identity, not just equality)", () => {
+	const text = "WEBHOOK_SECRET=set\n";
+	assert.ok(setEnvKeyIfEmpty(text, "WEBHOOK_SECRET", "x") === text);
+});
+
+// -- updateEnvFile: the thin fs wrapper — atomicity (tmp + rename) and mode preservation ---------------
+
+// A recording fake fs over one in-memory file. `ops` captures every call in order so tests can assert
+// the write is tmp-then-rename and never a direct write to the destination.
+function fakeFs(path, text, mode = 0o644) {
+	const files = new Map([[path, text]]);
+	const ops = [];
+	return {
+		files,
+		ops,
+		fs: {
+			readFileSync: (p) => {
+				ops.push(["read", p]);
+				return files.get(p);
+			},
+			writeFileSync: (p, data) => {
+				ops.push(["write", p, data]);
+				files.set(p, data);
+			},
+			renameSync: (from, to) => {
+				ops.push(["rename", from, to]);
+				files.set(to, files.get(from));
+				files.delete(from);
+			},
+			statSync: (p) => {
+				ops.push(["stat", p]);
+				return { mode: 0o100000 | mode };
+			},
+			chmodSync: (p, m) => {
+				ops.push(["chmod", p, m]);
+			},
+		},
+	};
+}
+
+test("updateEnvFile: writes the tmp file first, then renames it over the destination", () => {
+	const { fs, files, ops } = fakeFs("/deploy/.env", "WEBHOOK_SECRET=\n");
+	const result = updateEnvFile("/deploy/.env", "WEBHOOK_SECRET", "abc123", { fs });
+	assert.deepEqual(result, { changed: true });
+	assert.equal(files.get("/deploy/.env"), "WEBHOOK_SECRET=abc123\n");
+	const writes = ops.filter(([op]) => op === "write");
+	assert.deepEqual(writes, [["write", "/deploy/.env.tmp", "WEBHOOK_SECRET=abc123\n"]], "content lands on the tmp path only");
+	assert.ok(
+		ops.findIndex(([op]) => op === "write") < ops.findIndex(([op]) => op === "rename"),
+		"rename happens after the write",
+	);
+	assert.deepEqual(ops.at(-1), ["rename", "/deploy/.env.tmp", "/deploy/.env"]);
+});
+
+test("updateEnvFile: an already-set key writes NOTHING — no tmp, no rename, no mtime churn", () => {
+	const { fs, files, ops } = fakeFs("/deploy/.env", "WEBHOOK_SECRET=keep-me\n");
+	const result = updateEnvFile("/deploy/.env", "WEBHOOK_SECRET", "abc123", { fs });
+	assert.deepEqual(result, { changed: false });
+	assert.equal(files.get("/deploy/.env"), "WEBHOOK_SECRET=keep-me\n");
+	assert.deepEqual(ops, [["read", "/deploy/.env"]], "the file is read once and never touched");
+});
+
+test("updateEnvFile: a 0600 .env stays 0600 — chmod on the tmp BEFORE the rename", () => {
+	const { fs, ops } = fakeFs("/deploy/.env", "WEBHOOK_SECRET=\n", 0o600);
+	updateEnvFile("/deploy/.env", "WEBHOOK_SECRET", "abc123", { fs });
+	const chmodIdx = ops.findIndex(([op]) => op === "chmod");
+	assert.notEqual(chmodIdx, -1, "the tmp is chmodded");
+	assert.deepEqual(ops[chmodIdx], ["chmod", "/deploy/.env.tmp", 0o600]);
+	assert.ok(chmodIdx < ops.findIndex(([op]) => op === "rename"), "no window where the renamed file is wider than 0600");
+});
+
+test("updateEnvFile: any other mode is left alone (no chmod call at all)", () => {
+	const { fs, ops } = fakeFs("/deploy/.env", "WEBHOOK_SECRET=\n", 0o644);
+	updateEnvFile("/deploy/.env", "WEBHOOK_SECRET", "abc123", { fs });
+	assert.equal(ops.filter(([op]) => op === "chmod").length, 0);
+});

--- a/worker/test/up.test.mjs
+++ b/worker/test/up.test.mjs
@@ -1,0 +1,248 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { defaultPrompt, runUp } from "../src/up.mjs";
+
+// A fake `spawn`, mirroring doctor.test.mjs: plan keys are command-line prefixes ("docker version",
+// "docker image inspect", "docker pull", "docker tag", "docker ps", "docker volume", "docker run")
+// mapped to a canned exit code, a `{code, output}` pair, or "enoent" for a launch failure. Every spawn
+// is recorded into `calls` so tests can assert the EXACT argv of every host mutation.
+function fakeSpawn(plan, calls = []) {
+	return (cmd, args, opts) => {
+		const line = [cmd, ...args].join(" ");
+		const key = Object.keys(plan).find((k) => line.startsWith(k));
+		const outcome = plan[key];
+		calls.push({ cmd, args, opts });
+		const stream = () => ({
+			handlers: {},
+			on(ev, cb) {
+				this.handlers[ev] = cb;
+				return this;
+			},
+		});
+		const handlers = {};
+		const child = {
+			stdout: stream(),
+			stderr: stream(),
+			kill() {},
+			on(ev, cb) {
+				handlers[ev] = cb;
+				return this;
+			},
+		};
+		queueMicrotask(() => {
+			if (outcome === "enoent") {
+				handlers.error?.(new Error(`spawn ${cmd} ENOENT`));
+				return;
+			}
+			const { code, output } = typeof outcome === "object" && outcome !== null ? outcome : { code: outcome, output: "" };
+			if (output) child.stdout.handlers.data?.(output);
+			handlers.close?.(code);
+		});
+		return child;
+	};
+}
+
+// 64 hex chars, distinctive on purpose: the no-secret-in-output assertions grep for exactly this.
+const SECRET = "cafef00d".repeat(8);
+
+// Everything injected, everything recorded. `files` seeds the in-memory fs (path → text); the fake
+// init deliberately creates nothing, so a test that wants a .env after init seeds it up front.
+function harness({ plan = {}, listening = true, answers = [], files = {}, doctorCode = 0, argv = [] } = {}) {
+	const calls = [];
+	const promptCalls = [];
+	const initCalls = [];
+	const doctorCalls = [];
+	const buf = [];
+	const store = new Map(Object.entries(files));
+	const deps = {
+		env: { PI_PROVIDER: "anthropic" },
+		spawn: fakeSpawn(plan, calls),
+		out: (s) => buf.push(s),
+		prompt: (q) => {
+			promptCalls.push(q);
+			return answers.shift() ?? "";
+		},
+		fs: {
+			existsSync: (p) => store.has(p),
+			readFileSync: (p) => {
+				if (!store.has(p)) throw Object.assign(new Error(`ENOENT: ${p}`), { code: "ENOENT" });
+				return store.get(p);
+			},
+			writeFileSync: (p, data) => store.set(p, data),
+			renameSync: (from, to) => {
+				store.set(to, store.get(from));
+				store.delete(from);
+			},
+			statSync: () => ({ mode: 0o100600 }),
+			chmodSync: () => {},
+		},
+		probeTcp: async () => listening,
+		cwd: "/deploy",
+		randomHex: () => SECRET,
+		runInitFn: (cwd) => {
+			initCalls.push(cwd);
+			return 0;
+		},
+		runDoctorFn: (env) => {
+			doctorCalls.push(env);
+			return doctorCode;
+		},
+	};
+	return { run: () => runUp(argv, deps), calls, promptCalls, initCalls, doctorCalls, store, text: () => buf.join("") };
+}
+
+const green = { "docker version": 0, "docker image inspect": 0, "docker ps": { code: 0, output: "pi-dispatch-valkey\n" } };
+
+// The exact host mutations up may ever run — asserted array-for-array below, because "shown then run"
+// only holds if what runs is literally what was shown.
+const PULL = ["pull", "ghcr.io/edgehero/pi-job:latest"];
+const TAG = ["tag", "ghcr.io/edgehero/pi-job:latest", "pi-job:latest"];
+const VOLUME = ["volume", "create", "pi-dispatch-valkey-data"];
+const VALKEY_RUN = [
+	"run", "-d", "--name", "pi-dispatch-valkey", "--restart", "unless-stopped",
+	"-p", "127.0.0.1:6379:6379", "-v", "pi-dispatch-valkey-data:/data",
+	"--health-cmd", "valkey-cli ping", "--health-interval", "10s", "--health-timeout", "3s", "--health-retries", "5",
+	"valkey/valkey:8", "valkey-server", "--appendonly", "yes",
+];
+
+test("up: everything already in place prompts for nothing and exits 0", async () => {
+	const h = harness({ plan: green, listening: true });
+	assert.equal(await h.run(), 0);
+	assert.equal(h.promptCalls.length, 0, "nothing missing, nothing to consent to");
+	assert.match(h.text(), /Job image present \(pi-job:latest\)/);
+	assert.match(h.text(), /assuming your Valkey/);
+	assert.match(h.text(), /up: summary/);
+});
+
+test("up: declined prompts run NOTHING and the summary says skipped", async () => {
+	const h = harness({
+		plan: { "docker version": 0, "docker image inspect": 1 },
+		listening: false,
+		answers: ["", ""], // two prompts, both answered with Enter — the default is No
+	});
+	assert.equal(await h.run(), 0, "declining is not an error; doctor still ran and was green");
+	assert.equal(h.promptCalls.length, 2, "one consent per docker action pair (image, valkey)");
+	// The ONLY spawns are the two read-only probes — no pull, no tag, no volume, no run.
+	assert.deepEqual(h.calls.map((c) => c.args), [["version"], ["image", "inspect", "pi-job:latest"]]);
+	assert.match(h.text(), /job image\s+skipped \(declined\)/);
+	assert.match(h.text(), /valkey\s+skipped \(declined\)/);
+});
+
+test("up: --yes runs both docker action pairs with exactly the argv that was shown", async () => {
+	const h = harness({
+		plan: { "docker version": 0, "docker image inspect": 1, "docker pull": 0, "docker tag": 0, "docker volume": 0, "docker run": 0 },
+		listening: false,
+		argv: ["--yes"],
+	});
+	assert.equal(await h.run(), 0);
+	assert.equal(h.promptCalls.length, 0, "--yes waives every prompt");
+	const argvs = h.calls.map((c) => c.args);
+	assert.deepEqual(argvs.find((a) => a[0] === "pull"), PULL);
+	assert.deepEqual(argvs.find((a) => a[0] === "tag"), TAG);
+	assert.deepEqual(argvs.find((a) => a[0] === "volume"), VOLUME);
+	assert.deepEqual(argvs.find((a) => a[0] === "run"), VALKEY_RUN);
+	assert.ok(argvs.findIndex((a) => a[0] === "pull") < argvs.findIndex((a) => a[0] === "tag"), "pull before tag");
+	assert.ok(argvs.findIndex((a) => a[0] === "volume") < argvs.findIndex((a) => a[0] === "run"), "volume before run");
+	// --yes waives consent, never visibility: the commands are still printed before they run.
+	assert.match(h.text(), /docker pull ghcr\.io\/edgehero\/pi-job:latest/);
+	assert.match(h.text(), /docker volume create pi-dispatch-valkey-data/);
+});
+
+test("up: an image already present is never prompted for", async () => {
+	const h = harness({ plan: { "docker version": 0, "docker image inspect": 0 }, listening: false, answers: [""] });
+	await h.run();
+	assert.equal(h.promptCalls.length, 1, "only the valkey consent remains");
+	assert.match(h.promptCalls[0], /Proceed/);
+	assert.equal(h.calls.map((c) => c.args).find((a) => a[0] === "pull"), undefined);
+});
+
+test("up: something listening on 6379 never prompts and never runs docker run", async () => {
+	const h = harness({ plan: green, listening: true });
+	await h.run();
+	assert.equal(h.promptCalls.length, 0);
+	const argvs = h.calls.map((c) => c.args);
+	assert.equal(argvs.find((a) => a[0] === "run"), undefined);
+	assert.equal(argvs.find((a) => a[0] === "volume"), undefined);
+	assert.match(h.text(), /assuming your Valkey \(it is the pi-dispatch-valkey container\)/);
+});
+
+test("up: a foreign listener on 6379 is assumed but not claimed as ours", async () => {
+	const h = harness({ plan: { ...green, "docker ps": { code: 0, output: "" } }, listening: true });
+	await h.run();
+	assert.match(h.text(), /assuming your Valkey/);
+	assert.doesNotMatch(h.text(), /it is the pi-dispatch-valkey container/);
+});
+
+test("up: init and doctor always run, even when every docker action was declined", async () => {
+	const h = harness({ plan: { "docker version": 0, "docker image inspect": 1 }, listening: false, answers: ["n", "n"] });
+	await h.run();
+	assert.deepEqual(h.initCalls, ["/deploy"], "init ran, in the working directory");
+	assert.equal(h.doctorCalls.length, 1, "doctor ran");
+	assert.match(h.text(), /never overwrites/, "the never-clobber contract is said out loud");
+});
+
+test("up: WEBHOOK_SECRET is generated into an empty .env and the value NEVER reaches output", async () => {
+	const h = harness({ plan: green, files: { "/deploy/.env": "A=1\nWEBHOOK_SECRET=\n" } });
+	await h.run();
+	assert.equal(h.store.get("/deploy/.env"), `A=1\nWEBHOOK_SECRET=${SECRET}\n`, "the key was filled, other lines untouched");
+	assert.ok(!h.text().includes(SECRET), "the secret value must never be printed");
+	assert.match(h.text(), /generated WEBHOOK_SECRET/);
+});
+
+test("up: an operator's existing WEBHOOK_SECRET is never touched", async () => {
+	const h = harness({ plan: green, files: { "/deploy/.env": "WEBHOOK_SECRET=operator-chose-this\n" } });
+	await h.run();
+	assert.equal(h.store.get("/deploy/.env"), "WEBHOOK_SECRET=operator-chose-this\n");
+	assert.match(h.text(), /already set/);
+	assert.ok(!h.text().includes("operator-chose-this"), "existing values are secrets too");
+});
+
+test("up: no .env after init means the secret step is skipped, not invented", async () => {
+	const h = harness({ plan: green, files: {} });
+	assert.equal(await h.run(), 0);
+	assert.equal(h.store.has("/deploy/.env"), false, "up never creates a .env behind init's back");
+	assert.match(h.text(), /no \.env here/);
+});
+
+test("up: a down docker daemon returns 1 before any prompt, init, or doctor", async () => {
+	const h = harness({ plan: { "docker version": 1 }, listening: false });
+	assert.equal(await h.run(), 1);
+	assert.equal(h.promptCalls.length, 0, "no consent is collected for actions that cannot run");
+	assert.equal(h.initCalls.length, 0);
+	assert.equal(h.doctorCalls.length, 0);
+	assert.match(h.text(), /start Docker/, "a down daemon is distinguished from a missing binary");
+});
+
+test("up: a missing docker binary reads as 'install', not 'start', and also returns 1", async () => {
+	const h = harness({ plan: { "docker version": "enoent" } });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /install Docker/);
+});
+
+test("up: doctor's nonzero exit code propagates as up's own", async () => {
+	const h = harness({ plan: green, doctorCode: 1 });
+	assert.equal(await h.run(), 1);
+});
+
+test("up: a failed accepted pull is reported, skips the tag, and still reaches doctor (converge-style)", async () => {
+	const h = harness({
+		plan: { "docker version": 0, "docker image inspect": 1, "docker pull": 1 },
+		listening: true,
+		argv: ["--yes"],
+	});
+	assert.equal(await h.run(), 0, "a failed step does not fail up; doctor's verdict is the exit code");
+	assert.equal(h.calls.map((c) => c.args).find((a) => a[0] === "tag"), undefined, "no tag of an image that never arrived");
+	assert.equal(h.doctorCalls.length, 1);
+	assert.match(h.text(), /pull FAILED/);
+});
+
+test("defaultPrompt: non-TTY stdin declines immediately without readline (the event-loop-drain trap)", async () => {
+	// Against an ended stream, rl.question()'s promise never settles and holds no handle, so a real
+	// `up < /dev/null` would exit 0 mid-sequence, skipping init and doctor while looking like success.
+	// The guard turns that into an explicit printed decline. Regression test for exactly that run.
+	let printed = "";
+	const answer = await defaultPrompt("Proceed? [y/N] ", { isTTY: false, output: { write: (s) => (printed += s) } });
+	assert.equal(answer, "", "an empty answer is the No contract");
+	assert.match(printed, /Proceed\? \[y\/N\] /, "the question still reaches the transcript");
+	assert.match(printed, /defaulting to No/, "the default is stated, not silent");
+});


### PR DESCRIPTION
Second rung of #80, stacked on #83: the quickstart's five hand-typed chores become one consented pass, and doctor learns to offer its own fix lines.

## What

- **`pi-dispatch up [--yes]`** (`worker/src/up.mjs`): docker daemon check → consented pull+tag of the **default** job image → consented loopback Valkey start (reproducing `deploy/docker-compose.yml` semantics exactly: AOF, `127.0.0.1` bind, healthcheck, `restart: unless-stopped`, named volume) → `init` (create-only, as ever) → `WEBHOOK_SECRET` generated into `.env` **only when the key is empty**, value never printed → `doctor` → a summary naming what ran, what was skipped, and what to type next. The image pair is a deliberate literal — never `PI_JOB_IMAGE` — so a trigger-named `run.image` can never be fetched by this path; the consent keypress is SECURITY.md's "pulled onto that host yourself" act. `--yes` waives consent, never visibility: every command prints before it runs. An existing 6379 listener is probed and left alone (and only claimed as "the pi-dispatch-valkey container" when `docker ps` says it is).
- **`doctor --fix`**: per failing check, the exact fix doctor already prints is offered behind y/N default No — No on non-TTY stdin too. The tiers are **closed sets pinned by an inventory test** (a future check that grows a `fixAction` outside the allowed labels fails the suite): silent = init delegation + `mkdir`/`chmod 700` of the env-declared sessions dir; prompted = default-image pull+tag, loopback Valkey, overlay `auth.json` delete (prompted, not silent — it may be the operator's only credential copy), `import-pi` restage running under import-pi's own gates; never = malformed-JSON rewrites, triggers/pause-windows content, trigger-named images, semantic env guesses, branch protection. After fixes actually ran, one re-collect renders a `re-check after fixes` delta — converge-to-green, fix-at-most-once structurally.
- **`worker/src/env-file.mjs`**: `setEnvKeyIfEmpty` (pure; never-clobber implemented as string identity, so an untouched `.env` skips the write entirely) + atomic `updateEnvFile` preserving 0600. Built for `up` now, reused by the GitHub App setup flow later in #81.
- **One real bug found by the E2E smoke**: `rl.question()` against an already-ended stdin leaves an unsettled promise holding no handle, so `up < /dev/null` drained the event loop and exited 0 mid-sequence — looking like success while silently skipping init and doctor. Non-TTY stdin is now an explicit printed decline, with a regression test.

## Specs

New **`REQ-DEPLOYMENT-BOOTSTRAP`** (create-only scaffolds + per-action consent as a requirement, with the acceptance table) and **`DES-CLI-SURFACE`** (the CLI gate ladder: read-only / operator-typed-ungated / create-only / consented mutations, plus the load-bearing never-tier). `DES-WORKER-ON-HOST` "Accepted cost" amended — `up` shrinks the typing, not the price. Revision History rows in `design.md` + `requirements.md`; `CONST-BUDGET-BEFORE-TOKENS` (up spends nothing, ends at doctor), `REQ-GLOBAL-PI-OVERLAY`, `DES-CLI-TRIGGER-FOR-LOCAL` (up is not a producer), `INT-CONFIG-OVERLAY-CONTRACT` (repair-write precedent cited, not extended) — unchanged, checked.

## Tests

Full suite: **1682 tests, 1666 pass, 0 fail, 16 pre-existing skips.** New: up (15, incl. exact-argv assertions for every host mutation — "shown then run" only holds if what runs is literally what was shown), env-file (19), doctor --fix (14, incl. the never-tier doctrine pins and a piped end-to-end default-No). E2E smoke in a scratch dir: declined prompts run nothing; the full converge sequence completes on non-TTY. CI greps clean.
