### PR TITLE
feat: pi-dispatch setup github — App credentials in one browser click (issue #81)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,7 @@ GITHUB_AUTH_SOURCE=gh
 # For GITHUB_AUTH_SOURCE=pat: a repo-scoped, short-expiry fine-grained PAT
 GITHUB_PAT=
 # For GITHUB_AUTH_SOURCE=app (optional; required for multi-tenant)
+# `pi-dispatch setup github` fills all three in one browser click (App Manifest flow) and writes the PEM 0600
 GITHUB_APP_ID=
 GITHUB_APP_INSTALLATION_ID=
 GITHUB_APP_PRIVATE_KEY_PATH=

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -297,6 +297,13 @@ Stated openly rather than discovered later:
   scopes it carries (calling out broad ones like `admin:org`, `delete_repo`, `workflow`). Prefer a
   fine-grained PAT — or an App — for real per-job scoping. Your `~/.config/gh` is never mounted into a
   container; the credential reaches jobs only as env values.
+  **`pi-dispatch setup github` makes the App path the easy one** (issue #81): the GitHub App Manifest
+  flow mints the app id, private key, and webhook secret in one browser click, against a throwaway
+  listener on **your own loopback** — nothing crosses a maintainer-controlled service, the conversion
+  code is single-use and expires in an hour, and the wizard shows every `.env` line before writing it,
+  never prints a secret, writes the PEM `0600`, and refuses to overwrite an existing key file or an
+  already-set `WEBHOOK_SECRET`. The credential minted is the narrowest this system supports
+  (`contents`/`pull_requests`/`issues` write + `metadata` read, per-repo 1h installation tokens).
 - **On GitLab there is no stronger option to prefer.** GitLab has no App equivalent and no short-expiry
   per-job token, so your project access token is what every GitLab job gets, for as long as you leave it
   valid. Use a **project** token rather than a group token (a group token reaches every project in the

--- a/specs/design.md
+++ b/specs/design.md
@@ -568,6 +568,36 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   `SECURITY.md` requires), guess a semantic env value, or touch branch protection on a forge.
 - **Traces to**: `REQ-DEPLOYMENT-BOOTSTRAP`, `DES-CLI-TRIGGER-FOR-LOCAL`, `CONST-BUDGET-BEFORE-TOKENS`
 
+## DES-GH-APP-MANIFEST-SETUP
+
+- **Decision**: `pi-dispatch setup github` mints GitHub App credentials via the **App Manifest flow**:
+  a throwaway loopback HTTP listener serves a self-submitting form that POSTs the manifest to
+  `github.com/settings/apps/new` (or the `--org` variant), the browser redirect delivers a single-use
+  code (1h validity), and the unauthenticated `POST /app-manifests/{code}/conversions` returns the app
+  id, private-key PEM, and webhook secret in one response. The wizard then shows the exact `.env`
+  lines and writes them only on one explicit consent; the PEM lands beside `.env` with mode `0600`
+  (an existing key file refuses — never clobbered); an already-set `WEBHOOK_SECRET` is kept
+  (`setEnvKeyIfEmpty` — replacing it would invalidate working deliveries); the installation id is
+  discovered via an app JWT against `GET /app/installations` after the operator confirms installing.
+  `--no-webhook` creates the App with `hook_attributes.active:false` — the no-public-URL shape the
+  polling transport consumes.
+- **Why**: The App source is the strongest credential this system supports (SECURITY.md prefers it),
+  but acquiring it was the most manual mile in the whole setup: five settings pages, a hand-invented
+  webhook secret, and an installation id hunted from URLs. The manifest flow compresses all of it into
+  one click **without changing whose infrastructure is trusted**: the listener is the operator's own
+  loopback, GitHub is the only remote party, and no maintainer-controlled service ever sees a
+  credential. The JWT for installation discovery is ~15 lines of `node:crypto` RS256 on purpose —
+  auditable, dependency-light, and used once at setup time (job-time minting stays `@octokit/auth-app`
+  in `get-token.mjs`, unchanged).
+- **Gate ladder fit** (`DES-CLI-SURFACE`): operator-typed, and every write individually consented with
+  the content shown first; secrets never printed, redacted in every error path. There is deliberately
+  no `--yes` here — unlike `up`'s docker actions, these writes carry credentials.
+- **Rejected**: shipping a maintainer-registered OAuth client for device flow (inserts a maintainer
+  dependency into a self-hosted trust chain); auto-installing the App (the install page is a GitHub
+  consent screen — automating a consent screen defeats it).
+- **Traces to**: `DES-CLI-SURFACE`, `REQ-DEPLOYMENT-BOOTSTRAP`, `CONST-TOKEN-SCOPED-PER-JOB`,
+  `SECURITY.md` (auth-source ladder)
+
 ## DES-WORKER-ON-HOST
 
 - **Decision**: The worker runs **on the host** (a Node process, `pi-dispatch worker` / `npm start`), not
@@ -1544,6 +1574,7 @@ a tunnel.
 
 | Date | Change |
 |---|---|
+| 2026-08-02 | The App path becomes the easy path (issue #81). Added **DES-GH-APP-MANIFEST-SETUP**: `pi-dispatch setup github` runs GitHub's App Manifest flow against a throwaway loopback listener — one browser click returns app id + PEM + webhook secret via the unauthenticated single-use conversion endpoint; every `.env` line is shown before one explicit consent, the PEM lands 0600 and never clobbers, an existing `WEBHOOK_SECRET` is kept (replacing it would invalidate working deliveries), installation-id discovery uses a deliberately hand-rolled ~15-line `node:crypto` RS256 JWT (auditable, once-at-setup; job-time minting stays `@octokit/auth-app`, unchanged), and `--no-webhook` creates the hook-inactive shape the polling transport will consume. No `--yes` on this wizard — these writes carry credentials. Rejected on the record: a maintainer-registered device-flow client (maintainer dependency in a self-hosted trust chain) and auto-installing the App (automating a consent screen defeats it). **CONST-TOKEN-SCOPED-PER-JOB UNCHANGED, checked**: the wizard changes how credentials are *acquired*, not how job tokens are minted or scoped. **CONST-HMAC-OVER-RAW-BODY UNCHANGED, checked**: the webhook secret the flow mints feeds the same verify path. |
 | 2026-08-02 | The receiver gets a container story (issue #82). Repo-layout `deploy/` line updated: `docker compose --profile receiver up` runs the receiver beside Valkey from a prebuilt `ghcr.io/edgehero/pi-dispatch-receiver` image (multi-arch, GITHUB_TOKEN-published like pi-job); the default `docker compose up` stays Valkey-only. The receiver was the natural candidate — `grep docker receiver/src` is empty, it is the only internet-facing process, and containerising it costs nothing the trust model cares about. **DES-WORKER-ON-HOST UNCHANGED, checked**: the worker remains a host process — no service in the compose file mounts docker.sock, and the profile's existence changes nothing about why the worker cannot be containerised (client-side path translation, local-folder bind mounts). SECURITY.md's trusted-components row holds verbatim: a containerised receiver still never executes agent-authored content, and HMAC-before-parse is unchanged. |
 | 2026-08-02 | The clone stops being the only distribution (issue #80). **DES-NAME-KEEP-PI-DISPATCH amended, on its own terms**: its change trigger ("wanting to publish *any* npm artifact under this name — a management CLI") fired, and the resolution is scoped publishing (`@edgehero/pi-dispatch` = worker + CLI, `@edgehero/pi-dispatch-receiver`), not the rename — the collision only ever bound the bare name. The amendment also retro-records `@edgehero/pi-dispatch-admin`, which shipped 2026-07 without a row here: practice had diverged from the entry's unqualified "Do not publish to npm" line, and a constitution that quietly diverges from what ships is worse than none. The two checkout-relative runtime escapes are closed package-relative (worker/.env.example, worker/deploy/ mirrors with byte-equality sync tests against the root copies — the root files stay the documented, edited source). Bare `npx pi-dispatch` outside a checkout resolves to the squatter's package; docs use scoped forms everywhere. **DES-WORKER-ON-HOST UNCHANGED, checked**: npm-on-host is the architecturally correct distribution for a worker that must drive the host docker CLI. **CONST-PI-VERSION-PINNED UNCHANGED, checked**: the pins travel into the published packages byte-identical. |
 | 2026-08-02 | Durable running becomes a subcommand (issue #80). **DES-CONCURRENCY-3 amended**: the one-worker-per-docker-daemon boot-reaper invariant is now *enforced* at unit-mint time — `pi-dispatch service install` refuses a worker unit when one exists in the other scope; previously the invariant was one unenforced paragraph. `service` renders the shipped deploy/ templates by substituting their documented literals (`/usr/bin/node` → `process.execPath`, `/opt/pi-dispatch` → the real repo root) rather than introducing marker syntax, so the templates stay byte-usable examples and deploy-lint keeps checking exactly what ships; a pin test asserts every substitution literal is still present, making template drift a build failure instead of a broken render. The launchd gap is closed in the wrapper, not the plist: `KeepAlive/SuccessfulExit=false` cannot express exit-code-conditional restart, so `worker-env-wrapper.sh`/`.cmd` convert EXIT_POLICY (2) to a clean exit with a loud refusal note — launchd never relaunches a determinate policy refusal, mirroring systemd's `RestartPreventExitStatus=2` and nssm's `AppExit 2 Exit` (**CONST-RETRY-INFRA-ONLY UNCHANGED, checked**: the conversion is where the *supervisor* learns what the exit space already meant; the exit protocol itself is untouched). The wrapper's `exec` gave way to a trap/double-wait form because exit-2 interception needs a live parent — SIGTERM still reaches node via the trap. **DES-WORKER-ON-HOST UNCHANGED, checked**: `service` supervises the host process the entry mandates; nothing moves into a container. |

--- a/worker/.env.example
+++ b/worker/.env.example
@@ -97,6 +97,7 @@ GITHUB_AUTH_SOURCE=gh
 # For GITHUB_AUTH_SOURCE=pat: a repo-scoped, short-expiry fine-grained PAT
 GITHUB_PAT=
 # For GITHUB_AUTH_SOURCE=app (optional; required for multi-tenant)
+# `pi-dispatch setup github` fills all three in one browser click (App Manifest flow) and writes the PEM 0600
 GITHUB_APP_ID=
 GITHUB_APP_INSTALLATION_ID=
 GITHUB_APP_PRIVATE_KEY_PATH=

--- a/worker/src/cli.mjs
+++ b/worker/src/cli.mjs
@@ -11,6 +11,9 @@ const USAGE = `pi-dispatch — run pi coding-agent flows on your own folders
   pi-dispatch init         scaffold .env + triggers.json + pause-windows.json + pi-packages.json + subscriptions.json here
   pi-dispatch doctor [--fix]  preflight Docker, Valkey, the job image, and your provider key; --fix offers to run each fix (y/N per action)
   pi-dispatch up [--yes]   one consented pass: pull+tag the job image, start Valkey, init, doctor
+  pi-dispatch setup github mint GitHub App credentials in one browser click (App Manifest flow);
+                           every write shown first and individually consented — no --yes here
+                           (--webhook-url <URL> | --no-webhook) [--org <org>] [--name <appName>]
   pi-dispatch import-pi    stage your host pi setup (models/skills/persona) into a global overlay
                            [--no-extensions] [--with-packages] [--packages-file <path>]
                            [--from <agentDir>] [--to <overlayDir>]
@@ -52,6 +55,17 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
 	if (cmd === "up") {
 		const { runUp } = await import("./up.mjs");
 		return runUp(argv.slice(1), { env });
+	}
+
+	if (cmd === "setup") {
+		// Subcommand shape (`setup <forge>`) so future forges can land beside github without a new
+		// top-level verb; an unknown or missing target prints guidance rather than guessing.
+		if (argv[1] === "github") {
+			const { runGithubAppSetup } = await import("./github-app-setup.mjs");
+			return runGithubAppSetup(argv.slice(2), { env });
+		}
+		process.stdout.write(`pi-dispatch setup <target> — guided credential setup\n\n  targets: github\n\n  pi-dispatch setup github (--webhook-url <URL> | --no-webhook) [--org <org>] [--name <appName>]\n      mint GitHub App credentials via the App Manifest flow — one browser click returns the app id,\n      private key, and webhook secret; every write is shown first and individually consented\n`);
+		return argv[1] ? 1 : 0;
 	}
 
 	if (cmd === "import-pi") {

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -44,7 +44,7 @@
  * about severity: a --fix run still exits by the same failed/ok logic, warns stay warns, and the fix pass
  * happens at most once (check, fix, re-check -- never a loop).
  */
-import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, readSync, rmSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -483,6 +483,74 @@ export async function collectChecks(env, seams) {
 				label: "GITHUB_AUTH_SOURCE is gh but `gh auth status` failed",
 				fix: "run `gh auth login` (or switch GITHUB_AUTH_SOURCE) -- github jobs and run.github cron triggers will refuse to run",
 			});
+		}
+	}
+
+	// GITHUB_AUTH_SOURCE=app: completeness of the credential triple loadGitHubAuth hard-requires
+	// (config.mjs), preflighted here so a half-finished App setup surfaces as doctor lines instead of a
+	// boot refusal. WARN, never fail, same doctrine as the rest of the github block: a deployment can
+	// legitimately be mid-setup. The private key gets a hygiene pass on top — presence, POSIX mode, and
+	// a first-bytes PEM sniff — but its CONTENTS never reach output: only the leading bytes are read
+	// (never the whole key into memory), and nothing from the file is ever echoed. Every fix line points
+	// at `pi-dispatch setup github`, which mints all three values and writes the PEM 0600 in one pass.
+	if (ghSource === "app") {
+		const setupFix = "run `pi-dispatch setup github` -- it mints the App, writes these .env lines, and lands the key mode 0600";
+		const numeric = (v) => typeof v === "string" && /^\d+$/.test(v.trim());
+		for (const name of ["GITHUB_APP_ID", "GITHUB_APP_INSTALLATION_ID"]) {
+			checks.push({
+				ok: numeric(env[name]),
+				warn: true,
+				label: numeric(env[name])
+					? `${name} set (${env[name].trim()})`
+					: `GITHUB_AUTH_SOURCE=app but ${name} is ${env[name] ? `not numeric (${JSON.stringify(env[name])})` : "unset"} -- github jobs cannot mint tokens`,
+				fix: setupFix,
+			});
+		}
+		const keyPath = env.GITHUB_APP_PRIVATE_KEY_PATH;
+		if (!keyPath) {
+			checks.push({ ok: false, warn: true, label: "GITHUB_AUTH_SOURCE=app but GITHUB_APP_PRIVATE_KEY_PATH is unset -- the worker will refuse to boot", fix: setupFix });
+		} else if (!fileExists(keyPath)) {
+			checks.push({ ok: false, warn: true, label: `GITHUB_APP_PRIVATE_KEY_PATH does not exist (${keyPath})`, fix: setupFix });
+		} else {
+			checks.push({ ok: true, label: `GitHub App private key present (${keyPath})` });
+			// POSIX mode only -- on win32 stat modes are synthetic (0666-ish for everything), so a warn
+			// there would fire on every healthy deployment and teach operators to ignore it.
+			if (process.platform !== "win32") {
+				try {
+					const loose = statSync(keyPath).mode & 0o077;
+					if (loose !== 0) {
+						checks.push({
+							ok: false,
+							warn: true,
+							label: `the App private key at ${keyPath} is group/world-readable`,
+							fix: `chmod 600 ${keyPath} -- any local user can read the App's signing key right now (\`pi-dispatch setup github\` writes it 0600)`,
+						});
+					}
+				} catch {
+					// stat raced a deletion or an exotic fs: the presence line above already covered existence.
+				}
+			}
+			// First bytes only: enough to see "-----BEGIN", never the key material, and never echoed.
+			try {
+				const fd = openSync(keyPath, "r");
+				const head = Buffer.alloc(16);
+				let read = 0;
+				try {
+					read = readSync(fd, head, 0, head.length, 0);
+				} finally {
+					closeSync(fd);
+				}
+				if (!head.toString("utf8", 0, read).startsWith("-----BEGIN")) {
+					checks.push({
+						ok: false,
+						warn: true,
+						label: `the file at GITHUB_APP_PRIVATE_KEY_PATH does not look like a PEM (first line is not "-----BEGIN ...") -- contents not shown`,
+						fix: setupFix,
+					});
+				}
+			} catch {
+				checks.push({ ok: false, warn: true, label: `the App private key at ${keyPath} exists but is not readable by this user`, fix: setupFix });
+			}
 		}
 	}
 

--- a/worker/src/env-file.mjs
+++ b/worker/src/env-file.mjs
@@ -1,13 +1,18 @@
 /**
- * Single-key, never-clobber edits to a dotenv-style file.
+ * Single-key edits to a dotenv-style file, in two disciplines.
  *
- * Exists for `pi-dispatch up`, which fills WEBHOOK_SECRET into a scaffolded .env without asking the
- * operator to hand-run `openssl rand -hex 32`; the github setup flow (PR 6) will reuse it for the same
- * reason. It is init's contract applied to a single key instead of a whole file: init never overwrites
- * an existing file, and this never overwrites an existing VALUE — a key the operator already set is
- * sacrosanct, because a tool that "helpfully" rotates a live webhook secret breaks every configured
- * forge hook at once, silently. When the key is already set the input text is returned UNCHANGED
- * (byte-identical), so callers can compare identity to know nothing happened.
+ * `setEnvKeyIfEmpty` exists for `pi-dispatch up`, which fills WEBHOOK_SECRET into a scaffolded .env
+ * without asking the operator to hand-run `openssl rand -hex 32`. It is init's contract applied to a
+ * single key instead of a whole file: init never overwrites an existing file, and this never
+ * overwrites an existing VALUE — a key the operator already set is sacrosanct, because a tool that
+ * "helpfully" rotates a live webhook secret breaks every configured forge hook at once, silently.
+ *
+ * `setEnvKey` is the CONSENTED-overwrite sibling, added for `pi-dispatch setup github` (issue #81),
+ * whose whole point is replacing values like GITHUB_AUTH_SOURCE=gh with the App credentials the
+ * operator just minted and approved line-by-line. The consent lives at the CALLER, never here.
+ *
+ * Both return the input text UNCHANGED (byte-identical, same object) when there is nothing to do, so
+ * callers can compare identity to know nothing happened.
  *
  * Deliberately dependency-free (node:fs only, and only in the thin wrapper): it must stay importable
  * from any future setup command without dragging worker config or queue deps along.
@@ -65,10 +70,65 @@ export function setEnvKeyIfEmpty(text, key, value) {
 }
 
 /**
- * Read → setEnvKeyIfEmpty → write back ATOMICALLY (tmp + rename, the same shape as the admin's
+ * Pure transform over .env TEXT: set `key` to `value`, REPLACING whatever is there. The overwrite
+ * sibling of `setEnvKeyIfEmpty`, with the same line mechanics and the same first-match position rules:
+ *
+ *   - a set line `KEY=anything` (empty or not, whitespace tolerated)  → becomes `KEY=value`, in place;
+ *     the FIRST set line wins over later duplicates and over any commented line
+ *   - no set line, but a commented `# KEY=…` line                     → the comment becomes `KEY=value`
+ *   - no KEY line at all                                              → `KEY=value` appended at the end
+ *   - the first set line is already exactly `KEY=value`               → text returned UNCHANGED
+ *     (the input string object itself, so callers detect the no-op by identity, like the sibling)
+ *
+ * THE CONFIRM GATE LIVES AT THE CALLER. This function is mechanical and will happily replace a live
+ * credential; the wizard that calls it shows the exact lines it is about to write and collects an
+ * explicit y/N first (github-app-setup.mjs). Nothing in here asks, because a transform that sometimes
+ * prompts is untestable and a prompt that sometimes doesn't fire is not a gate. Every other byte is
+ * preserved exactly as in the sibling: whole-line replacement only, CRLF survives on the replaced
+ * line, the untouched remainder is never re-serialized. A matched line with stray whitespace
+ * (`KEY = old`) is normalised to canonical `KEY=value` — it is being rewritten anyway.
+ */
+export function setEnvKey(text, key, value) {
+	const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const setRe = new RegExp(`^\\s*${escaped}\\s*=`);
+	const commentRe = new RegExp(`^\\s*#\\s*${escaped}\\s*=`);
+
+	const lines = text.split("\n");
+	const replaceLine = (i) => {
+		lines[i] = `${key}=${value}${lines[i].endsWith("\r") ? "\r" : ""}`;
+		return lines.join("\n");
+	};
+
+	// Pass 1: the FIRST set line, whatever its value — this is the overwrite discipline. Already
+	// exactly `KEY=value` (modulo the CRLF tail) → the input object back, so the wrapper skips the write.
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i].endsWith("\r") ? lines[i].slice(0, -1) : lines[i];
+		if (!setRe.test(line)) continue;
+		if (line === `${key}=${value}`) return text;
+		return replaceLine(i);
+	}
+
+	// Pass 2: a commented-out `# KEY=` line (only reachable when no set line exists at all).
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i].endsWith("\r") ? lines[i].slice(0, -1) : lines[i];
+		if (commentRe.test(line)) return replaceLine(i);
+	}
+
+	// Pass 3: no trace of the key — append at the end, on its own line.
+	const base = text === "" || text.endsWith("\n") ? text : `${text}\n`;
+	return `${base}${key}=${value}\n`;
+}
+
+/**
+ * Read → transform → write back ATOMICALLY (tmp + rename, the same shape as the admin's
  * writeTriggers), so a watcher or a concurrent reader never sees a half-written .env. When the
  * transform is a no-op the file is not touched at all — no tmp, no rename, no mtime churn — and
  * `{ changed: false }` is returned so callers can say so.
+ *
+ * `overwrite` picks the transform: false (the default, and the only behaviour that existed before
+ * issue #81) applies `setEnvKeyIfEmpty`'s never-clobber discipline; true applies `setEnvKey`, for
+ * callers that have already shown the operator the exact line and collected consent — the gate is
+ * theirs, this wrapper stays mechanical either way.
  *
  * Mode: a .env at 0o600 (an operator who locked their secrets down) stays 0o600 — chmod on the tmp
  * BEFORE the rename, so no window exists where the secret-bearing file is wider than it was. Any
@@ -76,9 +136,9 @@ export function setEnvKeyIfEmpty(text, key, value) {
  * impose one.
  */
 export function updateEnvFile(path, key, value, deps = {}) {
-	const { fs = { readFileSync, writeFileSync, renameSync, statSync, chmodSync } } = deps;
+	const { fs = { readFileSync, writeFileSync, renameSync, statSync, chmodSync }, overwrite = false } = deps;
 	const text = fs.readFileSync(path, "utf8");
-	const next = setEnvKeyIfEmpty(text, key, value);
+	const next = (overwrite ? setEnvKey : setEnvKeyIfEmpty)(text, key, value);
 	if (next === text) return { changed: false };
 	const tmp = `${path}.tmp`;
 	fs.writeFileSync(tmp, next);

--- a/worker/src/github-app-setup.mjs
+++ b/worker/src/github-app-setup.mjs
@@ -1,0 +1,517 @@
+/**
+ * `pi-dispatch setup github` — mint GitHub App credentials via the App Manifest flow (issue #81,
+ * DES-GH-APP-MANIFEST-SETUP).
+ *
+ * Today the App source is the strongest credential this system supports (per-repo, one-hour
+ * installation tokens — CONST-TOKEN-SCOPED-PER-JOB) and also the most manual mile of setup: five
+ * settings pages, a hand-invented webhook secret, an installation id hunted out of URLs. The manifest
+ * flow compresses all of it into ONE browser click: a throwaway listener on this machine's loopback
+ * serves a self-submitting form that POSTs the manifest to github.com, GitHub bounces the browser back
+ * to the listener with a single-use code (valid 1h), and the UNAUTHENTICATED
+ * `POST /app-manifests/{code}/conversions` returns `{ id, slug, pem, webhook_secret, … }` in one
+ * response.
+ *
+ * Trust framing, which every edit here must preserve: NOTHING crosses a maintainer-controlled
+ * service. The listener is the operator's own 127.0.0.1; GitHub is the only remote party; the
+ * conversion code is single-use and expires. The wizard's own doctrine on top of that:
+ *
+ *   - There is deliberately NO `--yes` flag. Unlike `up`'s docker actions, every write here carries a
+ *     credential (a private key, a webhook secret, the auth source the worker will boot with), so each
+ *     one is shown verbatim and individually consented — a wizard that can be waved through end-to-end
+ *     is a wizard that writes keys nobody looked at.
+ *   - Secrets never reach output. The pem, webhook_secret, and client_secret are registered with a
+ *     scrubber the moment they exist, and EVERY byte this module prints — including error paths —
+ *     passes through it. The .env plan names keys and paths, never secret values.
+ *   - The PEM lands mode 0600 and NEVER clobbers: an existing file at the target path is a refusal,
+ *     because overwriting a key file destroys a credential this tool cannot restore.
+ *   - An existing WEBHOOK_SECRET is kept (setEnvKeyIfEmpty): the operator's configured forge hooks
+ *     verify against it, and rotating it here would silently break every working delivery. The three
+ *     values the operator DID just consent to replacing (source, app id, key path) go through the
+ *     overwrite transform — the consent prompt above is exactly the gate env-file.mjs documents.
+ *
+ * Everything side-effecting is injected (fetch, the listener, the browser opener, prompt, fs, clock),
+ * defaulting to the real thing — the up.mjs convention — so the whole flow is testable offline.
+ */
+import { spawn as nodeSpawn } from "node:child_process";
+import { createSign } from "node:crypto";
+import { chmodSync, existsSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { updateEnvFile } from "./env-file.mjs";
+import { defaultPrompt } from "./up.mjs";
+
+const API_ROOT = "https://api.github.com";
+// GitHub rejects requests without a User-Agent, and node's fetch does not always send one.
+const USER_AGENT = "pi-dispatch-setup-github";
+// The repo homepage, shown on the App's about page — informational, not a trust anchor.
+const HOMEPAGE = "https://github.com/edgehero/pi-dispatch";
+// GitHub app names are GLOBALLY unique and capped at 34 characters.
+const NAME_MAX = 34;
+
+const FLAG_HELP = `usage: pi-dispatch setup github (--webhook-url <URL> | --no-webhook) [--org <org>] [--name <appName>]
+
+  --webhook-url <URL>  the public URL of your pi-dispatch-receiver — GitHub delivers events there
+  --no-webhook         create the App with its webhook INACTIVE (the polling-ready shape; no public URL needed)
+  --org <org>          create the App under an organization instead of your user account
+  --name <appName>     the App's name (globally unique on GitHub, max ${NAME_MAX} chars; default pi-dispatch-<host>)`;
+
+/**
+ * Run the wizard. `deps` (all injected, all defaulted):
+ *   env, fetchFn, listen, openBrowser, out, prompt, fs, cwd, now — plus codeTimeoutMs, the ceiling on
+ *   how long the listener waits for the browser to come back with the conversion code.
+ */
+export async function runGithubAppSetup(argv = [], deps = {}) {
+	const {
+		env = process.env,
+		fetchFn = fetch,
+		listen = defaultListen,
+		openBrowser = defaultOpenBrowser,
+		out = (s) => process.stdout.write(s),
+		prompt = defaultPrompt,
+		fs = { existsSync, readFileSync, writeFileSync, renameSync, statSync, chmodSync },
+		cwd = process.cwd(),
+		now = () => Date.now(),
+		codeTimeoutMs = 600000, // ~10 min for a human to click through GitHub's create-app page
+	} = deps;
+
+	// Every byte printed goes through the scrubber. Secrets are registered the moment they exist, so
+	// even an error path that stringifies something secret-bearing cannot leak it into a scrollback.
+	const secrets = [];
+	const scrub = (s) => secrets.reduce((acc, secret) => (secret ? acc.split(secret).join("[redacted]") : acc), String(s));
+	const say = (s) => out(scrub(s));
+	const summary = [];
+
+	// -- flags ------------------------------------------------------------------------------------
+	let values;
+	try {
+		({ values } = parseArgs({
+			args: argv,
+			options: {
+				org: { type: "string" },
+				name: { type: "string" },
+				"webhook-url": { type: "string" },
+				"no-webhook": { type: "boolean", default: false },
+			},
+		}));
+	} catch (error) {
+		say(`error: ${error.message}\n\n${FLAG_HELP}\n`);
+		return 1;
+	}
+	const webhookUrl = values["webhook-url"];
+	const noWebhook = values["no-webhook"];
+	// Deliberately UNDEFAULTED, like GITLAB_WEBHOOK_MODE: a receiver URL cannot be guessed, and
+	// silently creating a hook-inactive App for an operator who wanted deliveries is the kind of
+	// "helpful" default that surfaces as a webhook that never fires.
+	if (!webhookUrl && !noWebhook) {
+		say(`error: choose a webhook shape — pass --webhook-url <public receiver URL>, or --no-webhook for the hook-inactive (polling-ready) shape\n\n${FLAG_HELP}\n`);
+		return 1;
+	}
+	if (webhookUrl && noWebhook) {
+		say(`error: --webhook-url and --no-webhook contradict each other — pass exactly one\n\n${FLAG_HELP}\n`);
+		return 1;
+	}
+	const appName = sanitizeAppName(values.name ?? defaultAppName(hostname()));
+	const postTarget = values.org
+		? `https://github.com/organizations/${encodeURIComponent(values.org)}/settings/apps/new`
+		: "https://github.com/settings/apps/new";
+
+	say("pi-dispatch setup github — mint GitHub App credentials in one browser click (App Manifest flow)\n");
+	say("nothing is written locally without your explicit consent; secrets are never printed\n\n");
+
+	// -- (b) loopback listener + the self-submitting form -----------------------------------------
+	// The manifest flow REQUIRES a browser form POST — a plain link cannot carry the payload — so the
+	// listener serves GET / (the auto-submitting form) and GET /callback?code=… (the bounce-back).
+	// The manifest is built lazily against the listener's final URL, because redirect_url needs the port.
+	let listener;
+	try {
+		listener = await listen((baseUrl) =>
+			buildFormPage(buildManifest({ name: appName, redirectUrl: `${baseUrl}/callback`, webhookUrl: noWebhook ? undefined : webhookUrl }), postTarget),
+		);
+	} catch (error) {
+		say(`error: could not bind a loopback listener (${error?.message ?? "unknown"})\n`);
+		say("    → nothing was created or written; free a local port (the listener picks a random one on 127.0.0.1) and re-run `pi-dispatch setup github`\n");
+		return 1;
+	}
+
+	try {
+		say(`Open this URL in a browser to create the App (name: ${appName}, target: ${values.org ? `org ${values.org}` : "your user account"}):\n\n`);
+		say(`  ${listener.url}/\n\n`);
+		// The redirect lands on THIS machine's 127.0.0.1 — said out loud, because on a remote server
+		// the browser cannot reach it without help, and the failure mode otherwise is a silent hang.
+		say(`note: GitHub will redirect the browser back to 127.0.0.1:${listener.port} ON THE MACHINE RUNNING THIS WIZARD.\n`);
+		say(`      Setting up a remote server? Open the URL in a browser on that machine, or forward the port first:\n`);
+		say(`      ssh -L ${listener.port}:127.0.0.1:${listener.port} <your-server>   then open the URL locally.\n\n`);
+		openBrowser(`${listener.url}/`);
+
+		let code;
+		try {
+			code = await listener.waitForCode(codeTimeoutMs);
+		} catch (error) {
+			say(`error: gave up waiting for GitHub's redirect (${error?.message ?? "timeout"})\n`);
+			say("    → no credentials were minted or written. If you completed the GitHub page after the timeout, the App may\n");
+			say("      exist without local credentials — delete it under Settings → Developer settings → GitHub Apps, then\n");
+			say("      re-run `pi-dispatch setup github` (each conversion code is single-use and expires after an hour)\n");
+			return 1;
+		}
+
+		// -- (c) the conversion: code -> credentials. UNAUTHENTICATED by design (the code IS the proof),
+		// single-use, valid 1h.
+		let response;
+		try {
+			response = await fetchFn(`${API_ROOT}/app-manifests/${encodeURIComponent(code)}/conversions`, {
+				method: "POST",
+				headers: { accept: "application/vnd.github+json", "user-agent": USER_AGENT },
+			});
+		} catch (error) {
+			say(`error: could not reach ${API_ROOT} to convert the manifest code (${error?.message ?? "network error"})\n`);
+			say("    → check this machine's network egress and re-run `pi-dispatch setup github`; the code is single-use, so a fresh run mints a fresh one\n");
+			return 1;
+		}
+		const body = await response.text();
+		if (response.status !== 201) {
+			// A failed conversion carries no secrets (that is the failure), so a snippet is safe — and
+			// still scrubbed, one rule for all output.
+			say(`error: the manifest conversion returned ${response.status} (expected 201): ${body.slice(0, 300)}\n`);
+			say("    → the conversion code is SINGLE-USE and expires after one hour — a re-used or stale code fails exactly like this. Re-run `pi-dispatch setup github` for a fresh one\n");
+			return 1;
+		}
+		let app;
+		try {
+			app = JSON.parse(body);
+		} catch {
+			// The 201 body carries the private key, so on a parse failure it is NEVER echoed.
+			say("error: GitHub's conversion response was not parseable JSON (body withheld — it may contain the private key)\n");
+			say("    → the App may now exist on GitHub without local credentials; check Settings → Developer settings → GitHub Apps, delete it, and re-run\n");
+			return 1;
+		}
+		// Register the secrets BEFORE any further printing — from here on nothing can echo them.
+		for (const secret of [app.pem, app.webhook_secret, app.client_secret]) {
+			if (typeof secret === "string" && secret !== "") secrets.push(secret);
+		}
+		if (!app.id || !app.slug || !app.pem) {
+			say("error: the conversion response is missing id/slug/pem — refusing to continue (response withheld; it may contain credentials)\n");
+			return 1;
+		}
+
+		// -- (d) show EXACTLY what would be written, then ONE consent -----------------------------
+		const pemPath = join(cwd, `github-app-${app.slug}.pem`);
+		const envPath = join(cwd, ".env");
+		// The secret is only worth writing when the App actually delivers webhooks: under --no-webhook
+		// nothing will ever sign a delivery with it, and planting it would only shadow whatever the
+		// operator sets when they wire a real receiver later.
+		const offerSecret = !noWebhook && typeof app.webhook_secret === "string" && app.webhook_secret !== "";
+		say(`\nGitHub created the App "${app.slug}" (id ${app.id}). Nothing is written locally yet.\n\n`);
+		say("setup would write:\n");
+		say(`  ${pemPath}\n`);
+		say("      the App's private key, mode 0600 (contents never shown; refuses if the file already exists)\n");
+		say(`  ${envPath}\n`);
+		say("      GITHUB_AUTH_SOURCE=app\n");
+		say(`      GITHUB_APP_ID=${app.id}\n`);
+		say(`      GITHUB_APP_PRIVATE_KEY_PATH=${pemPath}\n`);
+		if (offerSecret) {
+			say("      WEBHOOK_SECRET=<value not shown> — only if .env has none; an existing secret is KEPT, because your configured hooks verify deliveries against it\n");
+		}
+		if (!(await consent(prompt, "write these? [y/N] "))) {
+			say("\ndeclined — nothing was written locally.\n");
+			say(`note: the App itself DOES now exist on GitHub: ${app.html_url ?? `https://github.com/apps/${app.slug}`}\n`);
+			say("      to remove it: its settings page → Advanced → Delete GitHub App (or keep it and re-run setup later — a fresh run mints a fresh key)\n");
+			return 0;
+		}
+
+		// -- (e) the consented writes -------------------------------------------------------------
+		// Key files are never clobbered: the old file may be the only copy of a credential still in
+		// use somewhere, and this tool cannot restore what it overwrites.
+		if (fs.existsSync(pemPath)) {
+			say(`error: refusing to overwrite the existing key file at ${pemPath}\n`);
+			say("    → move or delete it first (is another App's key living there?), then re-run `pi-dispatch setup github`. Nothing was written\n");
+			return 1;
+		}
+		fs.writeFileSync(pemPath, app.pem, { mode: 0o600 });
+		summary.push(["private key", `written to ${pemPath} (mode 0600)`]);
+		if (!fs.existsSync(envPath)) {
+			// The consent above was for ".env lines"; with no .env the lines need a file. Created
+			// EMPTY here (not scaffolded — that is init's job) so the consented lines are all it gains.
+			fs.writeFileSync(envPath, "");
+			say(`note: no .env existed here — created one for the lines you approved\n`);
+		}
+		updateEnvFile(envPath, "GITHUB_AUTH_SOURCE", "app", { fs, overwrite: true });
+		updateEnvFile(envPath, "GITHUB_APP_ID", String(app.id), { fs, overwrite: true });
+		updateEnvFile(envPath, "GITHUB_APP_PRIVATE_KEY_PATH", pemPath, { fs, overwrite: true });
+		summary.push(["auth source", "GITHUB_AUTH_SOURCE=app (+ app id and key path) written to .env"]);
+		if (offerSecret) {
+			// setEnvKeyIfEmpty, NOT overwrite: an operator's existing webhook secret is what their
+			// already-configured hooks sign with — replacing it would invalidate working deliveries.
+			const { changed } = updateEnvFile(envPath, "WEBHOOK_SECRET", app.webhook_secret, { fs });
+			say(changed ? "✓ WEBHOOK_SECRET set in .env (value not shown)\n" : "✓ WEBHOOK_SECRET already set in .env — kept (your configured hooks keep verifying)\n");
+			summary.push(["WEBHOOK_SECRET", changed ? "set from the App's minted secret (value not shown)" : "already set — kept, so existing deliveries stay valid"]);
+		}
+		say(`✓ credentials written\n`);
+
+		// -- (f) install, then discover the installation id ---------------------------------------
+		const installUrl = `https://github.com/apps/${app.slug}/installations/new`;
+		say(`\nInstall the App on the repositories it should work on (a GitHub consent screen — deliberately not automated):\n\n  ${installUrl}\n\n`);
+		openBrowser(installUrl);
+		const manualIdHint = `find the id later under the App's settings → Install App (the number in the installation URL), then set GITHUB_APP_INSTALLATION_ID=<id> in ${envPath}`;
+		if (!(await consent(prompt, "installed? [y/N] "))) {
+			say(`\nno problem — install it whenever you like at the URL above; ${manualIdHint}\n`);
+			summary.push(["installation id", "not discovered (App not installed yet) — set GITHUB_APP_INSTALLATION_ID by hand after installing"]);
+			printSummary(say, summary, { noWebhook });
+			return 0;
+		}
+		// A ~15-line hand-rolled RS256 JWT (mintAppJwt below), deliberately NOT @octokit/auth-app:
+		// this runs once at setup time, and a dependency-light, auditable JWT is worth more here than
+		// library reuse — the operator can read every byte that touches their brand-new key. Job-time
+		// minting (get-token.mjs) keeps using @octokit/auth-app, unchanged.
+		const jwt = mintAppJwt(app.id, app.pem, Math.floor(now() / 1000));
+		secrets.push(jwt); // short-lived, but a valid credential for ~9 minutes — same no-print rule
+		let instResponse;
+		let instBody;
+		try {
+			instResponse = await fetchFn(`${API_ROOT}/app/installations`, {
+				headers: { authorization: `Bearer ${jwt}`, accept: "application/vnd.github+json", "user-agent": USER_AGENT },
+			});
+			instBody = await instResponse.text();
+		} catch (error) {
+			say(`error: could not reach ${API_ROOT} to list installations (${error?.message ?? "network error"})\n`);
+			say(`    → the credentials above ARE written and valid; ${manualIdHint}\n`);
+			return 1;
+		}
+		if (instResponse.status !== 200) {
+			say(`error: GET /app/installations returned ${instResponse.status} (expected 200): ${String(instBody).slice(0, 300)}\n`);
+			say(`    → the credentials above ARE written; ${manualIdHint}\n`);
+			return 1;
+		}
+		let installations;
+		try {
+			installations = JSON.parse(instBody);
+		} catch {
+			say(`error: GitHub's installations response was not parseable JSON\n    → ${manualIdHint}\n`);
+			return 1;
+		}
+
+		let chosen;
+		if (installations.length === 0) {
+			say(`\nGitHub reports no installations yet — the install may still be in flight.\n`);
+			say(`    → install at ${installUrl}, then ${manualIdHint}\n`);
+			summary.push(["installation id", "none found — install the App, then set GITHUB_APP_INSTALLATION_ID by hand"]);
+			printSummary(say, summary, { noWebhook });
+			return 0;
+		}
+		if (installations.length === 1) {
+			chosen = installations[0];
+		} else {
+			say("\nthe App is installed in more than one place:\n");
+			for (const inst of installations) say(`  ${String(inst.id).padEnd(12)} ${inst.account?.login ?? "(unknown account)"}\n`);
+			const answer = String((await prompt("installation id to use (blank to skip): ")) ?? "").trim();
+			if (answer === "") {
+				say(`skipped — ${manualIdHint}\n`);
+				summary.push(["installation id", "skipped — set GITHUB_APP_INSTALLATION_ID by hand"]);
+				printSummary(say, summary, { noWebhook });
+				return 0;
+			}
+			chosen = installations.find((inst) => String(inst.id) === answer);
+			if (!chosen) {
+				say(`error: ${answer} is not one of the listed installation ids\n    → ${manualIdHint}\n`);
+				return 1;
+			}
+		}
+		// Consented and shown first, like every other write in this wizard — an id is not a secret,
+		// so this one IS printed in full.
+		say(`\nsetup would write to ${envPath}:\n      GITHUB_APP_INSTALLATION_ID=${chosen.id}${chosen.account?.login ? ` (account: ${chosen.account.login})` : ""}\n`);
+		if (await consent(prompt, "write it? [y/N] ")) {
+			updateEnvFile(envPath, "GITHUB_APP_INSTALLATION_ID", String(chosen.id), { fs, overwrite: true });
+			say("✓ GITHUB_APP_INSTALLATION_ID written\n");
+			summary.push(["installation id", `GITHUB_APP_INSTALLATION_ID=${chosen.id} written to .env`]);
+		} else {
+			say(`declined — ${manualIdHint}\n`);
+			summary.push(["installation id", "declined — set GITHUB_APP_INSTALLATION_ID by hand"]);
+		}
+
+		// -- (g) summary ---------------------------------------------------------------------------
+		printSummary(say, summary, { noWebhook });
+		return 0;
+	} finally {
+		listener.close();
+	}
+}
+
+/** What was written and what remains — up.mjs's summary voice, so the two wizards read as one tool. */
+function printSummary(say, summary, { noWebhook }) {
+	say("\nsetup github: summary\n");
+	for (const [name, note] of summary) say(`  ${name.padEnd(17)} ${note}\n`);
+	say("\nNext:\n");
+	if (noWebhook) {
+		say("  the App was created with its webhook INACTIVE (--no-webhook) — the polling-ready shape.\n");
+		say("  Polling delivery is a follow-up; until it lands, forge triggers for this App will not fire on their own.\n");
+	} else {
+		say("  start the receiver so deliveries have somewhere to land: `pi-dispatch-receiver`\n");
+		say("  (or the deploy/docker-compose.yml receiver profile), reachable at the --webhook-url you gave GitHub.\n");
+	}
+	say("  `pi-dispatch doctor` re-checks the whole deployment, including these credentials.\n");
+}
+
+/** up.mjs's consent contract: default No; only an explicit y/yes (any case) accepts. */
+async function consent(prompt, question) {
+	const answer = await prompt(question);
+	return /^y(es)?$/i.test(String(answer ?? "").trim());
+}
+
+/** `pi-dispatch-<host>`, before sanitization — split out so the derivation is testable without os. */
+export function defaultAppName(host) {
+	return `pi-dispatch-${host ?? ""}`;
+}
+
+/**
+ * Fit a name into GitHub's App-name rules: ≤34 chars, and kept to lowercase letters, digits, and
+ * hyphens so the name survives GitHub's own slugging predictably (the slug becomes the install URL
+ * and the PEM filename). Anything else collapses to a hyphen; runs and edge hyphens are trimmed.
+ */
+export function sanitizeAppName(raw) {
+	const cleaned = String(raw ?? "")
+		.toLowerCase()
+		.replace(/[^a-z0-9-]+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "")
+		.slice(0, NAME_MAX)
+		.replace(/-$/, "");
+	return cleaned || "pi-dispatch";
+}
+
+/**
+ * The manifest GitHub converts into the App — the narrowest shape this system needs
+ * (SECURITY.md's auth-source ladder): write on exactly the three surfaces jobs touch, metadata read
+ * because the API requires it, private, and only the three event families the triggers file can name.
+ * `hook_attributes` carries the receiver URL, or `active: false` under --no-webhook — the
+ * no-public-URL shape the polling transport will consume.
+ */
+export function buildManifest({ name, redirectUrl, webhookUrl }) {
+	return {
+		name,
+		url: HOMEPAGE,
+		redirect_url: redirectUrl,
+		hook_attributes: webhookUrl ? { url: webhookUrl } : { active: false },
+		public: false,
+		default_permissions: { contents: "write", pull_requests: "write", issues: "write", metadata: "read" },
+		default_events: ["issues", "issue_comment", "pull_request"],
+	};
+}
+
+/**
+ * The page the loopback listener serves at GET /: a form that POSTs `manifest=<json>` to the GitHub
+ * create-from-manifest endpoint. A FORM, not a link, because the manifest flow requires the payload
+ * in a browser POST body. Auto-submits via script; the visible button is the no-JS fallback and the
+ * human-readable statement of what is about to be sent where.
+ */
+export function buildFormPage(manifest, postTarget) {
+	const json = escapeHtml(JSON.stringify(manifest));
+	const target = escapeHtml(postTarget);
+	return `<!doctype html>
+<meta charset="utf-8">
+<title>pi-dispatch setup github</title>
+<body>
+<p>Submitting the GitHub App manifest to <code>${target}</code> …</p>
+<form id="m" action="${target}" method="post">
+	<input type="hidden" name="manifest" value="${json}">
+	<button type="submit">Create the GitHub App</button>
+</form>
+<script>document.getElementById("m").submit();</script>
+</body>`;
+}
+
+function escapeHtml(s) {
+	return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+/**
+ * An RS256 app JWT, hand-rolled on node:crypto — deliberately NOT @octokit/auth-app, although it is
+ * already a dependency: this signature runs ONCE at setup time with a key minted seconds ago, and
+ * ~15 auditable lines the operator can read beat a library call they have to trust. `iat` is
+ * backdated 60s (GitHub's own clock-drift allowance) and `exp` stays inside the 10-minute maximum.
+ * `iss` is the app id, stringified — GitHub accepts either form.
+ */
+export function mintAppJwt(appId, pem, nowSeconds) {
+	const b64url = (s) => Buffer.from(s).toString("base64url");
+	const header = b64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+	const iat = nowSeconds - 60;
+	const payload = b64url(JSON.stringify({ iat, exp: iat + 600, iss: String(appId) }));
+	const signer = createSign("RSA-SHA256");
+	signer.update(`${header}.${payload}`);
+	const signature = signer.sign(pem).toString("base64url");
+	return `${header}.${payload}.${signature}`;
+}
+
+/**
+ * The default listener seam: node:http on 127.0.0.1, port 0 (kernel-assigned, so nothing collides).
+ * Serves GET / with `pageFor(url)` (built lazily — the manifest's redirect_url needs the final port)
+ * and GET /callback?code=… as the capture. Returns exactly `{ port, url, waitForCode, close }`;
+ * `waitForCode(timeoutMs)` resolves with the code or rejects on timeout. Loopback-only by
+ * construction: the bind address is 127.0.0.1, so nothing off-machine can reach the form or the code.
+ */
+async function defaultListen(pageFor) {
+	const { createServer } = await import("node:http");
+	let resolveCode;
+	const codePromise = new Promise((resolve) => {
+		resolveCode = resolve;
+	});
+	let url = "";
+	const server = createServer((req, res) => {
+		const requestUrl = new URL(req.url, "http://127.0.0.1");
+		if (req.method === "GET" && requestUrl.pathname === "/") {
+			res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			res.end(pageFor(url));
+			return;
+		}
+		if (req.method === "GET" && requestUrl.pathname === "/callback") {
+			const code = requestUrl.searchParams.get("code");
+			if (!code) {
+				res.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+				res.end("missing ?code — this URL is GitHub's redirect target, not a page to open by hand\n");
+				return;
+			}
+			res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			res.end("<!doctype html><meta charset=\"utf-8\"><p>Got it — return to the terminal running <code>pi-dispatch setup github</code>. You can close this tab.</p>");
+			resolveCode(code);
+			return;
+		}
+		res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+		res.end("not found\n");
+	});
+	await new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const port = server.address().port;
+	url = `http://127.0.0.1:${port}`;
+	return {
+		port,
+		url,
+		waitForCode: (timeoutMs) =>
+			new Promise((resolve, reject) => {
+				const timer = setTimeout(() => reject(new Error(`no redirect after ${Math.round(timeoutMs / 1000)}s`)), timeoutMs);
+				codePromise.then((code) => {
+					clearTimeout(timer);
+					resolve(code);
+				});
+			}),
+		close: () => server.close(),
+	};
+}
+
+/**
+ * Best-effort platform browser opener. ALWAYS paired with the URL printed to the terminal — a
+ * headless or SSH'd operator has no opener that works, and the printed URL pasted into any browser
+ * (on the right machine, or through the port-forward the wizard suggests) is the real contract; the
+ * spawn is only a convenience on top. Failures are swallowed for the same reason.
+ */
+function defaultOpenBrowser(url) {
+	const [cmd, args] =
+		process.platform === "darwin" ? ["open", [url]] : process.platform === "win32" ? ["cmd", ["/c", "start", "", url]] : ["xdg-open", [url]];
+	try {
+		const child = nodeSpawn(cmd, args, { stdio: "ignore", detached: true });
+		child.on("error", () => {});
+		child.unref();
+	} catch {
+		// No opener on this host — the printed URL carries the flow.
+	}
+}

--- a/worker/test/doctor.test.mjs
+++ b/worker/test/doctor.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
@@ -499,6 +499,86 @@ test("doctor: GITHUB_AUTH_SOURCE=app skips the in-image probe (mints per-job)", 
 	assert.match(text(), /✓ in-image gh auth: skipped \(GITHUB_AUTH_SOURCE=app mints per-job\)/);
 	assert.ok(!calls.some((c) => c.cmd === "docker" && c.args[0] === "run"), "app mints per-job — nothing to preflight");
 	assert.doesNotMatch(text(), /forwards your full gh login/, "no scope warning for source app");
+});
+
+// -- GITHUB_AUTH_SOURCE=app completeness (issue #81): the credential triple, preflighted -----------------
+//
+// Real temp files for the key, like the overlay tests above: the mode check stats a real mode and the
+// PEM sniff reads real leading bytes. cwd points at tmpdir and fileExists stays the default, so only
+// the app-auth env drives these outcomes; everything else warns at most (and warns never fail).
+
+const KEY_BODY = "sk-app-key-body-distinctive"; // planted so no-contents-in-output is a grep, not a hope
+function appKeyFile({ content = `-----BEGIN PRIVATE KEY-----\n${KEY_BODY}\n-----END PRIVATE KEY-----\n`, mode = 0o600 } = {}) {
+	const path = join(mkdtempSync(join(tmpdir(), "pi-app-key-")), "github-app-test.pem");
+	writeFileSync(path, content);
+	chmodSync(path, mode);
+	return path;
+}
+const appEnv = (extra = {}) => ({ PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-x", GITHUB_AUTH_SOURCE: "app", ...extra });
+const appDeps = (out) => ({ out, cwd: tmpdir(), spawn: fakeSpawn(green), probeValkey: async () => true, nodeVersion: "22.19.0" });
+
+test("doctor: a complete app-auth triple with a locked-down PEM is all green, contents never in output", async () => {
+	const keyPath = appKeyFile();
+	const { out, text } = capture();
+	const code = await runDoctor(appEnv({ GITHUB_APP_ID: "4242", GITHUB_APP_INSTALLATION_ID: "987654", GITHUB_APP_PRIVATE_KEY_PATH: keyPath }), appDeps(out));
+	assert.equal(code, 0);
+	assert.match(text(), /✓ GITHUB_APP_ID set \(4242\)/);
+	assert.match(text(), /✓ GITHUB_APP_INSTALLATION_ID set \(987654\)/);
+	assert.match(text(), new RegExp(`✓ GitHub App private key present \\(${keyPath.replace(/[.\\/]/g, "\\$&")}\\)`));
+	assert.doesNotMatch(text(), /group\/world-readable/);
+	assert.doesNotMatch(text(), /does not look like a PEM/);
+	assert.doesNotMatch(text(), new RegExp(KEY_BODY), "the key's contents must never reach output");
+});
+
+test("doctor: app source with the whole triple unset warns per variable, points at setup github, exits 0", async () => {
+	const { out, text } = capture();
+	const code = await runDoctor(appEnv(), appDeps(out));
+	assert.equal(code, 0, "app-auth completeness warns, never fails — a deployment can be mid-setup");
+	assert.match(text(), /⚠ GITHUB_AUTH_SOURCE=app but GITHUB_APP_ID is unset/);
+	assert.match(text(), /⚠ GITHUB_AUTH_SOURCE=app but GITHUB_APP_INSTALLATION_ID is unset/);
+	assert.match(text(), /⚠ GITHUB_AUTH_SOURCE=app but GITHUB_APP_PRIVATE_KEY_PATH is unset/);
+	assert.match(text(), /run `pi-dispatch setup github`/, "the fix is the wizard that mints all three");
+});
+
+test("doctor: a non-numeric GITHUB_APP_ID is named as such (an id is not a secret, so it IS echoed)", async () => {
+	const { out, text } = capture();
+	const code = await runDoctor(appEnv({ GITHUB_APP_ID: "Iv1.oops", GITHUB_APP_INSTALLATION_ID: "987654", GITHUB_APP_PRIVATE_KEY_PATH: appKeyFile() }), appDeps(out));
+	assert.equal(code, 0);
+	assert.match(text(), /⚠ GITHUB_AUTH_SOURCE=app but GITHUB_APP_ID is not numeric \("Iv1\.oops"\)/);
+	assert.match(text(), /✓ GITHUB_APP_INSTALLATION_ID set \(987654\)/, "the other two are judged independently");
+});
+
+test("doctor: a key path that points at nothing warns with the path", async () => {
+	const { out, text } = capture();
+	const missing = join(tmpdir(), "no-such-github-app.pem");
+	const code = await runDoctor(appEnv({ GITHUB_APP_ID: "4242", GITHUB_APP_INSTALLATION_ID: "987654", GITHUB_APP_PRIVATE_KEY_PATH: missing }), appDeps(out));
+	assert.equal(code, 0);
+	assert.match(text(), new RegExp(`⚠ GITHUB_APP_PRIVATE_KEY_PATH does not exist \\(${missing.replace(/[.\\/]/g, "\\$&")}\\)`));
+});
+
+test("doctor: a group/world-readable PEM warns with the chmod fix", { skip: process.platform === "win32" ? "POSIX modes are synthetic on win32 (the check skips itself there)" : false }, async () => {
+	const keyPath = appKeyFile({ mode: 0o644 });
+	const { out, text } = capture();
+	const code = await runDoctor(appEnv({ GITHUB_APP_ID: "4242", GITHUB_APP_INSTALLATION_ID: "987654", GITHUB_APP_PRIVATE_KEY_PATH: keyPath }), appDeps(out));
+	assert.equal(code, 0, "a loose mode is a warning, not a failure");
+	assert.match(text(), /⚠ the App private key at .* is group\/world-readable/);
+	assert.match(text(), new RegExp(`chmod 600 ${keyPath.replace(/[.\\/]/g, "\\$&")}`));
+	assert.doesNotMatch(text(), new RegExp(KEY_BODY));
+});
+
+test("doctor: a file that does not start with -----BEGIN warns, and its contents are never echoed", async () => {
+	const keyPath = appKeyFile({ content: `definitely not a pem ${KEY_BODY}\n` });
+	const { out, text } = capture();
+	const code = await runDoctor(appEnv({ GITHUB_APP_ID: "4242", GITHUB_APP_INSTALLATION_ID: "987654", GITHUB_APP_PRIVATE_KEY_PATH: keyPath }), appDeps(out));
+	assert.equal(code, 0);
+	assert.match(text(), /⚠ the file at GITHUB_APP_PRIVATE_KEY_PATH does not look like a PEM \(first line is not "-----BEGIN \.\.\."\)/);
+	assert.doesNotMatch(text(), new RegExp(KEY_BODY), "not even a malformed key's contents may reach output");
+});
+
+test("doctor: the app-auth block only fires for source app", async () => {
+	const { out, text } = capture();
+	await runDoctor(ghEnv({ GITHUB_AUTH_SOURCE: "pat" }), ghDeps(out, green));
+	assert.doesNotMatch(text(), /GITHUB_APP_ID/, "pat deployments hear nothing about App credentials");
 });
 
 // -- replica runs (REQ-REPLICA-RUNS): the multiplier is worth stating, not worth failing on ------------

--- a/worker/test/env-file.test.mjs
+++ b/worker/test/env-file.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { setEnvKeyIfEmpty, updateEnvFile } from "../src/env-file.mjs";
+import { setEnvKey, setEnvKeyIfEmpty, updateEnvFile } from "../src/env-file.mjs";
 
 // -- setEnvKeyIfEmpty: pure transform, table-driven over the text shapes it must handle ---------------
 //
@@ -96,6 +96,114 @@ test("setEnvKeyIfEmpty: the unchanged case returns the same string object (ident
 	assert.ok(setEnvKeyIfEmpty(text, "WEBHOOK_SECRET", "x") === text);
 });
 
+// -- setEnvKey: the consented-overwrite sibling — same line mechanics, opposite value discipline ------
+//
+// Same table convention: `expected: null` means "byte-identical input back", asserted by identity,
+// because the wrapper skips the write on identity exactly as it does for the sibling.
+
+const overwriteCases = [
+	{
+		name: "an existing set value IS replaced (the whole point of the sibling)",
+		text: "A=1\nGITHUB_AUTH_SOURCE=gh\nB=2\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "A=1\nGITHUB_AUTH_SOURCE=app\nB=2\n",
+	},
+	{
+		name: "an empty set line is filled in place",
+		text: "A=1\nGITHUB_AUTH_SOURCE=\nB=2\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "A=1\nGITHUB_AUTH_SOURCE=app\nB=2\n",
+	},
+	{
+		name: "whitespace around = is normalised to the canonical line",
+		text: "GITHUB_AUTH_SOURCE = gh\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "GITHUB_AUTH_SOURCE=app\n",
+	},
+	{
+		name: "a commented line is uncommented in place when no set line exists",
+		text: "A=1\n# GITHUB_AUTH_SOURCE=gh\nB=2\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "A=1\nGITHUB_AUTH_SOURCE=app\nB=2\n",
+	},
+	{
+		name: "no trace of the key appends at the end",
+		text: "A=1\nB=2\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "A=1\nB=2\nGITHUB_AUTH_SOURCE=app\n",
+	},
+	{
+		name: "appending to text without a trailing newline first completes the last line",
+		text: "A=1",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "A=1\nGITHUB_AUTH_SOURCE=app\n",
+	},
+	{
+		name: "appending to empty text yields just the one line",
+		text: "",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "GITHUB_AUTH_SOURCE=app\n",
+	},
+	{
+		name: "the FIRST set line wins; a later duplicate is left as it was",
+		text: "GITHUB_AUTH_SOURCE=gh\nGITHUB_AUTH_SOURCE=pat\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "GITHUB_AUTH_SOURCE=app\nGITHUB_AUTH_SOURCE=pat\n",
+	},
+	{
+		name: "a set line wins over a commented duplicate wherever the comment sits (the comment stays a comment)",
+		text: "# GITHUB_AUTH_SOURCE=doc note\nGITHUB_AUTH_SOURCE=gh\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "# GITHUB_AUTH_SOURCE=doc note\nGITHUB_AUTH_SOURCE=app\n",
+	},
+	{
+		name: "already exactly KEY=value is a no-op (identity)",
+		text: "A=1\nGITHUB_AUTH_SOURCE=app\nB=2\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: null,
+	},
+	{
+		name: "a key that merely prefixes another name does not match it",
+		text: "GITHUB_AUTH_SOURCE_OLD=x\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "GITHUB_AUTH_SOURCE_OLD=x\nGITHUB_AUTH_SOURCE=app\n",
+	},
+	{
+		name: "CRLF endings survive on the replaced line and everywhere else",
+		text: "A=1\r\nGITHUB_AUTH_SOURCE=gh\r\nB=2\r\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "A=1\r\nGITHUB_AUTH_SOURCE=app\r\nB=2\r\n",
+	},
+	{
+		name: "an already-exact line in a CRLF file is still a no-op (the \\r tail is not a difference)",
+		text: "GITHUB_AUTH_SOURCE=app\r\nB=2\r\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: null,
+	},
+	{
+		name: "surrounding comments and blank lines are preserved byte-for-byte",
+		text: "# header\n\nA=1   \n# note\nGITHUB_AUTH_SOURCE=gh\n\n# footer\n",
+		key: "GITHUB_AUTH_SOURCE",
+		expected: "# header\n\nA=1   \n# note\nGITHUB_AUTH_SOURCE=app\n\n# footer\n",
+	},
+];
+
+for (const { name, text, key, expected } of overwriteCases) {
+	test(`setEnvKey: ${name}`, () => {
+		const result = setEnvKey(text, key, "app");
+		if (expected === null) {
+			assert.equal(result, text, "unchanged means the INPUT text back, identically");
+		} else {
+			assert.equal(result, expected);
+		}
+	});
+}
+
+test("setEnvKey: the already-exact case returns the same string object (identity, not just equality)", () => {
+	const text = "GITHUB_AUTH_SOURCE=app\n";
+	assert.ok(setEnvKey(text, "GITHUB_AUTH_SOURCE", "app") === text);
+});
+
 // -- updateEnvFile: the thin fs wrapper — atomicity (tmp + rename) and mode preservation ---------------
 
 // A recording fake fs over one in-memory file. `ops` captures every call in order so tests can assert
@@ -166,4 +274,30 @@ test("updateEnvFile: any other mode is left alone (no chmod call at all)", () =>
 	const { fs, ops } = fakeFs("/deploy/.env", "WEBHOOK_SECRET=\n", 0o644);
 	updateEnvFile("/deploy/.env", "WEBHOOK_SECRET", "abc123", { fs });
 	assert.equal(ops.filter(([op]) => op === "chmod").length, 0);
+});
+
+// -- updateEnvFile { overwrite }: which transform runs is the ONLY difference — atomicity is shared ----
+
+test("updateEnvFile: overwrite:true replaces a set value, still via tmp + rename", () => {
+	const { fs, files, ops } = fakeFs("/deploy/.env", "GITHUB_AUTH_SOURCE=gh\n");
+	const result = updateEnvFile("/deploy/.env", "GITHUB_AUTH_SOURCE", "app", { fs, overwrite: true });
+	assert.deepEqual(result, { changed: true });
+	assert.equal(files.get("/deploy/.env"), "GITHUB_AUTH_SOURCE=app\n");
+	assert.deepEqual(ops.filter(([op]) => op === "write"), [["write", "/deploy/.env.tmp", "GITHUB_AUTH_SOURCE=app\n"]], "content lands on the tmp path only");
+	assert.deepEqual(ops.at(-1), ["rename", "/deploy/.env.tmp", "/deploy/.env"]);
+});
+
+test("updateEnvFile: the default (overwrite absent) keeps the never-clobber discipline", () => {
+	const { fs, files } = fakeFs("/deploy/.env", "GITHUB_AUTH_SOURCE=gh\n");
+	const result = updateEnvFile("/deploy/.env", "GITHUB_AUTH_SOURCE", "app", { fs });
+	assert.deepEqual(result, { changed: false }, "without the explicit overwrite opt-in, a set value stays sacrosanct");
+	assert.equal(files.get("/deploy/.env"), "GITHUB_AUTH_SOURCE=gh\n");
+});
+
+test("updateEnvFile: overwrite:true onto an already-exact line writes NOTHING (identity short-circuit)", () => {
+	const { fs, files, ops } = fakeFs("/deploy/.env", "GITHUB_AUTH_SOURCE=app\n");
+	const result = updateEnvFile("/deploy/.env", "GITHUB_AUTH_SOURCE", "app", { fs, overwrite: true });
+	assert.deepEqual(result, { changed: false });
+	assert.equal(files.get("/deploy/.env"), "GITHUB_AUTH_SOURCE=app\n");
+	assert.deepEqual(ops, [["read", "/deploy/.env"]], "the file is read once and never touched");
 });

--- a/worker/test/github-app-setup.test.mjs
+++ b/worker/test/github-app-setup.test.mjs
@@ -1,0 +1,508 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createVerify, generateKeyPairSync } from "node:crypto";
+import { buildFormPage, buildManifest, defaultAppName, mintAppJwt, runGithubAppSetup, sanitizeAppName } from "../src/github-app-setup.mjs";
+
+// A REAL RSA keypair, generated once: the conversion response carries the private half as its `pem`,
+// so the wizard's hand-rolled JWT is signed with a key the test can VERIFY against the public half —
+// the sign/verify roundtrip is the point, not a fixture string.
+const { publicKey: PUBLIC_PEM, privateKey: PRIVATE_PEM } = generateKeyPairSync("rsa", {
+	modulusLength: 2048,
+	publicKeyEncoding: { type: "spki", format: "pem" },
+	privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+// Distinctive on purpose: the no-secret-in-output assertions grep for exactly these.
+const HOOK_SECRET = "hooksecret-3f9a1c".repeat(3);
+const CLIENT_SECRET = "clientsecret-77aa0b".repeat(3);
+
+const APP = {
+	id: 4242,
+	slug: "pi-dispatch-testbox",
+	pem: PRIVATE_PEM,
+	webhook_secret: HOOK_SECRET,
+	client_secret: CLIENT_SECRET,
+	client_id: "Iv1.notasecret",
+	html_url: "https://github.com/apps/pi-dispatch-testbox",
+};
+
+const PEM_PATH = "/deploy/github-app-pi-dispatch-testbox.pem";
+const ENV_PATH = "/deploy/.env";
+// A .env in the pre-setup shape: gh source, App keys scaffolded empty (like .env.example).
+const SEED_ENV = "GITHUB_AUTH_SOURCE=gh\nGITHUB_APP_ID=\nGITHUB_APP_PRIVATE_KEY_PATH=\nWEBHOOK_SECRET=\n";
+
+// A fake fetch: route keys are URL substrings mapped to `{ status, body }` (body objects are
+// JSON-stringified) or an Error to throw. Every call is recorded (url, opts) so tests can assert the
+// method, headers, and the Authorization JWT.
+function fakeFetch(routes, calls) {
+	return async (url, opts = {}) => {
+		calls.push({ url, opts });
+		const key = Object.keys(routes).find((k) => url.includes(k));
+		if (key === undefined) throw new Error(`unrouted fetch in test: ${url}`);
+		const outcome = routes[key];
+		if (outcome instanceof Error) throw outcome;
+		const { status = 200, body = "" } = outcome;
+		return { status, text: async () => (typeof body === "string" ? body : JSON.stringify(body)) };
+	};
+}
+
+const greenRoutes = () => ({
+	"/app-manifests/": { status: 201, body: APP },
+	"/app/installations": { status: 200, body: [{ id: 987654, account: { login: "edgehero" } }] },
+});
+
+// Everything injected, everything recorded — the up.test.mjs harness shape. `files` seeds the
+// in-memory fs; `writes` records every writeFileSync (path, data, opts) so "declined writes NOTHING"
+// is an assertion about the recorder, not about the store's final state.
+function harness({ argv, answers = [], files = {}, routes = greenRoutes(), code = "onetimecode", listenError, waitError, nowMs = 1_700_000_000_000, timeoutMs } = {}) {
+	const buf = [];
+	const promptCalls = [];
+	const opened = [];
+	const fetchCalls = [];
+	const writes = [];
+	const store = new Map(Object.entries(files));
+	let pageFor = null;
+	let closed = 0;
+	const deps = {
+		env: {},
+		fetchFn: fakeFetch(routes, fetchCalls),
+		listen: async (pf) => {
+			if (listenError) throw new Error(listenError);
+			pageFor = pf;
+			return {
+				port: 43210,
+				url: "http://127.0.0.1:43210",
+				waitForCode: async () => {
+					if (waitError) throw new Error(waitError);
+					return code;
+				},
+				close: () => closed++,
+			};
+		},
+		openBrowser: (u) => opened.push(u),
+		out: (s) => buf.push(s),
+		prompt: async (q) => {
+			promptCalls.push(q);
+			return answers.shift() ?? "";
+		},
+		fs: {
+			existsSync: (p) => store.has(p),
+			readFileSync: (p) => {
+				if (!store.has(p)) throw Object.assign(new Error(`ENOENT: ${p}`), { code: "ENOENT" });
+				return store.get(p);
+			},
+			writeFileSync: (p, data, opts) => {
+				writes.push([p, data, opts]);
+				store.set(p, data);
+			},
+			renameSync: (from, to) => {
+				store.set(to, store.get(from));
+				store.delete(from);
+			},
+			statSync: () => ({ mode: 0o100600 }),
+			chmodSync: () => {},
+		},
+		cwd: "/deploy",
+		now: () => nowMs,
+		...(timeoutMs === undefined ? {} : { codeTimeoutMs: timeoutMs }),
+	};
+	return {
+		run: () => runGithubAppSetup(argv ?? ["--webhook-url", "https://hooks.example/github"], deps),
+		text: () => buf.join(""),
+		promptCalls,
+		opened,
+		fetchCalls,
+		writes,
+		store,
+		getPageFor: () => pageFor,
+		closedCount: () => closed,
+	};
+}
+
+/** The one rule with no exceptions: pem, webhook secret, client secret never reach output. */
+function assertNoSecrets(text) {
+	assert.ok(!text.includes(HOOK_SECRET), "the webhook secret must never reach output");
+	assert.ok(!text.includes(CLIENT_SECRET), "the client secret must never reach output");
+	// The PEM is multi-line; its body lines are the load-bearing bytes, so check a middle chunk too.
+	assert.ok(!text.includes(PRIVATE_PEM), "the private key must never reach output");
+	assert.ok(!text.includes(PRIVATE_PEM.split("\n")[2]), "no line of the private key may reach output");
+}
+
+// -- flags: the webhook shape is a choice, never a default ---------------------------------------------
+
+test("setup github: neither --webhook-url nor --no-webhook is a refusal with guidance, before any listener", async () => {
+	const h = harness({ argv: [] });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /choose a webhook shape/);
+	assert.match(h.text(), /--webhook-url <URL>/, "the usage block is shown");
+	assert.equal(h.getPageFor(), null, "no listener was ever bound");
+	assert.equal(h.fetchCalls.length, 0, "nothing was fetched");
+});
+
+test("setup github: --webhook-url plus --no-webhook is a refusal (they contradict)", async () => {
+	const h = harness({ argv: ["--webhook-url", "https://x.example", "--no-webhook"] });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /contradict/);
+});
+
+test("setup github: an unknown flag fails loud with the usage block", async () => {
+	const h = harness({ argv: ["--frobnicate"] });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /usage: pi-dispatch setup github/);
+});
+
+// -- the manifest: exact shape for both webhook modes --------------------------------------------------
+
+test("buildManifest: --webhook-url shape is exactly the narrow permission/event set with the hook URL", () => {
+	assert.deepEqual(buildManifest({ name: "pi-dispatch-x", redirectUrl: "http://127.0.0.1:1/callback", webhookUrl: "https://hooks.example/github" }), {
+		name: "pi-dispatch-x",
+		url: "https://github.com/edgehero/pi-dispatch",
+		redirect_url: "http://127.0.0.1:1/callback",
+		hook_attributes: { url: "https://hooks.example/github" },
+		public: false,
+		default_permissions: { contents: "write", pull_requests: "write", issues: "write", metadata: "read" },
+		default_events: ["issues", "issue_comment", "pull_request"],
+	});
+});
+
+test("buildManifest: no webhook URL yields hook_attributes {active:false} — the polling-ready shape", () => {
+	const manifest = buildManifest({ name: "pi-dispatch-x", redirectUrl: "http://127.0.0.1:1/callback", webhookUrl: undefined });
+	assert.deepEqual(manifest.hook_attributes, { active: false });
+	assert.deepEqual(manifest.default_permissions, { contents: "write", pull_requests: "write", issues: "write", metadata: "read" });
+	assert.deepEqual(manifest.default_events, ["issues", "issue_comment", "pull_request"]);
+});
+
+// -- the served form page: embeds the manifest, POSTs to the right target ------------------------------
+
+/** Recover the manifest JSON the page embeds (it is HTML-escaped into the hidden input). */
+function embeddedManifest(page) {
+	const m = page.match(/name="manifest" value="([^"]*)"/);
+	assert.ok(m, "the page carries a hidden manifest input");
+	const json = m[1].replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+	return JSON.parse(json);
+}
+
+test("form page: embeds the exact manifest, POSTs to the USER endpoint, and auto-submits", async () => {
+	const h = harness({ argv: ["--webhook-url", "https://hooks.example/github", "--name", "my-app"], answers: [""] });
+	await h.run();
+	const page = h.getPageFor()("http://127.0.0.1:43210");
+	assert.match(page, /action="https:\/\/github\.com\/settings\/apps\/new"/, "no --org means the user-account endpoint");
+	assert.match(page, /method="post"/);
+	assert.match(page, /<script>document\.getElementById\("m"\)\.submit\(\);<\/script>/, "the form self-submits — a link cannot carry the payload");
+	const manifest = embeddedManifest(page);
+	assert.equal(manifest.name, "my-app");
+	assert.equal(manifest.redirect_url, "http://127.0.0.1:43210/callback", "the redirect comes back to the listener's own /callback");
+	assert.deepEqual(manifest.hook_attributes, { url: "https://hooks.example/github" });
+});
+
+test("form page: --org switches the POST target to the organization endpoint", async () => {
+	const h = harness({ argv: ["--no-webhook", "--org", "acme"], answers: [""] });
+	await h.run();
+	const page = h.getPageFor()("http://127.0.0.1:43210");
+	assert.match(page, /action="https:\/\/github\.com\/organizations\/acme\/settings\/apps\/new"/);
+	assert.deepEqual(embeddedManifest(page).hook_attributes, { active: false });
+});
+
+test("buildFormPage: the embedded JSON is HTML-escaped (quotes cannot break out of the input value)", () => {
+	const manifest = buildManifest({ name: "x", redirectUrl: "http://l/callback" });
+	const page = buildFormPage(manifest, "https://github.com/settings/apps/new");
+	assert.ok(page.includes("&quot;name&quot;"), "JSON quotes are escaped into the attribute");
+	const embedded = page.match(/name="manifest" value="([^"]*)"/)[1];
+	assert.ok(!/[<>]/.test(embedded), "no raw angle brackets survive inside the attribute");
+	assert.deepEqual(embeddedManifest(page), manifest, "unescaping recovers the exact manifest — nothing was lost to escaping");
+});
+
+// -- conversion → the shown plan, and the decline path -------------------------------------------------
+
+test("setup github: the conversion result is shown as exact .env lines, secrets absent from ALL output", async () => {
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, answers: [""] }); // decline at the write gate
+	assert.equal(await h.run(), 0, "declining is not an error");
+	const text = h.text();
+	assert.match(text, /GITHUB_AUTH_SOURCE=app/);
+	assert.match(text, /GITHUB_APP_ID=4242/);
+	assert.match(text, new RegExp(`GITHUB_APP_PRIVATE_KEY_PATH=${PEM_PATH.replace(/[./]/g, "\\$&")}`));
+	assert.match(text, /WEBHOOK_SECRET=<value not shown>/, "the secret line is announced, never echoed");
+	assertNoSecrets(text);
+	// The conversion call itself: POST, the code in the path, no auth (the code IS the proof).
+	const conversion = h.fetchCalls.find((c) => c.url.includes("/app-manifests/"));
+	assert.equal(conversion.url, "https://api.github.com/app-manifests/onetimecode/conversions");
+	assert.equal(conversion.opts.method, "POST");
+	assert.equal(conversion.opts.headers.accept, "application/vnd.github+json");
+	assert.ok(conversion.opts.headers["user-agent"], "GitHub requires a User-Agent");
+	assert.equal(conversion.opts.headers.authorization, undefined, "the conversion is unauthenticated by design");
+});
+
+test("setup github: declining the write gate writes NOTHING and names the App's URL + how to delete it", async () => {
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, answers: ["n"] });
+	assert.equal(await h.run(), 0);
+	assert.deepEqual(h.writes, [], "the fs recorder is empty — nothing was written");
+	assert.equal(h.store.get(ENV_PATH), SEED_ENV, ".env is byte-identical");
+	assert.match(h.text(), /the App itself DOES now exist on GitHub: https:\/\/github\.com\/apps\/pi-dispatch-testbox/);
+	assert.match(h.text(), /Delete GitHub App/);
+	assert.equal(h.promptCalls.length, 1, "declined at the first gate — no further prompts");
+});
+
+// -- the accept path: PEM 0600, exact transforms, overwrite vs if-empty split --------------------------
+
+test("setup github: accepting writes the PEM 0600 and applies the exact .env transforms", async () => {
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, answers: ["y", "y", "y"] });
+	assert.equal(await h.run(), 0);
+	const pemWrite = h.writes.find(([p]) => p === PEM_PATH);
+	assert.ok(pemWrite, "the PEM was written");
+	assert.equal(pemWrite[1], PRIVATE_PEM, "the PEM content is the conversion response's pem, verbatim");
+	assert.deepEqual(pemWrite[2], { mode: 0o600 }, "the key file lands mode 0600");
+	// The three consented values went through the OVERWRITE transform (gh was replaced), the secret
+	// through the if-empty one (the empty scaffold line was filled) — asserted as one exact file.
+	assert.equal(
+		h.store.get(ENV_PATH),
+		`GITHUB_AUTH_SOURCE=app\nGITHUB_APP_ID=4242\nGITHUB_APP_PRIVATE_KEY_PATH=${PEM_PATH}\nWEBHOOK_SECRET=${HOOK_SECRET}\nGITHUB_APP_INSTALLATION_ID=987654\n`,
+	);
+	assert.deepEqual(
+		h.promptCalls,
+		["write these? [y/N] ", "installed? [y/N] ", "write it? [y/N] "],
+		"every write is individually consented; there is no --yes on this wizard",
+	);
+	assertNoSecrets(h.text());
+});
+
+test("setup github: an operator's existing WEBHOOK_SECRET is KEPT (if-empty), while GITHUB_AUTH_SOURCE is overwritten", async () => {
+	const seeded = "GITHUB_AUTH_SOURCE=gh\nWEBHOOK_SECRET=operator-chose-this\n";
+	const h = harness({ files: { [ENV_PATH]: seeded }, answers: ["y", "y", "y"] });
+	assert.equal(await h.run(), 0);
+	const env = h.store.get(ENV_PATH);
+	assert.match(env, /^GITHUB_AUTH_SOURCE=app$/m, "the consented auth-source line IS replaced");
+	assert.match(env, /^WEBHOOK_SECRET=operator-chose-this$/m, "the existing secret is untouched — working deliveries stay valid");
+	assert.ok(!env.includes(HOOK_SECRET), "the minted secret was not planted anywhere else either");
+	assert.match(h.text(), /WEBHOOK_SECRET already set in \.env — kept/);
+	assert.ok(!h.text().includes("operator-chose-this"), "existing values are secrets too");
+});
+
+test("setup github: --no-webhook never touches WEBHOOK_SECRET and says the App is hook-inactive", async () => {
+	const h = harness({ argv: ["--no-webhook"], files: { [ENV_PATH]: SEED_ENV }, answers: ["y", "y", "y"] });
+	assert.equal(await h.run(), 0);
+	assert.match(h.store.get(ENV_PATH), /^WEBHOOK_SECRET=$/m, "the empty scaffold line stays empty — nothing will sign deliveries with it");
+	assert.doesNotMatch(h.text(), /WEBHOOK_SECRET=<value not shown>/, "no secret line is even offered");
+	assert.match(h.text(), /webhook INACTIVE \(--no-webhook\)/);
+	assert.match(h.text(), /[Pp]olling/, "the follow-up transport is named so the shape is not a surprise");
+	assertNoSecrets(h.text());
+});
+
+test("setup github: an existing file at the PEM path is a refusal — key files are never clobbered", async () => {
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV, [PEM_PATH]: "OLD KEY MATERIAL" }, answers: ["y"] });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /refusing to overwrite the existing key file/);
+	assert.deepEqual(h.writes, [], "nothing was written — not the PEM, not .env");
+	assert.equal(h.store.get(PEM_PATH), "OLD KEY MATERIAL", "the old key file is untouched");
+	assert.equal(h.store.get(ENV_PATH), SEED_ENV);
+});
+
+test("setup github: with no .env, one is created holding exactly the approved lines", async () => {
+	const h = harness({ files: {}, answers: ["y", "y", "y"] });
+	assert.equal(await h.run(), 0);
+	assert.match(h.text(), /no \.env existed here — created one/);
+	assert.equal(
+		h.store.get(ENV_PATH),
+		`GITHUB_AUTH_SOURCE=app\nGITHUB_APP_ID=4242\nGITHUB_APP_PRIVATE_KEY_PATH=${PEM_PATH}\nWEBHOOK_SECRET=${HOOK_SECRET}\nGITHUB_APP_INSTALLATION_ID=987654\n`,
+	);
+});
+
+// -- the JWT: decoded, sane, and verifiable against the minted key's public half -----------------------
+
+test("setup github: the installations call carries an RS256 JWT — iss = app id, iat/exp sane, signature verifies", async () => {
+	const nowMs = 1_700_000_000_000;
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, answers: ["y", "y", "y"], nowMs });
+	assert.equal(await h.run(), 0);
+	const call = h.fetchCalls.find((c) => c.url.endsWith("/app/installations"));
+	assert.ok(call, "installations were fetched");
+	const jwt = call.opts.headers.authorization.replace(/^Bearer /, "");
+	const [headerB64, payloadB64, signatureB64] = jwt.split(".");
+	assert.deepEqual(JSON.parse(Buffer.from(headerB64, "base64url").toString()), { alg: "RS256", typ: "JWT" });
+	const payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+	assert.equal(payload.iss, "4242", "iss is the app id");
+	const nowSeconds = Math.floor(nowMs / 1000);
+	assert.equal(payload.iat, nowSeconds - 60, "iat is backdated 60s for clock drift");
+	assert.equal(payload.exp - payload.iat, 600, "the lifetime stays inside GitHub's 10-minute maximum");
+	assert.ok(payload.exp > nowSeconds, "the token is not already expired");
+	const verifier = createVerify("RSA-SHA256");
+	verifier.update(`${headerB64}.${payloadB64}`);
+	assert.ok(verifier.verify(PUBLIC_PEM, Buffer.from(signatureB64, "base64url")), "the signature verifies against the minted key's public half");
+	assert.ok(!h.text().includes(jwt), "the JWT is a live credential — never printed");
+});
+
+test("mintAppJwt: direct sign/verify roundtrip with a test keypair", () => {
+	const jwt = mintAppJwt(7, PRIVATE_PEM, 1000000);
+	const [h, p, s] = jwt.split(".");
+	assert.deepEqual(JSON.parse(Buffer.from(h, "base64url").toString()), { alg: "RS256", typ: "JWT" });
+	assert.deepEqual(JSON.parse(Buffer.from(p, "base64url").toString()), { iat: 999940, exp: 1000540, iss: "7" });
+	const verifier = createVerify("RSA-SHA256");
+	verifier.update(`${h}.${p}`);
+	assert.ok(verifier.verify(PUBLIC_PEM, Buffer.from(s, "base64url")));
+});
+
+// -- installation discovery: one / multiple / none / not-yet -------------------------------------------
+
+test("setup github: 'installed?' declined skips discovery entirely and exits 0 with the manual hint", async () => {
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, answers: ["y", ""] });
+	assert.equal(await h.run(), 0);
+	assert.equal(h.fetchCalls.filter((c) => c.url.endsWith("/app/installations")).length, 0, "no discovery without the operator's say-so");
+	assert.match(h.text(), /GITHUB_APP_INSTALLATION_ID=<id>/, "the manual line is spelled out");
+	assert.doesNotMatch(h.store.get(ENV_PATH), /GITHUB_APP_INSTALLATION_ID=\d/);
+	assert.match(h.text(), /setup github: summary/);
+});
+
+test("setup github: multiple installations are listed (login + id) and the chosen one is written", async () => {
+	const routes = {
+		"/app-manifests/": { status: 201, body: APP },
+		"/app/installations": { status: 200, body: [{ id: 11, account: { login: "acme" } }, { id: 22, account: { login: "edgehero" } }] },
+	};
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, routes, answers: ["y", "y", "22", "y"] });
+	assert.equal(await h.run(), 0);
+	assert.match(h.text(), /11\s+acme/);
+	assert.match(h.text(), /22\s+edgehero/);
+	assert.match(h.store.get(ENV_PATH), /^GITHUB_APP_INSTALLATION_ID=22$/m);
+	assert.match(h.text(), /GITHUB_APP_INSTALLATION_ID=22 \(account: edgehero\)/, "the line is shown before the write consent");
+});
+
+test("setup github: a blank answer to the multi-installation pick skips gracefully (exit 0, nothing written)", async () => {
+	const routes = {
+		"/app-manifests/": { status: 201, body: APP },
+		"/app/installations": { status: 200, body: [{ id: 11, account: { login: "acme" } }, { id: 22, account: { login: "edgehero" } }] },
+	};
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, routes, answers: ["y", "y", ""] });
+	assert.equal(await h.run(), 0);
+	assert.doesNotMatch(h.store.get(ENV_PATH), /GITHUB_APP_INSTALLATION_ID=\d/);
+	assert.match(h.text(), /skipped —/);
+});
+
+test("setup github: an answer that is not a listed installation id fails loud with the manual hint", async () => {
+	const routes = {
+		"/app-manifests/": { status: 201, body: APP },
+		"/app/installations": { status: 200, body: [{ id: 11, account: { login: "acme" } }, { id: 22, account: { login: "edgehero" } }] },
+	};
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, routes, answers: ["y", "y", "33", "y"] });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /33 is not one of the listed installation ids/);
+	assert.doesNotMatch(h.store.get(ENV_PATH), /GITHUB_APP_INSTALLATION_ID=\d/);
+});
+
+test("setup github: zero installations exits 0 gracefully with install + manual guidance", async () => {
+	const routes = { "/app-manifests/": { status: 201, body: APP }, "/app/installations": { status: 200, body: [] } };
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, routes, answers: ["y", "y"] });
+	assert.equal(await h.run(), 0);
+	assert.match(h.text(), /no installations yet/);
+	assert.match(h.text(), /https:\/\/github\.com\/apps\/pi-dispatch-testbox\/installations\/new/);
+	assert.doesNotMatch(h.store.get(ENV_PATH), /GITHUB_APP_INSTALLATION_ID=\d/);
+	assert.match(h.text(), /setup github: summary/);
+});
+
+test("setup github: declining the installation-id write keeps .env without it (the id gate is its own)", async () => {
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, answers: ["y", "y", "n"] });
+	assert.equal(await h.run(), 0);
+	assert.doesNotMatch(h.store.get(ENV_PATH), /GITHUB_APP_INSTALLATION_ID=\d/);
+	assert.match(h.text(), /declined —/);
+});
+
+// -- failure modes: all fail-loud, all with guidance, all scrubbed -------------------------------------
+
+test("setup github: a listener bind failure is a clean 1 with guidance, before anything was created", async () => {
+	const h = harness({ listenError: "EADDRINUSE" });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /could not bind a loopback listener \(EADDRINUSE\)/);
+	assert.equal(h.fetchCalls.length, 0);
+});
+
+test("setup github: timing out waiting for the redirect closes the listener and explains the single-use code", async () => {
+	const h = harness({ waitError: "no redirect after 600s" });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /gave up waiting for GitHub's redirect/);
+	assert.match(h.text(), /single-use and expires after an hour/);
+	assert.equal(h.closedCount(), 1, "the listener is closed on the way out");
+	assert.equal(h.fetchCalls.length, 0, "no conversion was attempted without a code");
+});
+
+test("setup github: a non-201 conversion shows status + body snippet and names the single-use/1h rule", async () => {
+	const routes = { "/app-manifests/": { status: 404, body: { message: "Not Found" } } };
+	const h = harness({ routes });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /returned 404 \(expected 201\)/);
+	assert.match(h.text(), /Not Found/, "the body snippet is shown — a failed conversion carries no secrets");
+	assert.match(h.text(), /SINGLE-USE and expires after one hour/);
+});
+
+test("setup github: a conversion network error fails loud with egress guidance", async () => {
+	const routes = { "/app-manifests/": new Error("getaddrinfo ENOTFOUND api.github.com") };
+	const h = harness({ routes });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /could not reach https:\/\/api\.github\.com/);
+	assert.match(h.text(), /ENOTFOUND/);
+});
+
+test("setup github: an unparseable 201 body is withheld entirely (it may contain the private key)", async () => {
+	const routes = { "/app-manifests/": { status: 201, body: `not json ${HOOK_SECRET} ${CLIENT_SECRET}` } };
+	const h = harness({ routes });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /not parseable JSON \(body withheld/);
+	assertNoSecrets(h.text());
+});
+
+test("setup github: secrets are scrubbed even from a hostile error message on the discovery path", async () => {
+	// An error whose message embeds every secret — the scrubber, not luck, is what keeps output clean.
+	const routes = {
+		"/app-manifests/": { status: 201, body: APP },
+		"/app/installations": new Error(`boom ${PRIVATE_PEM} ${HOOK_SECRET} ${CLIENT_SECRET}`),
+	};
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, routes, answers: ["y", "y"] });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /could not reach .* to list installations/);
+	assert.match(h.text(), /\[redacted\]/, "the scrubbed placeholder proves the scrubber ran");
+	assertNoSecrets(h.text());
+	assert.match(h.text(), /credentials above ARE written/, "the operator is told what state they are in");
+});
+
+test("setup github: a non-200 installations response fails loud but points at the manual path", async () => {
+	const routes = { "/app-manifests/": { status: 201, body: APP }, "/app/installations": { status: 401, body: { message: "bad credentials" } } };
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, routes, answers: ["y", "y"] });
+	assert.equal(await h.run(), 1);
+	assert.match(h.text(), /returned 401/);
+	assert.match(h.text(), /GITHUB_APP_INSTALLATION_ID=<id>/);
+});
+
+// -- operator ergonomics: the printed URL is the contract, the browser spawn a convenience -------------
+
+test("setup github: both URLs are printed AND handed to the opener; the port-forward hint is up front", async () => {
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, answers: ["y", "y", "y"] });
+	await h.run();
+	assert.deepEqual(h.opened, ["http://127.0.0.1:43210/", "https://github.com/apps/pi-dispatch-testbox/installations/new"]);
+	assert.match(h.text(), /http:\/\/127\.0\.0\.1:43210\//, "the form URL is printed for headless operators");
+	assert.match(h.text(), /ssh -L 43210:127\.0\.0\.1:43210/, "the remote-server hint names the exact forward");
+	assert.match(h.text(), /ON THE MACHINE RUNNING THIS WIZARD/);
+});
+
+test("setup github: the webhook-path summary points at the receiver", async () => {
+	const h = harness({ files: { [ENV_PATH]: SEED_ENV }, answers: ["y", "y", "y"] });
+	await h.run();
+	assert.match(h.text(), /setup github: summary/);
+	assert.match(h.text(), /pi-dispatch-receiver/);
+});
+
+// -- name derivation ------------------------------------------------------------------------------------
+
+test("sanitizeAppName: lowercases, collapses non [a-z0-9-] runs, trims edge hyphens, caps at 34", () => {
+	assert.equal(sanitizeAppName("My.Host_Name"), "my-host-name");
+	assert.equal(sanitizeAppName("--weird--"), "weird");
+	assert.equal(sanitizeAppName("x".repeat(50)).length, 34);
+	assert.ok(!sanitizeAppName(`${"x".repeat(33)}-y`).endsWith("-"), "a truncation never leaves a trailing hyphen");
+	assert.equal(sanitizeAppName("!!!"), "pi-dispatch", "nothing usable falls back to the bare name");
+});
+
+test("defaultAppName: pi-dispatch-<host>, sanitized end-to-end", () => {
+	assert.equal(sanitizeAppName(defaultAppName("Robs-MacBook.local")), "pi-dispatch-robs-macbook-local");
+});
+
+test("setup github: an over-long --name is sanitized into the manifest", async () => {
+	const h = harness({ argv: ["--no-webhook", "--name", "My Very Long And Fancy App Name For GitHub"], answers: [""] });
+	await h.run();
+	const manifest = embeddedManifest(h.getPageFor()("http://127.0.0.1:43210"));
+	assert.equal(manifest.name, "my-very-long-and-fancy-app-name-fo");
+	assert.ok(manifest.name.length <= 34);
+});


### PR DESCRIPTION
First half of #81. Stacked on #87. The hardest mile of the GitHub arm — acquiring App credentials — becomes one browser click.

## What

**`pi-dispatch setup github [--org <org>] [--name <n>] (--webhook-url <URL> | --no-webhook)`** runs GitHub's **App Manifest flow**: a throwaway listener on the operator's own loopback serves a self-submitting form that POSTs the manifest (permissions `contents`/`pull_requests`/`issues` write + `metadata` read; events `issues`/`issue_comment`/`pull_request`), the browser redirect delivers a single-use code (1h validity), and the unauthenticated conversion endpoint returns the **app id, private-key PEM, and webhook secret in one response**. Nothing crosses a maintainer-controlled service — GitHub is the only remote party.

The consent doctrine is tighter than `up`'s, because these writes carry credentials — there is deliberately **no `--yes`**:

- The exact `.env` lines are **shown before one explicit consent**; a decline writes nothing and prints the App's settings URL plus how to delete it.
- The PEM lands beside `.env` with mode `0600` and **refuses to clobber** an existing key file.
- An already-set `WEBHOOK_SECRET` is **kept** (replacing it would invalidate working deliveries); under `--no-webhook` it's never touched at all — nothing would ever sign with it.
- The webhook shape is **undefaulted** (the `GITLAB_WEBHOOK_MODE` precedent): omitting both flags is a refusal with guidance, because a URL can't be guessed and a silently hook-inactive App is a webhook that never fires. `--no-webhook` creates the hook-inactive shape the polling transport (second half of #81) consumes.
- One `say()` scrubber wraps **all** output: pem / webhook secret / client secret / JWT are registered the moment they're parsed and redacted in every path, including hostile error bodies; an unparseable conversion body is withheld entirely since it may contain the key.

Installation-id discovery mints a deliberately hand-rolled ~15-line `node:crypto` RS256 app JWT (auditable, used once at setup; job-time minting stays `@octokit/auth-app` in `get-token.mjs`, unchanged) and walks `GET /app/installations` — one, multiple (pick), and none (graceful guidance) all handled, each write consented. `env-file.mjs` gains `setEnvKey`/`{overwrite}` — the consented-overwrite sibling of `setEnvKeyIfEmpty`. `doctor` grows an app-auth completeness block (ids numeric, key path exists, `mode & 0o077` warning on POSIX, a 16-byte PEM sniff that never reads or echoes the key) with fix lines pointing at `setup github`.

## Specs

New **`DES-GH-APP-MANIFEST-SETUP`**, including the recorded rejections: a maintainer-registered device-flow client (inserts a maintainer dependency into a self-hosted trust chain) and auto-installing the App (automating a consent screen defeats it). SECURITY.md's auth-source ladder gains the manifest-flow paragraph — the App path (already the recommended one) is now also the easy one. Revision History row in `design.md`; `CONST-TOKEN-SCOPED-PER-JOB` (acquisition changed, minting/scoping untouched) and `CONST-HMAC-OVER-RAW-BODY` (the minted secret feeds the same verify path) — unchanged, checked.

## Tests

Full suite: **1780 tests, 1764 pass, 0 fail, 16 pre-existing skips** — 60 new (35 wizard, all offline with fake fetch/listen/prompt/fs incl. planted-secret-absence across every output path and a JWT sign/verify roundtrip; 18 env-file; 7 doctor with real temp PEM files). CI greps clean.
