### PR TITLE
chore(release): pi-dispatch 0.6.0, admin 0.3.0

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",


### PR DESCRIPTION
Release bump for the setup overhaul (#80/#81/#82, landed via #83 + #90).

- **root 0.5.0 → 0.6.0** — repo-release.yml cuts `v0.6.0` on merge.
- **admin 0.2.0 → 0.3.0** — release.yml publishes the console with its new cwd defaults (`./triggers.json` etc., matching `init` and the receiver; the old `deploy/` defaults were right only from a checkout root).
- Worker and receiver stay **0.1.0** — already published from the #90 merge with the complete tree; nothing to re-publish.

Full suite on this branch: 1797 tests, 1781 pass, 0 fail, 16 pre-existing skips.