### PR TITLE
feat: /dispatch setup — first-run wizard, deployment pointer, and detection (issue #92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,13 @@ pi install npm:@edgehero/pi-dispatch-admin   # then, in pi:  /dispatch
 
 Two other ways to load it: from a clone, the in-repo `.pi/extensions` shim auto-loads once you've trusted
 the project; or point pi at the source with `pi -e admin/src/index.ts` (add that path to the `"extensions"`
-array in `~/.pi/agent/settings.json` to make it permanent). To operate a **live** deployment, give the pi
-session the same `VALKEY_URL`, `PI_SETTINGS_FILE`, `PI_TRIGGERS_FILE`, `PI_PAUSE_WINDOWS_FILE`, and
-`PI_LOGS_DIR` the worker uses — the panel reads and writes those same files and queue, so both act on one
-deployment.
+array in `~/.pi/agent/settings.json` to make it permanent). Pointing the panel at a **live** deployment is
+automatic when `/dispatch setup` built it: the wizard writes a small **deployment pointer**
+(`~/.pi/agent/pi-dispatch-deployment.json`, override `PI_DISPATCH_DEPLOYMENT_FILE` — absolute paths only,
+never credentials), and the panel finds the deployment from any directory. Your own env always wins, key
+by key — exporting the same `VALKEY_URL` / `PI_SETTINGS_FILE` / `PI_TRIGGERS_FILE` /
+`PI_PAUSE_WINDOWS_FILE` / `PI_LOGS_DIR` the worker uses still works exactly as before, and is still the
+way to aim one pi session at a *different* deployment.
 
 Bare `/dispatch` opens the live dashboard overlay — one snapshot per second, `p`/`r` to pause/resume the
 queue in place, `↑`/`↓` to move across the triggers and runs, `Enter` to drill into either. **Triggers are

--- a/README.md
+++ b/README.md
@@ -279,6 +279,16 @@ then open the panel:
 pi install npm:@edgehero/pi-dispatch-admin   # then, in pi:  /dispatch
 ```
 
+**No deployment yet? The console builds one.** When `/dispatch` finds nothing — no pointer, no env, no
+config in the folder, queue unreachable — it offers **`/dispatch setup`**: pick a deployment folder
+(default `~/pi-dispatch`), consent to an `npm install` of the pinned runtime, watch `pi-dispatch up` run
+its own per-action prompts in your terminal, optionally install the worker as a user-level service, and
+land in the panel — with an optional first trigger for the repo you're sitting in, its flow picked from
+that repo's own `.pi/skills/`. Every step shows what it will do and asks first; every step can be
+declined; nothing is ever written into your repo (the `ai-trigger: allow` opt-in line is printed for
+*you* to commit), and no credential ever passes through a dialog. It's the same consented CLI underneath
+— the wizard just types it for you.
+
 Two other ways to load it: from a clone, the in-repo `.pi/extensions` shim auto-loads once you've trusted
 the project; or point pi at the source with `pi -e admin/src/index.ts` (add that path to the `"extensions"`
 array in `~/.pi/agent/settings.json` to make it permanent). Pointing the panel at a **live** deployment is

--- a/admin/skills/operate-pi-dispatch/SKILL.md
+++ b/admin/skills/operate-pi-dispatch/SKILL.md
@@ -57,6 +57,19 @@ Use them like this:
 
 The confirm is the approval step. Treat a decline as a final, legitimate answer.
 
+## Setting up a deployment — `/dispatch setup`, and why you cannot run it
+
+When the tools report no reachable deployment (queue unreachable, no configured paths), the fix is the
+first-run wizard — and it is **operator-typed only**: there is no model-callable setup tool, on purpose.
+Tell the operator to type `/dispatch setup`. It will, with a consent step per action: create a deployment
+folder, npm-install the pinned runtime into it, hand the terminal to `pi-dispatch up` (whose own y/N
+prompts gate the docker actions), optionally install the worker as a user-level service, write the
+deployment pointer so the panel finds everything afterwards, and offer a first trigger for the repo the
+session is in. What it will NOT do, ever: write into the operator's repo (the `ai-trigger: allow` line is
+printed for them to commit), accept a credential through a dialog, or run anything with `--yes`.
+Do not try to reproduce the wizard's steps through other tools or shell access — the sequencing exists
+so each mutation carries its own human gate.
+
 ## Staged packages — `run.packages`, and why you cannot set it
 
 When a trigger fires, the job loads the third-party **pi packages the operator staged** into their global

--- a/admin/src/deployment-pointer.mjs
+++ b/admin/src/deployment-pointer.mjs
@@ -1,0 +1,248 @@
+/**
+ * The deployment POINTER (INT-DEPLOYMENT-POINTER-CONTRACT, issue #92): the one file that lets the admin's
+ * `/dispatch` find a deployment the setup wizard built somewhere else. `resolvePaths` (read-model.mjs) is
+ * env-only BY CONTRACT and stays untouched -- a wizard-built deployment in `~/pi-dispatch` is invisible from
+ * any other cwd -- so this module layers the pointer's entries into `process.env` ONCE at extension load.
+ * Env always wins, key by key; with the layering in place, every `resolvePaths(process.env)` call site
+ * (every command and every LLM tool) is covered with zero signature changes.
+ *
+ * The contract in one line: **the pointer resolves paths only, never credentials, never capability
+ * grants.** The read side enforces that with an allowlist (`POINTER_ENV_ALLOWLIST`) rather than a
+ * blocklist: anything else in `env` is DROPPED silently (the operator-file unknown-fields-dropped
+ * policy) -- most pointedly `PI_DISPATCH_RUN_ROOTS`, because a pointer that could widen the AI-run
+ * folder allowlist would be a second, unreviewed door to a capability the panel deliberately gates
+ * behind the operator's own env; and any credential-shaped key, because secrets travel through the
+ * operator's env and the token broker, never through a file the wizard writes world-readable.
+ *
+ * Failure doctrine: a broken pointer must leave `/dispatch` exactly as functional as before the pointer
+ * existed (env then cwd defaults). So `readPointer` NEVER throws -- unparseable JSON, a non-object, a
+ * missing/invalid version, a newer version all come back as `{ ignored: reason }` -- and the apply path
+ * retains a one-line notice for the next `/dispatch` to surface (the REBUILT_NOTICE idiom: a surfaced
+ * warning, never a throw). This is deliberately weaker than the subscriptions file's loud refusal; the
+ * reconciliation is recorded in the spec: the pointer is an availability aid, not a data file.
+ *
+ * Staleness is the wizard's problem, not the reader's: `readPointer` never stats `deploymentDir` or any
+ * env value. The reader is pure over the file text plus one `fs.readFileSync`, so it cannot slow a
+ * session down or invent a second existence check that disagrees with the wizard's.
+ */
+
+import * as nodeFs from "node:fs";
+import { homedir } from "node:os";
+import { join, isAbsolute } from "node:path";
+
+/** The pointer schema version this build understands. A NEWER file is ignored with a notice, never guessed at. */
+export const POINTER_VERSION = 1;
+
+/**
+ * The only env keys a pointer may set -- the path/URL variables `resolvePaths` reads to find a deployment's
+ * files. An allowlist, not a blocklist: a new resolvePaths variable gets pointer coverage only by being
+ * added HERE, on review. `PI_DISPATCH_RUN_ROOTS` is absent on purpose (a capability grant, not a path),
+ * as is every credential-shaped key (the pointer never carries secrets).
+ */
+export const POINTER_ENV_ALLOWLIST = Object.freeze([
+  "VALKEY_URL",
+  "PI_LOGS_DIR",
+  "PI_SETTINGS_FILE",
+  "PI_TRIGGERS_FILE",
+  "PI_PAUSE_WINDOWS_FILE",
+  "PI_SUBSCRIPTIONS_FILE",
+]);
+
+const POINTER_BASENAME = "pi-dispatch-deployment.json";
+
+// ---- module state: the once-per-process memo, the retained notice, and the owned-key ledger ----
+
+// Whether the process-wide layering has happened. applyDeploymentPointer is called from the extension
+// factory, which pi may in principle evaluate more than once; the memo makes every call after the first
+// a no-op so the layering result cannot depend on load order or count.
+let appliedOnce = false;
+
+// The retained one-line notice from an ignored pointer, surfaced once by the next /dispatch. A single
+// slot, latest-wins: there is one pointer file, so there is at most one thing to say about it.
+let notice;
+
+// The keys THIS MODULE wrote into the env, and therefore the only keys a re-apply may update. A var the
+// operator exported is never in here, so it can never be overwritten -- not even by the wizard's own
+// re-apply after it rewrites the pointer.
+const ownedKeys = new Set();
+
+/**
+ * Where the pointer lives: `PI_DISPATCH_DEPLOYMENT_FILE`, defaulting to pi's own agent dir
+ * (`PI_CODING_AGENT_DIR` or `~/.pi/agent` -- the repo's one established home-dir pattern, resolved the
+ * way worker/src/import-pi.mjs does). `||` on both reads so an EMPTY string falls back like an unset one,
+ * matching resolvePaths' own defaulting idiom.
+ */
+export function pointerPath(env = process.env) {
+  return (
+    env.PI_DISPATCH_DEPLOYMENT_FILE ||
+    join(env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent"), POINTER_BASENAME)
+  );
+}
+
+/**
+ * Validate + filter one raw parsed pointer into the canonical `{ version, deploymentDir, env }` shape.
+ * The single normalizer for BOTH sides: `readPointer` runs every file through it, and `writePointer`
+ * runs every candidate through it before writing -- so a pointer that would be ignored on read is never
+ * written, and a disallowed env key can neither be applied NOR persisted through this API.
+ *
+ * Returns `{ pointer }` or `{ ignored: reason }`. Never throws.
+ */
+function normalizePointer(raw) {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ignored: "not a JSON object" };
+  }
+  // version is the one field that cannot be retrofitted: required, integer >= 1. A NEWER version means a
+  // future wizard wrote a shape this build does not understand -- ignore the whole file (degrading to the
+  // pre-pointer behavior) rather than half-read it, and name both versions so the operator knows which
+  // side to upgrade.
+  if (!Number.isInteger(raw.version) || raw.version < 1) {
+    return { ignored: "missing or invalid version (integer >= 1 required)" };
+  }
+  if (raw.version > POINTER_VERSION) {
+    return { ignored: `version ${raw.version} is newer than the supported version ${POINTER_VERSION}` };
+  }
+  if (typeof raw.deploymentDir !== "string" || !isAbsolute(raw.deploymentDir)) {
+    return { ignored: "deploymentDir must be an absolute path" };
+  }
+  // An absent env map reads as {} (a pointer may name only the deployment dir); a PRESENT non-object env
+  // is a malformed file and ignored whole -- silently "fixing" it would mask a hand-edit gone wrong.
+  const rawEnv = raw.env === undefined ? {} : raw.env;
+  if (rawEnv === null || typeof rawEnv !== "object" || Array.isArray(rawEnv)) {
+    return { ignored: "env must be an object" };
+  }
+  const env = {};
+  // Iterating the ALLOWLIST (not the file's keys) is what makes every unknown key -- run roots,
+  // credentials, typos -- vanish without a branch to forget. Values must be non-empty strings; and every
+  // path value must be ABSOLUTE, because a relative path would resolve against whichever session's cwd
+  // happens to read it -- silently wrong in exactly the cross-directory case the pointer exists to fix.
+  // VALKEY_URL is a URL, not a filesystem path, so it is exempt from the absoluteness gate only.
+  for (const key of POINTER_ENV_ALLOWLIST) {
+    const value = rawEnv[key];
+    if (typeof value !== "string" || value === "") continue;
+    if (key !== "VALKEY_URL" && !isAbsolute(value)) continue;
+    env[key] = value;
+  }
+  // Unknown TOP-LEVEL fields drop here too: only the three canonical fields are ever kept or re-written.
+  return { pointer: { version: raw.version, deploymentDir: raw.deploymentDir, env } };
+}
+
+/**
+ * Read and normalize the pointer file. Returns exactly one of:
+ *   `{ pointer }`          -- a valid pointer, env already allowlist-filtered
+ *   `{ ignored: reason }`  -- a file that exists but cannot be honored (never a throw)
+ *   `{ absent: true }`     -- no file: the normal pre-wizard state, not an error
+ *
+ * Pure over the file text + `fs.readFileSync`: no stat of `deploymentDir`, no module-state mutation
+ * (notices are retained by the APPLY path, not here) -- stale-deployment detection is the wizard's job.
+ */
+export function readPointer({ path = pointerPath(), fs = nodeFs } = {}) {
+  let text;
+  try {
+    text = fs.readFileSync(path, "utf8");
+  } catch (err) {
+    if (err && err.code === "ENOENT") return { absent: true };
+    // Any other read failure (permissions, EISDIR, ...) degrades like a malformed file: ignored, named.
+    return { ignored: `unreadable: ${err?.message ?? err}` };
+  }
+  let raw;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    return { ignored: `unparseable JSON: ${err.message}` };
+  }
+  return normalizePointer(raw);
+}
+
+/**
+ * The shared layering step for apply/re-apply. A key is written only when the pointer may govern it:
+ * either nobody set it (`undefined` -- and note that an operator's EMPTY export counts as set, because
+ * exporting `PI_LOGS_DIR=""` is still operator intent this module must not second-guess), or this module
+ * itself set it on an earlier pass (`ownedKeys`). An ignored pointer retains the one-line notice and
+ * applies nothing.
+ */
+function layerPointer(env, fs) {
+  const path = pointerPath(env);
+  const res = readPointer({ path, fs });
+  if (res.ignored) {
+    notice = `deployment pointer ignored: ${res.ignored} (${path})`;
+    return { applied: [] };
+  }
+  if (res.absent) return { applied: [] };
+  const applied = [];
+  for (const [key, value] of Object.entries(res.pointer.env)) {
+    if (env[key] !== undefined && !ownedKeys.has(key)) continue; // the operator's export always wins
+    env[key] = value;
+    ownedKeys.add(key);
+    applied.push(key);
+  }
+  return { applied };
+}
+
+/**
+ * Layer the pointer's allowed, absolute env entries into `env` (default `process.env`), once per process.
+ * Returns `{ applied: [keys] }` (informational; empty on memo hit / absent / ignored).
+ *
+ * Called at the TOP of the extension factory on purpose: `resolvePaths(process.env)` runs per-command AND
+ * per LLM tool call, so factory-time layering is in place before any resolve -- including for an operator
+ * who never types `/dispatch` and only lets the model call `dispatch_status`. Memoized so a second factory
+ * evaluation cannot re-read the file mid-session; the ONLY refresh path is `reapplyDeploymentPointer`,
+ * which the wizard calls deliberately after rewriting the file.
+ */
+export function applyDeploymentPointer(env = process.env, { fs = nodeFs } = {}) {
+  if (appliedOnce) return { applied: [] };
+  appliedOnce = true;
+  return layerPointer(env, fs);
+}
+
+/**
+ * Re-read the pointer and refresh the layering -- the wizard's post-write hook, so a just-built deployment
+ * takes effect in the SAME pi session without a restart. Same signature and return as apply, but it skips
+ * the memo. Safety is unchanged: it may set a still-unset key or update a key THIS MODULE set earlier,
+ * and never one the operator exported (even one exported after the first apply). A key the module owns
+ * that a rewritten pointer no longer carries keeps its last applied value until process restart -- the
+ * re-apply updates, it never unsets, so a half-typed pointer edit cannot yank paths out from under a
+ * live panel.
+ */
+export function reapplyDeploymentPointer(env = process.env, { fs = nodeFs } = {}) {
+  appliedOnce = true; // a later plain apply stays a no-op; this call IS the refresh
+  return layerPointer(env, fs);
+}
+
+/**
+ * Return the retained one-line notice once, then clear it -- undefined when there is nothing to say.
+ * The `/dispatch` handler drains this into `notify(..., "warning")`, which is the pointer's entire error
+ * surface: one line, once, never a throw.
+ */
+export function takePointerNotice() {
+  const n = notice;
+  notice = undefined;
+  return n;
+}
+
+/**
+ * Write a pointer for the wizard: validated through the SAME normalizer as the read side (a pointer that
+ * would be ignored on read is refused here with `{ invalid: reason }` and the file is untouched), then
+ * written atomically (tmp + rename, the repo's write idiom) as 2-space JSON with a trailing newline --
+ * hand-editable thereafter. Note it persists the NORMALIZED shape: disallowed env keys and relative path
+ * values are dropped before the bytes exist, so this API cannot be used to smuggle a credential or a
+ * capability grant into the file. Returns `{ ok: true }` on success.
+ */
+export function writePointer({ path = pointerPath(), pointer, fs = nodeFs } = {}) {
+  const res = normalizePointer(pointer);
+  if (res.ignored) return { invalid: res.ignored };
+  const tmp = `${path}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(res.pointer, null, 2)}\n`);
+  fs.renameSync(tmp, path);
+  return { ok: true };
+}
+
+/**
+ * TEST-ONLY: clear the process-wide memo, the retained notice, and the owned-key ledger, so each test
+ * case starts from the fresh-process state. Named to make any production call site an obvious review
+ * failure; production code has no reason to reset -- the memo being process-wide is the point.
+ */
+export function resetForTests() {
+  appliedOnce = false;
+  notice = undefined;
+  ownedKeys.clear();
+}

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -61,6 +61,11 @@ import {
   readSubscriptions,
   KNOWN_KEYS,
 } from "./read-model.mjs";
+// The deployment pointer (INT-DEPLOYMENT-POINTER-CONTRACT): the wizard-written file that aims this
+// extension at a deployment built in another directory. Layered into process.env once at factory load
+// (the operator's env always wins), so resolvePaths stays env-only by contract while every one of its
+// call sites below is covered without a signature change.
+import { applyDeploymentPointer, takePointerNotice } from "./deployment-pointer.mjs";
 import { foldCosts, whatIfFlow } from "./costs.mjs";
 // The REAL pricing façade. costs.mjs may not hold a module-scope worker/pricing import by contract (the
 // fold is pure; tests inject a canned fake) -- index.ts is where the fs-adjacent assembly lives, so the
@@ -111,6 +116,21 @@ export default function admin(pi: ExtensionAPI): void {
       );
       return;
     }
+  }
+
+  // Layer the setup wizard's deployment pointer into process.env exactly once, before anything can call
+  // resolvePaths(process.env). Placement matters twice over: AFTER the capability probe, so a refused
+  // load stays a complete no-op (an extension that registers nothing must not mutate the env either);
+  // and at the FACTORY top rather than inside the /dispatch handler, because resolvePaths runs
+  // per-command AND per LLM tool call -- an operator who never types /dispatch but lets the model call
+  // dispatch_status still needs the pointer's paths in place before the first resolve. The try/catch is
+  // the never-throw doctrine: an extension factory must never fail to load over a bad pointer file; the
+  // retained notice (surfaced on the next /dispatch) is the error channel, not an exception.
+  try {
+    applyDeploymentPointer();
+  } catch {
+    // Deliberately swallowed: applyDeploymentPointer degrades internally ({ ignored } + notice), so
+    // anything reaching here is unexpected -- and still must not take the whole extension down.
   }
 
   pi.registerCommand("dispatch", {
@@ -716,6 +736,12 @@ async function dispatch(pi: ExtensionAPI, args: string, ctx: any): Promise<void>
   // draws through panel.mjs' active table, and this is the one funnel all subcommands pass through. The
   // dashboard's own styler keeps its default for now -- its `ascii` opt-in lands when the view PR settles.
   setGlyphs(paths.asciiGlyphs);
+
+  // Drain the deployment pointer's retained one-line notice (a broken or newer pointer file) into the
+  // operator's face exactly once -- the REBUILT_NOTICE idiom: a surfaced warning, never a throw, and
+  // never into model context.
+  const pnote = takePointerNotice();
+  if (pnote) notify?.(pnote, "warning");
 
   if (sub === "") {
     await openDashboard(paths, ctx, notify);

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -33,6 +33,11 @@
  * ships an `operate-pi-dispatch` skill, advertised via `resources_discover`, that tells
  * the model how to use those human-in-the-loop write gates.
  *
+ * `/dispatch setup` (issue #92) runs the guided deployment wizard (setup-wizard.ts); a bare
+ * `/dispatch` on a host with no deployment at all offers it, and a one-time session_start
+ * nudge names it on a fresh host. The wizard sequences the worker CLI's own consented
+ * commands and writes the deployment pointer this factory applies above.
+ *
  * Supported pi version: 0.80.7. The factory registers nothing unless every API
  * member it consumes is present; on a miss it names the member and the
  * supported version on stderr and returns.
@@ -76,6 +81,10 @@ import { buildSandboxRunArgs, launchSandbox as spawnSandbox, resolveSandbox, san
 import { readManifest } from "@edgehero/pi-dispatch/sandbox-store";
 import { renderStatus, renderRuns, renderBudget, renderTriggers, renderSettingsView, renderCosts, renderWhatIf } from "./render.mjs";
 import { makeDashboard, createDashboardDeps } from "./dashboard.ts";
+// Only the nudge is loaded eagerly (it must register its session_start handler at factory time); the
+// wizard itself stays behind the dispatch handler's lazy import. The setup-wizard module imports
+// buildTriggerEntry back from here -- a cycle on paper, but both sides only call across it at runtime.
+import { registerNudge } from "./setup-wizard.ts";
 import { matchesKey } from "./keys.mjs";
 
 // The single source of truth for the ExtensionAPI surface this extension
@@ -90,7 +99,7 @@ const REBUILT_NOTICE = (reason: string) =>
   `replaced invalid settings file (${reason}) — other keys were lost`;
 
 const USAGE =
-  "usage: /dispatch <status|pause|resume|run|runs|logs|budget|costs|triggers|settings|set|unset>";
+  "usage: /dispatch <status|pause|resume|run|runs|logs|budget|costs|triggers|settings|set|unset|setup>";
 
 const KNOWN_SUBCOMMANDS = [
   "status",
@@ -105,6 +114,7 @@ const KNOWN_SUBCOMMANDS = [
   "settings",
   "set",
   "unset",
+  "setup",
 ] as const;
 
 export default function admin(pi: ExtensionAPI): void {
@@ -135,13 +145,14 @@ export default function admin(pi: ExtensionAPI): void {
 
   pi.registerCommand("dispatch", {
     description:
-      "pi-dispatch admin: status|pause|resume|run|runs|logs|budget|costs|triggers|settings|set|unset",
+      "pi-dispatch admin: status|pause|resume|run|runs|logs|budget|costs|triggers|settings|set|unset|setup",
     getArgumentCompletions: (prefix) => completeArguments(prefix),
     handler: async (args, ctx) => dispatch(pi, args, ctx),
   });
 
   registerTools(pi);
   registerSkill(pi);
+  registerNudge(pi);
 }
 
 /**
@@ -655,7 +666,7 @@ const PR_ACTION_VOCAB: Record<string, { hint: string; dflt: string }> = {
   azure: { hint: "created updated", dflt: "updated" },
 };
 
-function buildTriggerEntry(kind: string, f: any): any {
+export function buildTriggerEntry(kind: string, f: any): any {
   if (kind === "cron") {
     // Optional per-entry provider/model/maxTurns pass through to job.data (highest precedence); omitted when
     // blank so the value still resolves against the settings overlay/env at job start (triggers.mjs:127-131).
@@ -744,6 +755,32 @@ async function dispatch(pi: ExtensionAPI, args: string, ctx: any): Promise<void>
   if (pnote) notify?.(pnote, "warning");
 
   if (sub === "") {
+    // Detection decides what a bare /dispatch means (issue #92). Lazy import: the wizard module loads
+    // only on the bare command and `setup`, never for the read subcommands or the LLM tools.
+    const { detectDeployment, runSetupWizard } = await import("./setup-wizard.ts");
+    const det = await detectDeployment({ env: process.env, cwd: ctx?.cwd });
+    if (det.state === "none") {
+      // Nothing anywhere: offer the wizard instead of opening a panel onto an empty deployment. The
+      // confirm is the offer -- a decline (or a build without dialogs) degrades to the usage line.
+      if (typeof ctx?.ui?.confirm === "function") {
+        const ok = await ctx.ui.confirm(
+          "pi-dispatch setup",
+          "No deployment found (no pointer, no env, no config here, queue unreachable). Set one up now?",
+        );
+        if (ok) {
+          await runSetupWizard(paths, ctx, notify, { openDashboardFn: openDashboard });
+          return;
+        }
+      }
+      notify?.(`${USAGE} — run /dispatch setup when you are ready`, "info");
+      return;
+    }
+    if (det.state === "cwd" || det.state === "reachable") {
+      // A deployment that works only from this directory (cwd scaffold) or was merely probed
+      // (reachable queue, no config wired): open the panel as always, plus ONE hint that a pointer
+      // would make it work from anywhere. "pointer"/"env" open with no hint -- exactly as today.
+      notify?.(`using ${det.detail} — /dispatch setup can write a deployment pointer so this works from anywhere`, "info");
+    }
     await openDashboard(paths, ctx, notify);
     return;
   }
@@ -830,6 +867,14 @@ async function dispatch(pi: ExtensionAPI, args: string, ctx: any): Promise<void>
     }
     case "unset": {
       applyUnset(paths.settingsFile, tokens, notify);
+      return;
+    }
+    case "setup": {
+      // Same lazy import as the bare branch; openDashboard rides in as a dep so the wizard's final
+      // step (and its "Open the panel anyway" escape) reuse this module's opener without a cycle at
+      // evaluation time.
+      const { runSetupWizard } = await import("./setup-wizard.ts");
+      await runSetupWizard(paths, ctx, notify, { openDashboardFn: openDashboard });
       return;
     }
     default:

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -1,0 +1,605 @@
+/**
+ * The `/dispatch setup` wizard (issue #92): a guided, step-by-step build of a pi-dispatch deployment,
+ * driven entirely through pi's own dialogs and one attached-terminal overlay.
+ *
+ * Division of labor, deliberately: the WORKER's CLI (`up`, `service`, `setup github`) stays the one
+ * place host mutations happen -- the wizard only sequences those commands, attached to the operator's
+ * terminal, with a confirm in front of each spawn showing the exact command. The wizard's OWN writes
+ * are three files, each tame: the deployment dir's private `package.json` (never clobbered), the
+ * deployment pointer (via `writePointer`'s validating normalizer), and one appended trigger entry (via
+ * the validated, atomic `writeTriggers`). Secrets are never touched: the provider-key step is a notice
+ * naming the file, nothing more.
+ *
+ * Every step is declinable and a decline CONTINUES to the next step (converge-style, like `up` itself):
+ * an operator who already ran half the quickstart by hand skips the steps that are done. The only hard
+ * stop is the post-install version assertion -- a wrong runtime version poisons every later step, so
+ * that failure is loud and final (worker/src/import-pi.mjs:334-341 idiom).
+ */
+
+import * as nodeFs from "node:fs";
+import { spawn as nodeSpawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+// The single source of truth for skill-directory names -- the same regex the worker's flow gate applies
+// at job time, so the wizard can never offer a flow the gate would refuse on shape.
+import { SKILL_NAME_RE } from "@edgehero/pi-dispatch/flow-gate";
+import {
+  POINTER_ENV_ALLOWLIST,
+  POINTER_VERSION,
+  pointerPath,
+  readPointer,
+  reapplyDeploymentPointer,
+  writePointer,
+} from "./deployment-pointer.mjs";
+import { readQueueState, resolvePaths, writeTriggers } from "./read-model.mjs";
+// buildTriggerEntry is index.ts's on x run matrix -- the SAME builder the dialogs and the LLM tool use,
+// so the wizard's first trigger has exactly their shape. The import is circular on paper (index.ts
+// lazy-imports this module from its /dispatch handler and statically imports registerNudge below), but
+// never at evaluation time: both sides only CALL across the boundary at runtime, after both modules
+// have finished loading.
+import { buildTriggerEntry } from "./index.ts";
+
+type Notify = ((message: string, type?: string) => void) | undefined;
+
+/**
+ * The `@edgehero/pi-dispatch` version this wizard installs -- pinned, never `latest`, so a wizard run
+ * is reproducible and the admin that drove it was reviewed against the runtime it produced. The
+ * anti-drift test (setup-wizard.test.mjs) ties this literal to the in-repo `worker/package.json`
+ * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
+ * follows in the same change.
+ */
+export const RUNTIME_VERSION = "0.1.0";
+
+/** The pointer marker file suffix and the four-file cwd scaffold signature, shared by detect + nudge. */
+const NUDGE_MARKER_BASENAME = "pi-dispatch-setup.nudged";
+const CWD_SCAFFOLD_FILES = [".env", "triggers.json", "pause-windows.json", "subscriptions.json"];
+
+/**
+ * The env keys whose PRESENCE means "the operator pointed the admin at a deployment": the pointer
+ * allowlist minus VALKEY_URL. Derived, not restated, so a new resolvePaths path variable added to the
+ * allowlist is picked up here on the same review. VALKEY_URL is deliberately excluded from the
+ * presence check: an exported queue URL is a claim, and detection PROBES it (branch 4) rather than
+ * trusting it -- a dead URL should yield the setup offer, not a broken panel, and the tests pin the
+ * probe to a dead port through exactly this seam.
+ */
+const ENV_PATH_KEYS = POINTER_ENV_ALLOWLIST.filter((key) => key !== "VALKEY_URL");
+
+/** Non-empty-string presence, matching resolvePaths' own `||` defaulting (an empty export falls back). */
+function envIsSet(env: any, key: string): boolean {
+  return typeof env[key] === "string" && env[key] !== "";
+}
+
+/**
+ * Whether `cwd` carries `pi-dispatch init`'s scaffold signature: `.env` + `triggers.json` +
+ * `pause-windows.json` + `subscriptions.json`, ALL present. Deliberately not `pi-packages.json`:
+ * older deployments predate it (init grew it later), and requiring it would misread every one of them
+ * as unconfigured.
+ */
+function hasCwdScaffold(cwd: string, fs: any): boolean {
+  return CWD_SCAFFOLD_FILES.every((name) => fs.existsSync(join(cwd, name)));
+}
+
+/** The default queue probe: one self-closing readQueueState; reachable iff it did not come back `{ unreachable }`. */
+async function defaultProbeQueue(url: string): Promise<boolean> {
+  return !(await readQueueState({ url })).unreachable;
+}
+
+/**
+ * Where is the deployment, if anywhere? Returns `{ state, detail }` with state one of:
+ *   "pointer"   -- a VALID pointer file exists (the wizard ran, or the operator wrote one)
+ *   "env"       -- one of the path env vars is exported (the operator wired the env)
+ *   "cwd"       -- this directory carries init's scaffold signature (a launched-from-the-deployment session)
+ *   "reachable" -- none of the above, but the queue answers at the (default or exported) VALKEY_URL
+ *   "none"      -- nothing found: the setup offer's trigger state
+ *
+ * The order IS the trust order: an explicit pointer beats env beats cwd beats a bare network probe. A
+ * stale/invalid pointer file falls through (readPointer's `{ ignored }`), degrading to the pre-pointer
+ * detection exactly as `/dispatch` itself degrades -- the retained notice, not this function, tells the
+ * operator the file is broken.
+ *
+ * NEVER consulted: `logsDir` / `settingsFile` absence. Both default lazily into OS temp locations
+ * (see resolvePaths), so their absence proves nothing about a deployment and testing them would drag
+ * OS-temp paths into a detection that is otherwise pure over the operator's own files.
+ */
+export async function detectDeployment({
+  env = process.env,
+  cwd = process.cwd(),
+  fs = nodeFs,
+  probeQueue = defaultProbeQueue,
+}: any = {}): Promise<{ state: "pointer" | "env" | "cwd" | "reachable" | "none"; detail: string }> {
+  const pointerRes: any = readPointer({ path: pointerPath(env), fs });
+  if (pointerRes.pointer) {
+    return { state: "pointer", detail: `deployment pointer -> ${pointerRes.pointer.deploymentDir}` };
+  }
+  const setKeys = ENV_PATH_KEYS.filter((key) => envIsSet(env, key));
+  if (setKeys.length > 0) {
+    return { state: "env", detail: `env points at a deployment (${setKeys.join(", ")})` };
+  }
+  if (typeof cwd === "string" && cwd !== "" && hasCwdScaffold(cwd, fs)) {
+    return { state: "cwd", detail: `deployment files in ${cwd}` };
+  }
+  const valkeyUrl = env.VALKEY_URL || "redis://127.0.0.1:6379";
+  if (await probeQueue(valkeyUrl)) {
+    return { state: "reachable", detail: `queue reachable at ${valkeyUrl}` };
+  }
+  return { state: "none", detail: "no pointer, no env, no deployment files here, queue unreachable" };
+}
+
+/**
+ * Run one command ATTACHED to the operator's terminal from inside a pi TUI session, and resolve its
+ * `{ code, error }`. Three constraints shape this function, none negotiable:
+ *
+ *   1. The live `tui` handle exists ONLY inside a `ctx.ui.custom` factory -- there is no other
+ *      sanctioned way to suspend pi's render loop and input handling (`stop()`/`start()` are pi's own
+ *      $EDITOR pair; dashboard.ts:399-424 is the in-repo precedent). So the spawn runs inside a
+ *      one-line overlay whose factory brackets it.
+ *   2. Dialogs and an attached child are mutually exclusive: `ui.confirm`/`select` paint through the
+ *      TUI this very function stops. Every question is asked BEFORE runAttached; the overlay itself
+ *      renders one static line and asks nothing.
+ *   3. `stdio: "inherit"` hands stdin to the child until it closes, so the component ignores input --
+ *      while suspended there are no keys to receive, and competing for them would race the child
+ *      (worker/src/sandbox.mjs:155-171, the never-reject spawn shape reused here).
+ *
+ * Unlike openSandboxSession (index.ts), the EXIT CODE is captured and returned, never discarded: the
+ * install step's version assertion and the up step's continue/stop gate both decide on it. The
+ * `finally` restores the TUI and forces the full redraw even when the spawn itself throws.
+ */
+export async function runAttached(
+  ctx: any,
+  { title, argv0, args, cwd, env, shell, spawnFn = nodeSpawn }: any,
+): Promise<{ code: number | null; error?: Error }> {
+  if (ctx?.mode !== "tui" || typeof ctx?.ui?.custom !== "function") {
+    return { code: null, error: new Error("needs the terminal UI") };
+  }
+  const custom = ctx.ui.custom;
+  const factory = (tui: any, _theme: any, _keybindings: any, done: (value: any) => void) => {
+    void (async () => {
+      let outcome: { code: number | null; error?: Error } = { code: null };
+      tui?.stop?.();
+      try {
+        process.stdout.write(`\n${title}\n\n`);
+        outcome = await new Promise((resolve) => {
+          let child: any;
+          try {
+            child = spawnFn(argv0, args, { stdio: "inherit", cwd, env, ...(shell ? { shell: true } : {}) });
+          } catch (err: any) {
+            // A synchronously-throwing spawn (bad injected fake, exotic platform failure) must land in
+            // the same never-reject shape -- the finally below is the whole suspend-safety guarantee.
+            resolve({ code: null, error: err });
+            return;
+          }
+          child.on("error", (err: any) => resolve({ code: null, error: err }));
+          child.on("close", (code: number | null) => resolve({ code }));
+        });
+      } catch (err: any) {
+        outcome = { code: null, error: err };
+      } finally {
+        tui?.start?.();
+        tui?.requestRender?.(true);
+        done(outcome);
+      }
+    })();
+    return {
+      render: () => [title],
+      invalidate(): void {
+        // Static content; the TUI redraws from render().
+      },
+      handleInput(): void {
+        // Constraint 3: the child owns stdin for the duration; the overlay never acts on input.
+      },
+    };
+  };
+  const result = await custom.call(ctx.ui, factory, { overlay: true });
+  return result ?? { code: null, error: new Error("the overlay closed before the command finished") };
+}
+
+/**
+ * The exact npm argv for installing the pinned runtime. Pure, and NO filesystem path in argv: the
+ * install target is the spawn's `cwd`, never a `--prefix <dir>` pair. That absence is what makes
+ * `shell: true` safe on win32 (npmSpawnOptions below): argv holds only literal flags spelled out here
+ * plus one `name@version` token whose both halves are literals of this module -- no operator-supplied
+ * string can reach the command line as shell syntax (worker/src/import-pi.mjs:400-419 carries the full
+ * argument; re-introducing a path here breaks it and must be revisited together with that comment).
+ *
+ * `--ignore-scripts` is load-bearing exactly as in import-pi: without it, lifecycle scripts of the
+ * package and every transitive dependency run as the operator at install time. No `--omit=peer` /
+ * `--install-strategy=nested` here, deliberately: this is a normal application install resolved by
+ * node's own algorithm at run time, not a staged self-contained overlay.
+ */
+export function npmInstallArgs(): string[] {
+  return [
+    "install",
+    `@edgehero/pi-dispatch@${RUNTIME_VERSION}`,
+    "--omit=dev",
+    "--omit=optional",
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+    "--loglevel=error",
+  ];
+}
+
+/**
+ * The npm binary + spawn options for one platform. win32 needs BOTH `npm.cmd` and `shell: true`
+ * (CVE-2024-27980: Node refuses to spawn a `.cmd` without a shell -- worker/src/import-pi.mjs:400-419),
+ * and that is safe here ONLY because npmInstallArgs keeps every path out of argv; everywhere else it is
+ * plain `npm` with the target dir as cwd.
+ */
+export function npmSpawnOptions(platform: string, dir: string): { bin: string; options: { cwd: string; shell?: true } } {
+  return platform === "win32" ? { bin: "npm.cmd", options: { cwd: dir, shell: true } } : { bin: "npm", options: { cwd: dir } };
+}
+
+/**
+ * The repo's offerable flows: every `.pi/skills/<name>` directory whose name the worker's own
+ * SKILL_NAME_RE accepts AND that actually contains a SKILL.md. Both filters matter: a name the gate
+ * would refuse must not be offered, and a skill-less directory would enqueue a job with no
+ * instructions. `[]` on ANY error (no `.pi/skills`, unreadable, not a repo) -- an empty list simply
+ * downgrades the picker to a free-text input.
+ */
+export function listRepoSkills(cwd: string, fs: any = nodeFs): string[] {
+  try {
+    const root = join(cwd, ".pi", "skills");
+    return fs
+      .readdirSync(root)
+      .filter((name: string) => SKILL_NAME_RE.test(name) && fs.existsSync(join(root, name, "SKILL.md")));
+  } catch {
+    return [];
+  }
+}
+
+/** The installed runtime's version inside `dir`, or undefined when absent/unreadable/shapeless. */
+function readInstalledVersion(fs: any, runtimeDir: string): string | undefined {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(join(runtimeDir, "package.json"), "utf8"));
+    return typeof pkg?.version === "string" ? pkg.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** The cron-id charset the triggers validator enforces (triggers.mjs:144-151; no ":" -- it corrupts the repeat jobId). */
+const CRON_ID_RE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * The step engine. Every collaborator is injectable through `deps` so the tests drive the whole
+ * sequence offline with recording fakes; production passes only `openDashboardFn` (index.ts's own
+ * dashboard opener -- handed in rather than imported to keep the module cycle call-time-only).
+ *
+ * Steps (each declinable; a decline continues): (1) detect + intent, (2) deployment dir, (3) pinned
+ * npm install with post-install version assertion, (4) `up`, (5) deployment pointer, (6) provider-key
+ * notice, (7) worker service, (8) github credentials, (9) first cron trigger for ctx.cwd, (10)
+ * re-detect + open the panel.
+ */
+export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps: any = {}): Promise<void> {
+  const {
+    fs = nodeFs,
+    env = process.env,
+    platform = process.platform,
+    execPath = process.execPath,
+    homedirFn = homedir,
+    runAttachedFn = runAttached,
+    writePointerFn = writePointer,
+    reapplyFn = reapplyDeploymentPointer,
+    detectFn = detectDeployment,
+    openDashboardFn,
+    writeTriggersFn = writeTriggers,
+    resolvePathsFn = resolvePaths,
+    listRepoSkillsFn = listRepoSkills,
+    existsSyncFn = (p: string) => fs.existsSync(p),
+  } = deps;
+  const ui = ctx?.ui;
+
+  // Capability gate, the handleDashboardAction idiom: the wizard is dialogs end to end, so a build
+  // without the primitives degrades to one notice instead of half-running.
+  if (typeof ui?.input !== "function" || typeof ui?.select !== "function" || typeof ui?.confirm !== "function") {
+    notify?.("setup needs dialogs (newer pi) — no input/select/confirm available", "warning");
+    return;
+  }
+
+  // ── (1) detection + intent ─────────────────────────────────────────────────────────────────────
+  const det = await detectFn({ env, cwd: ctx?.cwd, fs });
+  notify?.(`pi-dispatch setup — detected: ${det.detail}`, "info");
+  const intent = await ui.select("pi-dispatch setup", ["Guided setup", "Open the panel anyway", "Cancel"]);
+  if (intent === "Open the panel anyway") {
+    if (typeof openDashboardFn === "function") await openDashboardFn(paths, ctx, notify);
+    return;
+  }
+  if (intent !== "Guided setup") return;
+
+  // ── (2) the deployment dir ─────────────────────────────────────────────────────────────────────
+  // The one step with no "skip": every later step names this dir, so blank AND cancel both take the
+  // default rather than aborting nine steps over one Esc. The mkdir itself is silent-tier (recursive,
+  // idempotent, creates an empty dir at a path the operator just typed) -- but the dir is NAMED in the
+  // very next confirm's message, so nothing lands anywhere the operator has not read on screen.
+  const defaultDir = join(homedirFn(), "pi-dispatch");
+  const dirAnswer = await ui.input("deployment directory — where the runtime and its config live", defaultDir);
+  const dir = dirAnswer === undefined || dirAnswer.trim() === "" ? defaultDir : dirAnswer.trim();
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch (err: any) {
+    notify?.(`could not create ${dir}: ${err?.message ?? err} — setup cannot continue`, "error");
+    return;
+  }
+  const runtimeDir = join(dir, "node_modules", "@edgehero", "pi-dispatch");
+  const cliPath = join(runtimeDir, "src", "cli.mjs");
+
+  // ── (3) install the pinned runtime ─────────────────────────────────────────────────────────────
+  if (readInstalledVersion(fs, runtimeDir) === RUNTIME_VERSION) {
+    // Convergence, said out loud: a re-run of the wizard must not re-download a runtime that is
+    // already the pinned version -- and must SAY it skipped, so the operator is not left wondering.
+    notify?.(`runtime ${RUNTIME_VERSION} already installed in ${dir} — skipping npm install`, "info");
+  } else {
+    const args = npmInstallArgs();
+    const { bin, options } = npmSpawnOptions(platform, dir);
+    const okInstall = await ui.confirm(
+      "Install the pi-dispatch runtime",
+      `Run in ${dir}:\n  ${bin} ${args.join(" ")}\n\n(scripts disabled; installs the pinned @edgehero/pi-dispatch@${RUNTIME_VERSION})`,
+    );
+    if (!okInstall) {
+      notify?.(`install skipped — later steps assume the runtime at ${runtimeDir}`, "info");
+    } else {
+      // A private root package.json pins npm's idea of "the project" to the deployment dir, so the
+      // install cannot walk up into (or read config from) whatever happens to be above it. IF ABSENT
+      // only -- the import-pi.mjs:294 idiom: a file the operator may have edited is never clobbered.
+      const rootPkg = join(dir, "package.json");
+      if (!fs.existsSync(rootPkg)) {
+        fs.writeFileSync(rootPkg, `${JSON.stringify({ name: "pi-dispatch-deployment", private: true }, null, 2)}\n`);
+      }
+      const res = await runAttachedFn(ctx, {
+        title: `npm install @edgehero/pi-dispatch@${RUNTIME_VERSION} — in ${dir}`,
+        argv0: bin,
+        args,
+        cwd: options.cwd,
+        shell: options.shell,
+        env,
+      });
+      // POST-INSTALL ASSERTION, and the wizard's only hard stop: assert the artifact, never npm's exit
+      // code alone (import-pi.mjs:330-341 -- npm has reported success over a wrong or absent stage).
+      // Every later step runs THIS runtime; continuing past a wrong version would `up` and service a
+      // deployment the wizard was never reviewed against.
+      const installed = readInstalledVersion(fs, runtimeDir);
+      if (installed !== RUNTIME_VERSION) {
+        const how = res.error ? `npm could not run: ${res.error.message}` : `npm exited ${res.code}`;
+        notify?.(
+          `${how}; installed version is ${installed ?? "(absent)"}, not the pinned ${RUNTIME_VERSION} — stopping setup. Fix the install, then re-run /dispatch setup.`,
+          "error",
+        );
+        return;
+      }
+      notify?.(`installed @edgehero/pi-dispatch@${RUNTIME_VERSION} into ${dir}`, "info");
+    }
+  }
+
+  // ── (4) up: image, Valkey, init, doctor — the worker's own consented pass ──────────────────────
+  // NEVER `--yes`: up's per-mutation y/N prompts ARE the host-mutation consents (docker pull, docker
+  // run). The wizard's confirm approves STARTING the pass; auto-accepting the child's gates would
+  // collapse per-action consent into one blanket yes the operator never gave.
+  const okUp = await ui.confirm(
+    "Bring the deployment up",
+    `Run in ${dir}:\n  ${execPath} ${cliPath} up\n\nup shows each docker action and asks y/N before it — nothing is auto-accepted.`,
+  );
+  if (!okUp) {
+    notify?.(`skipped — run it later: node ${cliPath} up  (in ${dir})`, "info");
+  } else {
+    const res = await runAttachedFn(ctx, {
+      title: `pi-dispatch up — in ${dir}`,
+      argv0: execPath,
+      args: [cliPath, "up"],
+      cwd: dir,
+      env,
+    });
+    if (res.error || res.code !== 0) {
+      // up's own exit code mirrors doctor's verdict, so a nonzero here usually means "something is
+      // still missing", not "everything failed" -- the operator, who just watched the output, decides.
+      const why = res.error ? `could not start (${res.error.message})` : `exited ${res.code}`;
+      const choice = await ui.select(`up ${why} — continue setup?`, ["Continue anyway", "Stop"]);
+      if (choice !== "Continue anyway") return;
+    }
+  }
+
+  // ── (5) the deployment pointer ─────────────────────────────────────────────────────────────────
+  // Only the three cwd-default files need pointing: resolvePaths defaults them to "./" (right only
+  // when pi runs FROM the deployment dir), while logsDir/settingsFile default to absolute OS-temp
+  // locations and VALKEY_URL's default already matches the container up starts. Absolute paths by
+  // pointer contract (a relative value is dropped by the normalizer).
+  const pointer = {
+    version: POINTER_VERSION,
+    deploymentDir: dir,
+    env: {
+      PI_TRIGGERS_FILE: join(dir, "triggers.json"),
+      PI_PAUSE_WINDOWS_FILE: join(dir, "pause-windows.json"),
+      PI_SUBSCRIPTIONS_FILE: join(dir, "subscriptions.json"),
+    },
+  };
+  const pPath = pointerPath(env);
+  // The JSON is shown VERBATIM: this file is the one artifact that redirects every future /dispatch,
+  // so the operator approves the exact bytes-to-be, not a summary of them.
+  const okPointer = await ui.confirm("Write the deployment pointer", `${pPath} gets:\n${JSON.stringify(pointer, null, 2)}`);
+  if (!okPointer) {
+    notify?.(`skipped — without the pointer, /dispatch finds this deployment only when pi runs from ${dir}`, "info");
+  } else {
+    const res = writePointerFn({ path: pPath, pointer, fs });
+    if (res.invalid) {
+      notify?.(`pointer rejected: ${res.invalid}`, "error");
+    } else {
+      // Re-apply immediately so THIS session's panel opens against the new deployment -- the memoized
+      // factory-time apply already ran, and reapply is its one sanctioned refresh (no restart needed).
+      reapplyFn(env, { fs });
+      notify?.(`pointer written — the panel now finds ${dir} from any directory, in this session too`, "info");
+    }
+  }
+
+  // ── (6) provider key: notice only, never-tier ──────────────────────────────────────────────────
+  // Deliberately NO dialog and NO write: a secret must never transit a wizard dialog (dialog text is
+  // not a credential channel) nor a wizard-written file. The operator edits the named file themselves,
+  // or leans on the already-logged-into-pi fallback the worker honours.
+  notify?.(
+    `provider key: set ANTHROPIC_API_KEY (or your provider's key) in ${join(dir, ".env")} — already logged into pi on this machine? leave it blank and jobs use that login. Setup never reads or writes the key itself.`,
+    "info",
+  );
+
+  // ── (7) the worker ─────────────────────────────────────────────────────────────────────────────
+  const workerChoice = await ui.select("Run the worker", [
+    "Install as an OS service (user-level)",
+    "I'll run it myself",
+    "Skip",
+  ]);
+  if (workerChoice === "Install as an OS service (user-level)") {
+    // `service install` is user-level by default on every platform (service.mjs:13); no flag needed.
+    await runAttachedFn(ctx, {
+      title: `pi-dispatch service install — in ${dir}`,
+      argv0: execPath,
+      args: [cliPath, "service", "install"],
+      cwd: dir,
+      env,
+    });
+  } else if (workerChoice === "I'll run it myself") {
+    notify?.(`run: node ${cliPath} worker  (in ${dir}; keep it running — its own terminal, tmux, …)`, "info");
+  }
+
+  // ── (8) github credentials (optional) ──────────────────────────────────────────────────────────
+  // Phrased so declining is obviously fine: local cron triggers -- the first-trigger step right below
+  // -- need none of this, and the command is named for later.
+  const okGithub = await ui.confirm(
+    "GitHub webhook triggers (optional)",
+    "Only needed for label/comment/PR triggers on GitHub repos. Local cron triggers need none of this — declining is the normal choice for a first setup. Mint GitHub App credentials now?",
+  );
+  if (okGithub) {
+    await runAttachedFn(ctx, {
+      title: `pi-dispatch setup github — in ${dir}`,
+      argv0: execPath,
+      args: [cliPath, "setup", "github"],
+      cwd: dir,
+      env,
+    });
+  } else {
+    notify?.(`later: node ${cliPath} setup github  (in ${dir})`, "info");
+  }
+
+  // ── (9) a first trigger for the repo pi is sitting in ──────────────────────────────────────────
+  // Offered only when ctx.cwd names an existing directory: the trigger's folder is the one hard
+  // precondition (the worker refuses a missing run.folder at load), so no folder, no offer.
+  if (typeof ctx?.cwd === "string" && ctx.cwd !== "" && existsSyncFn(ctx.cwd)) {
+    await offerFirstTrigger(ctx.cwd, dir, ui, notify, { fs, listRepoSkillsFn, writeTriggersFn });
+  }
+
+  // ── (10) re-detect + open the panel ────────────────────────────────────────────────────────────
+  const finalDet = await detectFn({ env, cwd: ctx?.cwd, fs });
+  notify?.(`setup finished — ${finalDet.detail}`, "info");
+  if (typeof openDashboardFn === "function") {
+    // Fresh resolvePaths on purpose: the pointer re-apply above layered the new deployment's paths
+    // into the env, so the panel must resolve NOW, not reuse the pre-wizard `paths`.
+    await openDashboardFn(resolvePathsFn(env), ctx, notify);
+  }
+}
+
+/**
+ * Step 9's body: pick a flow (the repo's own skills first, free text as the escape), then id/pattern/
+ * task with the same defaults the add-trigger dialog uses, then write ONE cron entry -- into the
+ * DEPLOYMENT dir's triggers.json, deliberately not `paths.triggersPath`: the pointer written in step 5
+ * aims the panel (and the worker's init scaffold) at the deployment dir, and a trigger written to
+ * wherever the pre-wizard env happened to point would land in a file the new deployment never reads.
+ * Any cancel or invalid answer skips the step; the wizard continues.
+ */
+async function offerFirstTrigger(
+  repoCwd: string,
+  deployDir: string,
+  ui: any,
+  notify: Notify,
+  { fs, listRepoSkillsFn, writeTriggersFn }: any,
+): Promise<void> {
+  const offer = await ui.select("First trigger", ["A cron trigger for this repo", "Skip"]);
+  if (offer !== "A cron trigger for this repo") return;
+
+  // The repo's own skills as a picker, with a typed escape for a flow that is not committed yet; an
+  // empty listing (no .pi/skills) downgrades to the input directly.
+  const skills = listRepoSkillsFn(repoCwd, fs);
+  const TYPE_ANOTHER = "type another…";
+  let flow: string | undefined;
+  if (skills.length > 0) {
+    const picked = await ui.select("flow — the .pi/skills/<name> skill the job runs", [...skills, TYPE_ANOTHER]);
+    if (picked === undefined) return;
+    flow = picked === TYPE_ANOTHER ? await ui.input("flow — the .pi/skills/<name> skill the job runs", "fix") : picked;
+  } else {
+    flow = await ui.input("flow — the .pi/skills/<name> skill the job runs", "fix");
+  }
+  if (flow === undefined || flow.trim() === "") return;
+  flow = flow.trim();
+
+  const idAnswer = await ui.input("cron id — unique name for this schedule, no ':'", "nightly");
+  if (idAnswer === undefined) return;
+  const id = idAnswer.trim() === "" ? "nightly" : idAnswer.trim();
+  // The triggers validator's own charset (triggers.mjs:144-151), checked here so a bad id fails at the
+  // dialog instead of surfacing as a rejected write three questions later.
+  if (!CRON_ID_RE.test(id)) {
+    notify?.(`invalid cron id '${id}' — letters, digits, dot, dash, underscore only (no ':') — skipping the trigger`, "error");
+    return;
+  }
+  const patternAnswer = await ui.input("schedule — cron pattern, 5 or 6 fields (min hour day month weekday)", "0 3 * * *");
+  if (patternAnswer === undefined) return;
+  const pattern = patternAnswer.trim() === "" ? "0 3 * * *" : patternAnswer.trim();
+  const taskAnswer = await ui.input("task — the prompt text handed to the agent for this run", "run the flow");
+  if (taskAnswer === undefined) return;
+  const task = taskAnswer.trim() === "" ? "run the flow" : taskAnswer.trim();
+
+  // The same disclosure `pi-dispatch run` makes (cli.mjs:112): the job edits the operator's checkout,
+  // not a clone, and there is no undo -- said BEFORE the entry exists, while cancelling still helps.
+  notify?.(`a local cron job edits ${repoCwd} IN PLACE with no undo — commit or stash before it first fires`, "warning");
+  // Print-only, NEVER written: the ai-trigger gate lives in the repo's own reviewed history, and a
+  // wizard that edited the serviced repo would grant itself the very opt-in the gate exists to demand.
+  notify?.(
+    `to let AI-invoked runs use this flow, add \`ai-trigger: allow\` to ${join(".pi", "skills", flow, "SKILL.md")} frontmatter — takes effect once committed. Setup never writes into the repo.`,
+    "info",
+  );
+
+  const entry = buildTriggerEntry("cron", { id, pattern, folder: repoCwd, flow, task });
+  const res = writeTriggersFn({ triggersPath: join(deployDir, "triggers.json"), mutate: (list: any[]) => [...list, entry] });
+  notify?.(
+    res.ok !== false && !res.invalid
+      ? `trigger added — ${id} (${pattern}) runs ${flow} in ${repoCwd}`
+      : `trigger rejected: ${res.invalid}`,
+    res.invalid ? "error" : "info",
+  );
+}
+
+/**
+ * The one-time startup nudge: on a fresh, unconfigured host, tell the operator `/dispatch setup`
+ * exists -- once EVER, then a marker file keeps it quiet for good.
+ *
+ * Sync-only checks by design: this handler runs on EVERY pi startup, so it may read a few local files
+ * but must never probe the queue -- a network round-trip (even a fast-failing one) taxing every session
+ * start to detect a state the pointer/env/cwd checks already cover is the wrong trade. The probe-backed
+ * "reachable" state stays a bare-`/dispatch` concern, where the operator explicitly asked.
+ *
+ * Notify-only: no dialog is ever raised from a session_start handler (an unprompted modal at startup
+ * is exactly the interruption a nudge must not be). The whole body is try/caught -- a nudge that could
+ * break a session start would cost more than it ever says.
+ */
+export function registerNudge(pi: any, deps: any = {}): void {
+  const { fs = nodeFs, env = process.env, homedirFn = homedir } = deps;
+  pi.on("session_start", (event: any, ctx: any) => {
+    try {
+      // Only a real interactive startup: reload/resume/fork repeat within a configured workflow, and
+      // without a UI there is nobody to nudge (and no notify to carry it).
+      if (event?.reason !== "startup" || !ctx?.hasUI) return;
+      // A PRESENT pointer -- valid or broken -- means the operator has been here; /dispatch itself
+      // surfaces broken-pointer notices, so the nudge stays quiet on anything but true absence.
+      if (!(readPointer({ path: pointerPath(env), fs }) as any).absent) return;
+      // The full sextet here (VALKEY_URL included), unlike detection's env branch: with no probe
+      // allowed, an exported queue URL is the closest sync evidence of intent, and the nudge errs
+      // toward silence.
+      if (POINTER_ENV_ALLOWLIST.some((key) => envIsSet(env, key))) return;
+      const cwd = typeof ctx?.cwd === "string" && ctx.cwd !== "" ? ctx.cwd : process.cwd();
+      if (hasCwdScaffold(cwd, fs)) return;
+      const agentDir = env.PI_CODING_AGENT_DIR || join(homedirFn(), ".pi", "agent");
+      const marker = join(agentDir, NUDGE_MARKER_BASENAME);
+      if (fs.existsSync(marker)) return;
+      ctx?.ui?.notify?.("pi-dispatch: no deployment configured — /dispatch setup gets you started", "info");
+      // Marker AFTER the notify: if the write fails (missing agent dir, read-only fs) the catch below
+      // swallows it and the nudge may repeat -- twice-said beats never-said-and-crashed.
+      fs.writeFileSync(marker, `${new Date().toISOString()}\n`);
+    } catch {
+      // Deliberately swallowed: a session start must never fail over a nudge.
+    }
+  });
+}

--- a/admin/test/deployment-pointer.test.mjs
+++ b/admin/test/deployment-pointer.test.mjs
@@ -1,0 +1,276 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  POINTER_VERSION,
+  POINTER_ENV_ALLOWLIST,
+  pointerPath,
+  readPointer,
+  applyDeploymentPointer,
+  reapplyDeploymentPointer,
+  takePointerNotice,
+  writePointer,
+  resetForTests,
+} from "../src/deployment-pointer.mjs";
+
+/**
+ * In-memory fs for the pointer tests: readFileSync/writeFileSync/renameSync over a plain object, with a
+ * recorded call sequence so the writePointer test can assert the atomic tmp-then-rename protocol exactly.
+ */
+function fakeFs(initial = {}) {
+  const files = { ...initial };
+  const calls = [];
+  return {
+    files,
+    calls,
+    readFileSync(p) {
+      if (!(p in files)) throw Object.assign(new Error(`ENOENT: ${p}`), { code: "ENOENT" });
+      return files[p];
+    },
+    writeFileSync(p, data) {
+      calls.push(["writeFileSync", p]);
+      files[p] = String(data);
+    },
+    renameSync(a, b) {
+      calls.push(["renameSync", a, b]);
+      files[b] = files[a];
+      delete files[a];
+    },
+  };
+}
+
+// Every fake env pins the pointer location so the tests never look at the real ~/.pi/agent.
+const P = "/pointer.json";
+const DIR = "/home/op/pi-dispatch";
+
+function envWith(extra = {}) {
+  return { PI_DISPATCH_DEPLOYMENT_FILE: P, ...extra };
+}
+
+function pointerJson(env, { version = 1, deploymentDir = DIR } = {}) {
+  return JSON.stringify({ version, deploymentDir, env });
+}
+
+test("applyDeploymentPointer layers allowed absolute entries into an unset env", () => {
+  resetForTests();
+  const fs = fakeFs({
+    [P]: pointerJson({
+      VALKEY_URL: "redis://10.0.0.5:6379",
+      PI_LOGS_DIR: join(DIR, "logs"),
+      PI_TRIGGERS_FILE: join(DIR, "triggers.json"),
+    }),
+  });
+  const env = envWith();
+  const res = applyDeploymentPointer(env, { fs });
+  assert.deepEqual(res.applied.sort(), ["PI_LOGS_DIR", "PI_TRIGGERS_FILE", "VALKEY_URL"]);
+  assert.equal(env.VALKEY_URL, "redis://10.0.0.5:6379");
+  assert.equal(env.PI_LOGS_DIR, join(DIR, "logs"));
+  assert.equal(env.PI_TRIGGERS_FILE, join(DIR, "triggers.json"));
+  assert.equal(takePointerNotice(), undefined, "a valid pointer surfaces nothing");
+});
+
+test("an operator-set var is never overwritten — not even an empty export", () => {
+  resetForTests();
+  const fs = fakeFs({
+    [P]: pointerJson({
+      PI_LOGS_DIR: "/deploy/logs",
+      PI_TRIGGERS_FILE: "/deploy/triggers.json",
+      VALKEY_URL: "redis://deploy:6379",
+    }),
+  });
+  // An empty string IS operator intent (resolvePaths' `||` keys treat it as fall-back-to-default, and the
+  // pointer must not second-guess that choice).
+  const env = envWith({ PI_LOGS_DIR: "/operator/logs", PI_TRIGGERS_FILE: "" });
+  applyDeploymentPointer(env, { fs });
+  assert.equal(env.PI_LOGS_DIR, "/operator/logs", "the operator's export wins");
+  assert.equal(env.PI_TRIGGERS_FILE, "", "an empty operator export also wins");
+  assert.equal(env.VALKEY_URL, "redis://deploy:6379", "unset keys still layer in");
+});
+
+test("a second applyDeploymentPointer is a no-op (memoized), even after the file changes", () => {
+  resetForTests();
+  const fs = fakeFs({ [P]: pointerJson({ PI_LOGS_DIR: "/a/logs" }) });
+  const env = envWith();
+  applyDeploymentPointer(env, { fs });
+  assert.equal(env.PI_LOGS_DIR, "/a/logs");
+  fs.files[P] = pointerJson({ PI_LOGS_DIR: "/b/logs", VALKEY_URL: "redis://b:6379" });
+  const second = applyDeploymentPointer(env, { fs });
+  assert.deepEqual(second, { applied: [] }, "the memo makes the second call a no-op");
+  assert.equal(env.PI_LOGS_DIR, "/a/logs", "the changed file is not re-read");
+  assert.equal(env.VALKEY_URL, undefined);
+});
+
+test("reapplyDeploymentPointer updates only module-owned keys; an operator var planted between calls survives", () => {
+  resetForTests();
+  const fs = fakeFs({ [P]: pointerJson({ PI_LOGS_DIR: "/a/logs", VALKEY_URL: "redis://a:6379" }) });
+  const env = envWith();
+  applyDeploymentPointer(env, { fs });
+  // The operator exports a var AFTER the first apply; the wizard then rewrites the pointer and reapplies.
+  env.PI_SETTINGS_FILE = "/operator/settings.json";
+  fs.files[P] = pointerJson({
+    PI_LOGS_DIR: "/b/logs",
+    PI_SETTINGS_FILE: "/b/settings.json",
+    PI_TRIGGERS_FILE: "/b/triggers.json",
+  });
+  reapplyDeploymentPointer(env, { fs });
+  assert.equal(env.PI_LOGS_DIR, "/b/logs", "a module-owned key follows the rewritten pointer");
+  assert.equal(env.PI_SETTINGS_FILE, "/operator/settings.json", "the operator's later export is untouchable");
+  assert.equal(env.PI_TRIGGERS_FILE, "/b/triggers.json", "a still-unset key layers in on reapply");
+  assert.equal(env.VALKEY_URL, "redis://a:6379", "an owned key the new pointer dropped keeps its last value");
+  // Reapply IS the refresh: a later plain apply must stay memoized.
+  fs.files[P] = pointerJson({ PI_LOGS_DIR: "/c/logs" });
+  assert.deepEqual(applyDeploymentPointer(env, { fs }), { applied: [] });
+  assert.equal(env.PI_LOGS_DIR, "/b/logs");
+});
+
+test("a newer pointer version is ignored whole, with one notice naming both versions", () => {
+  resetForTests();
+  const fs = fakeFs({ [P]: pointerJson({ PI_LOGS_DIR: "/deploy/logs" }, { version: 2 }) });
+  const read = readPointer({ path: P, fs });
+  assert.match(read.ignored, /version 2/, "the reason names the file's version");
+  assert.match(read.ignored, new RegExp(`version ${POINTER_VERSION}`), "and the supported version");
+  const env = envWith();
+  applyDeploymentPointer(env, { fs });
+  assert.equal(env.PI_LOGS_DIR, undefined, "an ignored pointer applies nothing");
+  const note = takePointerNotice();
+  assert.match(note, /2/);
+  assert.match(note, /1/);
+  assert.equal(takePointerNotice(), undefined, "the notice is drained on first take");
+});
+
+test("readPointer degrades on every malformed shape and reports absence distinctly", () => {
+  resetForTests();
+  const cases = [
+    ["{nope", /unparseable JSON/],
+    ["[1,2]", /not a JSON object/],
+    ['"a string"', /not a JSON object/],
+    [JSON.stringify({ deploymentDir: DIR, env: {} }), /version/],
+    [JSON.stringify({ version: 0, deploymentDir: DIR, env: {} }), /version/],
+    [JSON.stringify({ version: "1", deploymentDir: DIR, env: {} }), /version/],
+    [JSON.stringify({ version: 1, env: {} }), /deploymentDir/],
+    [JSON.stringify({ version: 1, deploymentDir: "relative/dir", env: {} }), /deploymentDir/],
+    [JSON.stringify({ version: 1, deploymentDir: DIR, env: "nope" }), /env/],
+    [JSON.stringify({ version: 1, deploymentDir: DIR, env: ["nope"] }), /env/],
+  ];
+  for (const [text, reason] of cases) {
+    const res = readPointer({ path: P, fs: fakeFs({ [P]: text }) });
+    assert.match(res.ignored, reason, `ignored: ${text}`);
+  }
+  assert.deepEqual(readPointer({ path: P, fs: fakeFs() }), { absent: true }, "no file is the normal state, not an error");
+});
+
+test("unknown keys, PI_DISPATCH_RUN_ROOTS, credential-shaped keys, and relative path values are dropped", () => {
+  resetForTests();
+  const fs = fakeFs({
+    [P]: pointerJson({
+      PI_TRIGGERS_FILE: join(DIR, "triggers.json"), // the one survivor
+      PI_DISPATCH_RUN_ROOTS: "/a:/b", // a capability grant, never honored from a pointer
+      GITHUB_TOKEN: "ghs_secret", // credential-shaped: paths only, never credentials
+      SOME_FUTURE_KEY: "/abs/x",
+      PI_LOGS_DIR: "relative/logs", // relative path value: would resolve against the wrong cwd
+      VALKEY_URL: 6379, // non-string value
+      PI_SETTINGS_FILE: "", // empty value can only mask a working default
+    }),
+  });
+  const read = readPointer({ path: P, fs });
+  assert.deepEqual(read.pointer.env, { PI_TRIGGERS_FILE: join(DIR, "triggers.json") });
+  const env = envWith();
+  applyDeploymentPointer(env, { fs });
+  assert.equal(env.PI_TRIGGERS_FILE, join(DIR, "triggers.json"));
+  assert.equal(env.PI_DISPATCH_RUN_ROOTS, undefined, "the AI-run allowlist cannot widen via a pointer");
+  assert.equal(env.GITHUB_TOKEN, undefined);
+  assert.equal(env.SOME_FUTURE_KEY, undefined);
+  assert.equal(env.PI_LOGS_DIR, undefined);
+  assert.equal(env.VALKEY_URL, undefined);
+  assert.equal(env.PI_SETTINGS_FILE, undefined);
+});
+
+test("writePointer rejects a pointer the read side would ignore, without writing", () => {
+  resetForTests();
+  const fs = fakeFs();
+  const bad = [
+    { version: 2, deploymentDir: DIR, env: {} }, // newer than this build writes
+    { version: 1, deploymentDir: "relative/dir", env: {} },
+    { version: 1, env: {} },
+    "not an object",
+  ];
+  for (const pointer of bad) {
+    const res = writePointer({ path: P, pointer, fs });
+    assert.ok(res.invalid, `rejected: ${JSON.stringify(pointer)}`);
+  }
+  assert.deepEqual(fs.calls, [], "a rejected pointer is never written");
+  assert.deepEqual(fs.files, {});
+});
+
+test("writePointer writes the NORMALIZED pointer atomically: tmp then rename, 2-space JSON, trailing newline", () => {
+  resetForTests();
+  const fs = fakeFs();
+  const res = writePointer({
+    path: P,
+    pointer: {
+      version: 1,
+      deploymentDir: DIR,
+      env: {
+        PI_LOGS_DIR: join(DIR, "logs"),
+        PI_DISPATCH_RUN_ROOTS: "/a", // dropped before the bytes exist
+        PI_TRIGGERS_FILE: "relative/triggers.json", // relative: dropped
+      },
+      note: "unknown top-level fields drop too",
+    },
+    fs,
+  });
+  assert.deepEqual(res, { ok: true });
+  assert.deepEqual(fs.calls, [
+    ["writeFileSync", `${P}.tmp`],
+    ["renameSync", `${P}.tmp`, P],
+  ], "the write is tmp+rename, in that order — atomic");
+  assert.equal(`${P}.tmp` in fs.files, false, "the tmp file is renamed away");
+  const text = fs.files[P];
+  const expected = { version: 1, deploymentDir: DIR, env: { PI_LOGS_DIR: join(DIR, "logs") } };
+  assert.equal(text, `${JSON.stringify(expected, null, 2)}\n`, "2-space JSON with a trailing newline, hand-editable");
+  assert.deepEqual(readPointer({ path: P, fs }), { pointer: expected }, "the write round-trips through the read side");
+});
+
+test("pointerPath: agent-dir default, PI_CODING_AGENT_DIR override, PI_DISPATCH_DEPLOYMENT_FILE override, || fallback on empty", () => {
+  assert.equal(pointerPath({}), join(homedir(), ".pi", "agent", "pi-dispatch-deployment.json"));
+  assert.equal(
+    pointerPath({ PI_CODING_AGENT_DIR: "/custom/agent" }),
+    join("/custom/agent", "pi-dispatch-deployment.json"),
+  );
+  assert.equal(pointerPath({ PI_DISPATCH_DEPLOYMENT_FILE: "/elsewhere/p.json" }), "/elsewhere/p.json");
+  // `||` semantics on both reads: an empty override falls back rather than producing "" or "/pi-dispatch...".
+  assert.equal(pointerPath({ PI_DISPATCH_DEPLOYMENT_FILE: "" }), join(homedir(), ".pi", "agent", "pi-dispatch-deployment.json"));
+  assert.equal(
+    pointerPath({ PI_CODING_AGENT_DIR: "", PI_DISPATCH_DEPLOYMENT_FILE: "" }),
+    join(homedir(), ".pi", "agent", "pi-dispatch-deployment.json"),
+  );
+});
+
+test("resetForTests clears the memo, the notice, and the owned-key ledger", () => {
+  resetForTests();
+  const fs = fakeFs({ [P]: pointerJson({ PI_LOGS_DIR: "/a/logs" }, { version: 2 }) });
+  applyDeploymentPointer(envWith(), { fs });
+  resetForTests();
+  assert.equal(takePointerNotice(), undefined, "the retained notice does not leak across a reset");
+  // The memo is cleared: a fresh apply re-reads the (now valid, changed) file into a fresh env.
+  fs.files[P] = pointerJson({ PI_LOGS_DIR: "/b/logs" });
+  const env = envWith();
+  const res = applyDeploymentPointer(env, { fs });
+  assert.deepEqual(res.applied, ["PI_LOGS_DIR"]);
+  assert.equal(env.PI_LOGS_DIR, "/b/logs");
+});
+
+test("the allowlist is exactly the six resolvePaths path/URL keys, and the version constant is 1", () => {
+  // A guard for the contract itself: adding a key here must be a reviewed decision (the docblock's
+  // "paths only, never credentials, never capability grants"), so the exact list is pinned.
+  assert.deepEqual([...POINTER_ENV_ALLOWLIST].sort(), [
+    "PI_LOGS_DIR",
+    "PI_PAUSE_WINDOWS_FILE",
+    "PI_SETTINGS_FILE",
+    "PI_SUBSCRIPTIONS_FILE",
+    "PI_TRIGGERS_FILE",
+    "VALKEY_URL",
+  ]);
+  assert.equal(POINTER_VERSION, 1);
+});

--- a/admin/test/pinned-extension-api.test.mjs
+++ b/admin/test/pinned-extension-api.test.mjs
@@ -41,7 +41,9 @@ function extractInterface(src, name) {
 test("(a) the pinned extension types still declare every member the admin depends on", () => {
   // registerCommand/registerTool/sendMessage are pi.* members; getArgumentCompletions, custom, notify are
   // the command/ui surfaces the handler, logs viewer and dashboard reach through ctx. executionMode is the
-  // ToolDefinition field the pause/resume tools set to "sequential".
+  // ToolDefinition field the pause/resume tools set to "sequential". confirm/select/input are the dialog
+  // primitives the CRUD driver and the setup wizard run on, and session_start is the event the wizard's
+  // one-time nudge registers for -- a pi upgrade moving any of them must fail here, not on an operator.
   const needles = [
     "registerCommand(name",
     "registerTool<TParams",
@@ -49,6 +51,10 @@ test("(a) the pinned extension types still declare every member the admin depend
     "getArgumentCompletions",
     "custom<T>(",
     "notify(message",
+    "confirm(title",
+    "select(title",
+    "input(title",
+    "session_start",
     "executionMode",
   ];
   for (const needle of needles) {

--- a/admin/test/setup-wizard.test.mjs
+++ b/admin/test/setup-wizard.test.mjs
@@ -1,0 +1,733 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import * as realFs from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The `/dispatch setup` wizard (setup-wizard.ts): the detection tree, the pinned npm shapes, the
+ * suspend/spawn bracket, the step engine's consent seams, the first-trigger flow, and the one-time
+ * startup nudge. Everything runs offline: detection and the wizard take injected env/fs/probe/spawn
+ * seams, and the real-fs cases use per-test temp dirs.
+ */
+
+// Hermeticity, BEFORE the module graph loads: pointerPath() and the nudge marker derive from
+// PI_CODING_AGENT_DIR, and no test may ever read (or write!) the real ~/.pi/agent.
+process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), "admin-setup-agent-"));
+
+const piRequire = createRequire(import.meta.resolve("@earendil-works/pi-coding-agent"));
+const { createJiti } = piRequire("jiti");
+const jiti = createJiti(import.meta.url);
+const mod = await jiti.import(fileURLToPath(new URL("../src/setup-wizard.ts", import.meta.url)));
+
+/** A probe that fails the test if detection consults the network when it must not. */
+const mustNotProbe = async () => {
+  throw new Error("detection consulted the queue probe on a branch that must short-circuit before it");
+};
+
+/** An empty temp dir (no scaffold files), for cwd arguments. */
+const emptyDir = () => mkdtempSync(join(tmpdir(), "admin-setup-empty-"));
+
+/** A canned-answer, recording ctx.ui in the crud.test.mjs shape, plus (title/message) capture. */
+function wizardUi({ select = [], input = [], confirm = [] } = {}) {
+  const notes = [];
+  const seen = { select: [], input: [], confirm: [] };
+  const sel = [...select];
+  const inp = [...input];
+  const con = [...confirm];
+  const ui = {
+    async select(title, options) {
+      seen.select.push({ title, options });
+      return sel.shift();
+    },
+    async input(title, placeholder) {
+      seen.input.push({ title, placeholder });
+      return inp.shift();
+    },
+    async confirm(title, message) {
+      seen.confirm.push({ title, message });
+      return con.shift();
+    },
+    notify: (m, t) => notes.push({ m, t }),
+  };
+  return { ui, notes, seen };
+}
+
+/** Common recording deps for the step engine; every host-touching seam is a fake that records. */
+function wizardDeps(overrides = {}) {
+  const attached = [];
+  const pointerWrites = [];
+  const order = [];
+  const dashboards = [];
+  const deps = {
+    env: { PI_DISPATCH_DEPLOYMENT_FILE: join(mkdtempSync(join(tmpdir(), "admin-setup-ptr-")), "pointer.json") },
+    platform: "linux",
+    execPath: "/usr/bin/node-under-test",
+    homedirFn: () => mkdtempSync(join(tmpdir(), "admin-setup-home-")),
+    detectFn: async () => ({ state: "none", detail: "canned detection" }),
+    runAttachedFn: async (_ctx, opts) => {
+      attached.push(opts);
+      return { code: 0 };
+    },
+    writePointerFn: (args) => {
+      pointerWrites.push(args);
+      order.push("write");
+      return { ok: true };
+    },
+    reapplyFn: () => {
+      order.push("reapply");
+      return { applied: [] };
+    },
+    openDashboardFn: async (paths, _ctx, _notify) => {
+      dashboards.push(paths);
+    },
+    resolvePathsFn: () => ({ canned: "resolved" }),
+    ...overrides,
+  };
+  return { deps, attached, pointerWrites, order, dashboards };
+}
+
+const tuiCtx = (ui, cwd) => ({ mode: "tui", hasUI: true, ui, cwd });
+
+/** Plant an installed runtime of `version` inside a deployment dir (what the npm step would produce). */
+function plantRuntime(dir, version) {
+  const runtimeDir = join(dir, "node_modules", "@edgehero", "pi-dispatch");
+  mkdirSync(runtimeDir, { recursive: true });
+  writeFileSync(join(runtimeDir, "package.json"), JSON.stringify({ name: "@edgehero/pi-dispatch", version }));
+  return runtimeDir;
+}
+
+const cliPathOf = (dir) => join(dir, "node_modules", "@edgehero", "pi-dispatch", "src", "cli.mjs");
+
+// ── the detection tree: one test per branch, in trust order ──────────────────────────────────────
+
+test("detect: a valid pointer file wins, and the probe is never consulted", async () => {
+  const pfile = join(mkdtempSync(join(tmpdir(), "admin-det-")), "pointer.json");
+  writeFileSync(pfile, JSON.stringify({ version: 1, deploymentDir: "/srv/deploy", env: {} }));
+  const det = await mod.detectDeployment({
+    env: { PI_DISPATCH_DEPLOYMENT_FILE: pfile },
+    cwd: emptyDir(),
+    probeQueue: mustNotProbe,
+  });
+  assert.equal(det.state, "pointer");
+  assert.match(det.detail, /\/srv\/deploy/, "the detail names the deployment dir");
+});
+
+test("detect: a stale/invalid pointer file falls through to the later branches", async () => {
+  const pfile = join(mkdtempSync(join(tmpdir(), "admin-det-")), "pointer.json");
+  // A future-version pointer is readPointer's { ignored } -- detection must degrade exactly like
+  // /dispatch itself does, not stop at a file it cannot honor.
+  writeFileSync(pfile, JSON.stringify({ version: 99, deploymentDir: "/srv/deploy", env: {} }));
+  const det = await mod.detectDeployment({
+    env: { PI_DISPATCH_DEPLOYMENT_FILE: pfile, PI_TRIGGERS_FILE: "/x/triggers.json" },
+    cwd: emptyDir(),
+    probeQueue: mustNotProbe,
+  });
+  assert.equal(det.state, "env", "the broken pointer is skipped, the env branch answers");
+});
+
+test("detect: an exported path variable means 'env', named in the detail", async () => {
+  const det = await mod.detectDeployment({
+    env: { PI_DISPATCH_DEPLOYMENT_FILE: join(emptyDir(), "absent.json"), PI_TRIGGERS_FILE: "/x/triggers.json" },
+    cwd: emptyDir(),
+    probeQueue: mustNotProbe,
+  });
+  assert.equal(det.state, "env");
+  assert.match(det.detail, /PI_TRIGGERS_FILE/);
+});
+
+test("detect: VALKEY_URL alone is probed, never trusted as 'env'", async () => {
+  // An exported queue URL is a claim about the network, so detection verifies it (branch 4) instead of
+  // short-circuiting -- a dead URL must yield the setup offer, and the wiring tests pin the probe to a
+  // dead port through exactly this behaviour.
+  let probedUrl;
+  const det = await mod.detectDeployment({
+    env: { PI_DISPATCH_DEPLOYMENT_FILE: join(emptyDir(), "absent.json"), VALKEY_URL: "redis://127.0.0.1:1" },
+    cwd: emptyDir(),
+    probeQueue: async (url) => {
+      probedUrl = url;
+      return false;
+    },
+  });
+  assert.equal(det.state, "none");
+  assert.equal(probedUrl, "redis://127.0.0.1:1", "the exported URL fed the probe");
+});
+
+test("detect: the cwd scaffold quadruple means 'cwd' (pi-packages.json deliberately not required)", async () => {
+  const cwd = emptyDir();
+  // Exactly init's original signature -- and NO pi-packages.json, which older deployments predate.
+  for (const f of [".env", "triggers.json", "pause-windows.json", "subscriptions.json"]) writeFileSync(join(cwd, f), "");
+  const det = await mod.detectDeployment({
+    env: { PI_DISPATCH_DEPLOYMENT_FILE: join(emptyDir(), "absent.json") },
+    cwd,
+    probeQueue: mustNotProbe,
+  });
+  assert.equal(det.state, "cwd");
+  assert.match(det.detail, new RegExp(cwd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("detect: a partial scaffold is not 'cwd' — it falls through to the probe", async () => {
+  const cwd = emptyDir();
+  for (const f of [".env", "triggers.json", "pause-windows.json"]) writeFileSync(join(cwd, f), "");
+  const det = await mod.detectDeployment({
+    env: { PI_DISPATCH_DEPLOYMENT_FILE: join(emptyDir(), "absent.json") },
+    cwd,
+    probeQueue: async () => false,
+  });
+  assert.equal(det.state, "none");
+});
+
+test("detect: a reachable queue with nothing else configured is 'reachable'", async () => {
+  const det = await mod.detectDeployment({
+    env: { PI_DISPATCH_DEPLOYMENT_FILE: join(emptyDir(), "absent.json") },
+    cwd: emptyDir(),
+    probeQueue: async () => true,
+  });
+  assert.equal(det.state, "reachable");
+  assert.match(det.detail, /redis:\/\/127\.0\.0\.1:6379/, "the default URL was the one probed");
+});
+
+test("detect: never stats logsDir/settingsFile — every fs touch is the pointer or the scaffold", async () => {
+  // logsDir and settingsFile default lazily into OS temp locations, so their absence proves nothing;
+  // a recording fake fs pins that detection never grows a stat of either. Whitelist assertion: every
+  // recorded path must be the pointer file or one of the four scaffold files -- nothing else, ever.
+  const reads = [];
+  const enoent = () => Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  const fakeFs = {
+    readFileSync: (p) => {
+      reads.push(String(p));
+      throw enoent();
+    },
+    existsSync: (p) => {
+      reads.push(String(p));
+      return false;
+    },
+    statSync: (p) => {
+      reads.push(String(p));
+      throw enoent();
+    },
+    readdirSync: (p) => {
+      reads.push(String(p));
+      return [];
+    },
+  };
+  const cwd = "/detect-cwd";
+  const det = await mod.detectDeployment({
+    env: { PI_DISPATCH_DEPLOYMENT_FILE: "/agent/pointer.json", PI_LOGS_DIR: "", PI_SETTINGS_FILE: "" },
+    cwd,
+    fs: fakeFs,
+    probeQueue: async () => false,
+  });
+  assert.equal(det.state, "none");
+  const allowed = new Set([
+    "/agent/pointer.json",
+    join(cwd, ".env"),
+    join(cwd, "triggers.json"),
+    join(cwd, "pause-windows.json"),
+    join(cwd, "subscriptions.json"),
+  ]);
+  assert.ok(reads.length > 0, "the fake fs was actually consulted");
+  for (const p of reads) assert.ok(allowed.has(p), `unexpected filesystem read: ${p}`);
+  assert.ok(!reads.some((p) => /logs|settings/i.test(p)), "no logsDir/settingsFile path was ever touched");
+});
+
+// ── the npm shapes: pure, exact, path-free ───────────────────────────────────────────────────────
+
+test("npmInstallArgs: the exact pinned, script-less argv with no filesystem path token", () => {
+  const args = mod.npmInstallArgs();
+  assert.deepEqual(args, [
+    "install",
+    `@edgehero/pi-dispatch@${mod.RUNTIME_VERSION}`,
+    "--omit=dev",
+    "--omit=optional",
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+    "--loglevel=error",
+  ]);
+  // The win32 shell:true safety argument (import-pi.mjs:400-419) rests on argv holding NO filesystem
+  // path: no absolute/relative path token, no backslash, no --prefix pair -- the install target is cwd.
+  for (const a of args) {
+    assert.ok(!a.startsWith("/") && !a.startsWith(".") && !a.startsWith("\\"), `no path token in argv: ${a}`);
+    assert.ok(!a.includes("\\"), `no backslash in argv: ${a}`);
+  }
+  assert.ok(!args.some((a) => a.includes("--prefix")), "the install target is the spawn cwd, never a --prefix path");
+});
+
+test("npmSpawnOptions: npm.cmd + shell on win32, plain npm elsewhere, cwd is the deployment dir", () => {
+  assert.deepEqual(mod.npmSpawnOptions("win32", "C:\\deploy"), { bin: "npm.cmd", options: { cwd: "C:\\deploy", shell: true } });
+  assert.deepEqual(mod.npmSpawnOptions("linux", "/deploy"), { bin: "npm", options: { cwd: "/deploy" } });
+  assert.deepEqual(mod.npmSpawnOptions("darwin", "/deploy"), { bin: "npm", options: { cwd: "/deploy" } });
+});
+
+// ── RUNTIME_VERSION anti-drift ───────────────────────────────────────────────────────────────────
+
+test("RUNTIME_VERSION matches the in-repo worker/package.json version (release bumps stay atomic)", () => {
+  const workerPkg = JSON.parse(readFileSync(fileURLToPath(new URL("../../worker/package.json", import.meta.url)), "utf8"));
+  assert.equal(mod.RUNTIME_VERSION, workerPkg.version);
+});
+
+// ── runAttached: the suspend/spawn/restore bracket ───────────────────────────────────────────────
+
+/** A ctx whose ui.custom invokes the factory with a recording fake tui and resolves on done(). */
+function attachedCtx(order) {
+  const tui = {
+    stop: () => order.push("stop"),
+    start: () => order.push("start"),
+    requestRender: (full) => order.push(`render:${full}`),
+  };
+  const ui = {
+    custom(factory, opts) {
+      assert.equal(opts?.overlay, true, "runAttached runs as an overlay");
+      return new Promise((resolve) => {
+        const component = factory(tui, {}, {}, resolve);
+        assert.equal(typeof component.render, "function", "the factory returns a component");
+        component.handleInput("x"); // must be inert: the child owns stdin
+      });
+    },
+  };
+  return { mode: "tui", ui };
+}
+
+test("runAttached: stop → spawn → start + requestRender(true), and the exit code is captured", async () => {
+  const order = [];
+  const { EventEmitter } = await import("node:events");
+  const spawnFn = (argv0, args, options) => {
+    order.push(`spawn:${argv0}`);
+    assert.equal(options.stdio, "inherit", "the child owns the terminal");
+    assert.equal(options.cwd, "/deploy");
+    const child = new EventEmitter();
+    setImmediate(() => child.emit("close", 7));
+    return child;
+  };
+  const res = await mod.runAttached(attachedCtx(order), { title: "t", argv0: "x", args: [], cwd: "/deploy", spawnFn });
+  assert.equal(res.code, 7, "the exit code is captured, never discarded (unlike the sandbox opener)");
+  assert.deepEqual(order, ["stop", "spawn:x", "start", "render:true"]);
+});
+
+test("runAttached: a spawn 'error' event resolves { code: null, error } and still restores the tui", async () => {
+  const order = [];
+  const { EventEmitter } = await import("node:events");
+  const spawnFn = () => {
+    order.push("spawn");
+    const child = new EventEmitter();
+    setImmediate(() => child.emit("error", new Error("ENOENT-ish")));
+    return child;
+  };
+  const res = await mod.runAttached(attachedCtx(order), { title: "t", argv0: "x", args: [], spawnFn });
+  assert.equal(res.code, null);
+  assert.match(res.error.message, /ENOENT-ish/);
+  assert.deepEqual(order, ["stop", "spawn", "start", "render:true"]);
+});
+
+test("runAttached: a synchronously-throwing spawn still runs the finally bracket", async () => {
+  const order = [];
+  const spawnFn = () => {
+    order.push("spawn");
+    throw new Error("boom at spawn time");
+  };
+  const res = await mod.runAttached(attachedCtx(order), { title: "t", argv0: "x", args: [], spawnFn });
+  assert.equal(res.code, null);
+  assert.match(res.error.message, /boom at spawn time/);
+  assert.deepEqual(order, ["stop", "spawn", "start", "render:true"], "start + full redraw even on a throw");
+});
+
+test("runAttached: refuses without a TUI (mode/custom), spawning nothing", async () => {
+  const spawnFn = () => {
+    throw new Error("must not spawn");
+  };
+  for (const ctx of [{ mode: "print", ui: { custom: () => {} } }, { mode: "tui", ui: {} }, undefined]) {
+    const res = await mod.runAttached(ctx, { title: "t", argv0: "x", args: [], spawnFn });
+    assert.equal(res.code, null);
+    assert.match(res.error.message, /terminal UI/);
+  }
+});
+
+// ── the step engine ──────────────────────────────────────────────────────────────────────────────
+
+test("wizard: without the dialog primitives it degrades to one notice and touches nothing", async () => {
+  const notes = [];
+  const { deps, attached } = wizardDeps({
+    detectFn: async () => {
+      throw new Error("must not even detect");
+    },
+  });
+  await mod.runSetupWizard({}, { mode: "tui", ui: {} }, (m, t) => notes.push({ m, t }), deps);
+  assert.equal(notes.length, 1);
+  assert.match(notes[0].m, /dialogs|newer pi/);
+  assert.equal(attached.length, 0);
+});
+
+test("wizard: 'Open the panel anyway' short-circuits to the dashboard with the original paths", async () => {
+  const { ui, seen } = wizardUi({ select: ["Open the panel anyway"] });
+  const paths = { triggersPath: "/decoy/triggers.json" };
+  const opened = [];
+  const { deps } = wizardDeps({ openDashboardFn: async (p) => opened.push(p) });
+  await mod.runSetupWizard(paths, tuiCtx(ui), ui.notify, deps);
+  assert.equal(opened.length, 1);
+  assert.equal(opened[0], paths, "the pre-wizard paths object, by identity");
+  assert.equal(seen.input.length, 0, "no later step ran");
+});
+
+test("wizard: declined confirms spawn NOTHING, and every step is still offered", async () => {
+  const dir = emptyDir();
+  const { ui, notes, seen } = wizardUi({
+    select: ["Guided setup", "Skip"],
+    input: [dir],
+    confirm: [false, false, false, false], // install, up, pointer, github -- all declined
+  });
+  const { deps, attached, pointerWrites, dashboards } = wizardDeps();
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.equal(attached.length, 0, "a declined confirm never reaches a spawn");
+  assert.equal(pointerWrites.length, 0, "a declined pointer confirm writes nothing");
+  assert.equal(seen.confirm.length, 4, "all four consent gates were offered despite the declines");
+  assert.equal(seen.select.length, 2, "intent + worker choice");
+  assert.ok(notes.some((n) => /provider key/.test(n.m)), "the never-tier provider-key notice still fires");
+  assert.ok(notes.some((n) => /setup finished/.test(n.m)));
+  assert.equal(dashboards.length, 1, "the wizard still ends at the panel");
+  assert.deepEqual(dashboards[0], { canned: "resolved" }, "opened against freshly resolved paths");
+});
+
+test("wizard: an accepted install spawns the exact npm shape and never clobbers an existing package.json", async () => {
+  const dir = emptyDir();
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "custom-root" }));
+  const { ui, seen } = wizardUi({
+    select: ["Guided setup", "Skip"],
+    input: [dir],
+    confirm: [true, false, false, false],
+  });
+  const { deps, attached, dashboards } = wizardDeps({
+    runAttachedFn: async (_ctx, opts) => {
+      attached.push(opts);
+      plantRuntime(dir, mod.RUNTIME_VERSION); // what a good npm run produces
+      return { code: 0 };
+    },
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.equal(attached.length, 1);
+  assert.equal(attached[0].argv0, "npm", "posix npm, per npmSpawnOptions");
+  assert.deepEqual(attached[0].args, mod.npmInstallArgs());
+  assert.equal(attached[0].cwd, dir, "the install target is the spawn cwd");
+  assert.equal(attached[0].shell, undefined, "no shell off win32");
+  assert.match(seen.confirm[0].message, /npm install/, "the confirm shows the exact command");
+  assert.match(seen.confirm[0].message, new RegExp(dir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), "and names the dir");
+  assert.deepEqual(JSON.parse(readFileSync(join(dir, "package.json"), "utf8")), { name: "custom-root" }, "an existing root package.json is never clobbered");
+  assert.equal(dashboards.length, 1, "a clean install continues to the end");
+});
+
+test("wizard: a post-install version mismatch stops the wizard loudly — no later step runs", async () => {
+  const dir = emptyDir();
+  const { ui, notes, seen } = wizardUi({
+    select: ["Guided setup"],
+    input: [dir],
+    confirm: [true], // accept the install; nothing later should be asked
+  });
+  const { deps, attached, dashboards } = wizardDeps({
+    runAttachedFn: async (_ctx, opts) => {
+      attached.push(opts);
+      plantRuntime(dir, "9.9.9"); // npm "succeeded" with the wrong artifact (import-pi:334-341)
+      return { code: 0 };
+    },
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.ok(notes.some((n) => n.t === "error" && /9\.9\.9/.test(n.m) && /not the pinned/.test(n.m)), "the error names both versions");
+  assert.equal(attached.length, 1, "only the npm spawn ran — never up/service/github");
+  assert.equal(seen.confirm.length, 1, "no later consent gate was reached");
+  assert.equal(dashboards.length, 0, "the wizard did not continue to the panel");
+  // The if-absent private root package.json was written before the install (import-pi:294 idiom).
+  assert.deepEqual(JSON.parse(readFileSync(join(dir, "package.json"), "utf8")), { name: "pi-dispatch-deployment", private: true });
+});
+
+test("wizard: an already-pinned runtime skips the install silently-but-said", async () => {
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, notes, seen } = wizardUi({
+    select: ["Guided setup", "Skip"],
+    input: [dir],
+    confirm: [false, false, false], // up, pointer, github — no install confirm expected
+  });
+  const { deps, attached } = wizardDeps();
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.ok(!seen.confirm.some((c) => /Install the pi-dispatch runtime/.test(c.title)), "no install dialog");
+  assert.ok(notes.some((n) => /already installed/.test(n.m) && /skipping npm install/.test(n.m)), "the skip is said out loud");
+  assert.equal(attached.length, 0);
+});
+
+test("wizard: up runs without --yes; a nonzero exit gates on Continue/Stop, and Stop ends the wizard", async () => {
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, seen } = wizardUi({
+    select: ["Guided setup", "Stop"],
+    input: [dir],
+    confirm: [true], // accept up; it fails; Stop
+  });
+  const { deps, attached, dashboards } = wizardDeps({
+    runAttachedFn: async (_ctx, opts) => {
+      attached.push(opts);
+      return { code: 1 };
+    },
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.equal(attached.length, 1);
+  assert.deepEqual(attached[0].args, [cliPathOf(dir), "up"], "the child's own y/N gates are the consents — never --yes");
+  assert.ok(!attached[0].args.includes("--yes"));
+  assert.equal(attached[0].cwd, dir);
+  assert.match(seen.select[1].title, /up exited 1/);
+  assert.equal(seen.confirm.length, 1, "Stop: the pointer step was never reached");
+  assert.equal(dashboards.length, 0);
+});
+
+test("wizard: a failed up with 'Continue anyway' proceeds to the pointer step", async () => {
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, seen } = wizardUi({
+    select: ["Guided setup", "Continue anyway", "Skip"],
+    input: [dir],
+    confirm: [true, false, false], // up (fails), pointer declined, github declined
+  });
+  const { deps, dashboards } = wizardDeps({
+    runAttachedFn: async () => ({ code: 3 }),
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.ok(seen.confirm.some((c) => /pointer/.test(c.title)), "the wizard continued past the failure");
+  assert.equal(dashboards.length, 1);
+});
+
+test("wizard: the pointer is written only after a confirm showing the JSON verbatim, then re-applied", async () => {
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, seen } = wizardUi({
+    select: ["Guided setup", "Skip"],
+    input: [dir],
+    confirm: [false, true, false], // up declined, POINTER ACCEPTED, github declined
+  });
+  const { deps, pointerWrites, order } = wizardDeps();
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.equal(pointerWrites.length, 1);
+  const { path, pointer } = pointerWrites[0];
+  assert.equal(path, deps.env.PI_DISPATCH_DEPLOYMENT_FILE, "written where pointerPath(env) says");
+  assert.equal(pointer.version, 1);
+  assert.equal(pointer.deploymentDir, dir);
+  assert.deepEqual(pointer.env, {
+    PI_TRIGGERS_FILE: join(dir, "triggers.json"),
+    PI_PAUSE_WINDOWS_FILE: join(dir, "pause-windows.json"),
+    PI_SUBSCRIPTIONS_FILE: join(dir, "subscriptions.json"),
+  });
+  const pointerConfirm = seen.confirm.find((c) => /pointer/.test(c.title));
+  assert.ok(pointerConfirm.message.includes(JSON.stringify(pointer, null, 2)), "the confirm shows the exact JSON-to-be");
+  assert.ok(pointerConfirm.message.includes(dir), "including the deploymentDir");
+  assert.deepEqual(order, ["write", "reapply"], "re-applied AFTER the write, so this session picks it up");
+});
+
+// ── the first-trigger step ───────────────────────────────────────────────────────────────────────
+
+/** Wrap the real fs, recording every write/mkdir path, so "never writes into the repo" is assertable. */
+function recordingFs() {
+  const writes = [];
+  return {
+    writes,
+    fs: {
+      mkdirSync: (p, o) => {
+        writes.push(String(p));
+        return realFs.mkdirSync(p, o);
+      },
+      writeFileSync: (p, d) => {
+        writes.push(String(p));
+        return realFs.writeFileSync(p, d);
+      },
+      renameSync: (a, b) => {
+        writes.push(String(b));
+        return realFs.renameSync(a, b);
+      },
+      existsSync: (p) => realFs.existsSync(p),
+      readFileSync: (p, e) => realFs.readFileSync(p, e),
+      readdirSync: (p) => realFs.readdirSync(p),
+    },
+  };
+}
+
+test("wizard: the first trigger targets ctx.cwd, lists real repo skills, and writes only the deploy dir", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "admin-setup-repo-"));
+  // One offerable skill, one gate-refused name (uppercase+space fails SKILL_NAME_RE), one without SKILL.md.
+  mkdirSync(join(repo, ".pi", "skills", "nightly-tidy"), { recursive: true });
+  writeFileSync(join(repo, ".pi", "skills", "nightly-tidy", "SKILL.md"), "# tidy\n");
+  mkdirSync(join(repo, ".pi", "skills", "Bad Name"), { recursive: true });
+  writeFileSync(join(repo, ".pi", "skills", "Bad Name", "SKILL.md"), "# nope\n");
+  mkdirSync(join(repo, ".pi", "skills", "no-skill-md"), { recursive: true });
+
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, notes, seen } = wizardUi({
+    select: ["Guided setup", "Skip", "A cron trigger for this repo", "nightly-tidy"],
+    input: [dir, "", "", ""], // dir, id blank→nightly, pattern blank→0 3 * * *, task blank→run the flow
+    confirm: [false, false, false],
+  });
+  const rec = recordingFs();
+  const triggerWrites = [];
+  const { deps } = wizardDeps({
+    fs: rec.fs,
+    writeTriggersFn: ({ triggersPath, mutate }) => {
+      triggerWrites.push({ triggersPath, list: mutate([]) });
+      return { ok: true };
+    },
+  });
+  const paths = { triggersPath: "/decoy/triggers.json" };
+  await mod.runSetupWizard(paths, tuiCtx(ui, repo), ui.notify, deps);
+
+  const flowSelect = seen.select.find((s) => /flow/.test(s.title));
+  assert.deepEqual(flowSelect.options, ["nightly-tidy", "type another…"], "SKILL_NAME_RE + SKILL.md filter the offer");
+
+  assert.equal(triggerWrites.length, 1);
+  assert.equal(triggerWrites[0].triggersPath, join(dir, "triggers.json"), "the DEPLOY dir's file — where the pointer aims the panel");
+  assert.notEqual(triggerWrites[0].triggersPath, paths.triggersPath, "never the pre-wizard resolved path");
+  const entry = triggerWrites[0].list[0];
+  assert.deepEqual(entry, {
+    on: { type: "cron", id: "nightly", pattern: "0 3 * * *" },
+    run: { kind: "local", folder: repo, flow: "nightly-tidy", task: "run the flow" },
+  });
+
+  assert.ok(notes.some((n) => n.t === "warning" && /IN PLACE with no undo/.test(n.m)), "the in-place-edit warning fired");
+  assert.ok(notes.some((n) => /ai-trigger: allow/.test(n.m)), "the frontmatter line is notified, not written");
+  for (const p of rec.writes) {
+    assert.ok(!p.startsWith(repo), `the wizard must never write into the repo: ${p}`);
+  }
+});
+
+test("wizard: an invalid cron id refuses at the dialog and skips the trigger", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "admin-setup-repo-"));
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, notes } = wizardUi({
+    select: ["Guided setup", "Skip", "A cron trigger for this repo"],
+    // No .pi/skills in this repo, so flow is a free input: dir, flow, then the bad id.
+    input: [dir, "tidy", "night:ly"],
+    confirm: [false, false, false],
+  });
+  const triggerWrites = [];
+  const { deps } = wizardDeps({
+    writeTriggersFn: (args) => {
+      triggerWrites.push(args);
+      return { ok: true };
+    },
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui, repo), ui.notify, deps);
+  assert.ok(notes.some((n) => n.t === "error" && /invalid cron id/.test(n.m)), "the ':' id is refused with the charset named");
+  assert.equal(triggerWrites.length, 0, "nothing was written");
+});
+
+test("wizard: no first-trigger offer when ctx.cwd is unset or missing on disk", async () => {
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  for (const cwd of [undefined, join(emptyDir(), "absent-subdir")]) {
+    const { ui, seen } = wizardUi({
+      select: ["Guided setup", "Skip"],
+      input: [dir],
+      confirm: [false, false, false],
+    });
+    const triggerWrites = [];
+    const { deps } = wizardDeps({
+      writeTriggersFn: (args) => {
+        triggerWrites.push(args);
+        return { ok: true };
+      },
+    });
+    await mod.runSetupWizard({}, tuiCtx(ui, cwd), ui.notify, deps);
+    assert.ok(!seen.select.some((s) => /First trigger/.test(s.title)), "the step is not offered without a real folder");
+    assert.equal(triggerWrites.length, 0);
+  }
+});
+
+test("listRepoSkills: filters by SKILL_NAME_RE and SKILL.md presence; [] on any error", () => {
+  const repo = mkdtempSync(join(tmpdir(), "admin-setup-skills-"));
+  mkdirSync(join(repo, ".pi", "skills", "fix"), { recursive: true });
+  writeFileSync(join(repo, ".pi", "skills", "fix", "SKILL.md"), "");
+  mkdirSync(join(repo, ".pi", "skills", "review"), { recursive: true });
+  writeFileSync(join(repo, ".pi", "skills", "review", "SKILL.md"), "");
+  mkdirSync(join(repo, ".pi", "skills", "UPPER"), { recursive: true });
+  writeFileSync(join(repo, ".pi", "skills", "UPPER", "SKILL.md"), "");
+  mkdirSync(join(repo, ".pi", "skills", "empty-one"), { recursive: true });
+  assert.deepEqual(mod.listRepoSkills(repo).sort(), ["fix", "review"]);
+  assert.deepEqual(mod.listRepoSkills(join(repo, "nope")), [], "a missing .pi/skills is an empty offer, not a throw");
+});
+
+// ── the one-time startup nudge ───────────────────────────────────────────────────────────────────
+
+/** Register the nudge against a crud-style pi Proxy and capture the session_start handler. */
+function nudgeSetup({ env = {}, scaffoldCwd = false } = {}) {
+  const agentDir = mkdtempSync(join(tmpdir(), "admin-nudge-agent-"));
+  const cwd = mkdtempSync(join(tmpdir(), "admin-nudge-cwd-"));
+  if (scaffoldCwd) {
+    for (const f of [".env", "triggers.json", "pause-windows.json", "subscriptions.json"]) writeFileSync(join(cwd, f), "");
+  }
+  let handler;
+  const pi = new Proxy(
+    {},
+    {
+      get: (_t, k) =>
+        k === "on"
+          ? (evt, h) => {
+              if (evt === "session_start") handler = h;
+            }
+          : () => {},
+    },
+  );
+  mod.registerNudge(pi, { env: { PI_CODING_AGENT_DIR: agentDir, ...env } });
+  const notes = [];
+  const dialogs = [];
+  const ctx = {
+    hasUI: true,
+    cwd,
+    ui: {
+      notify: (m, t) => notes.push([m, t]),
+      select: () => dialogs.push("select"),
+      input: () => dialogs.push("input"),
+      confirm: () => dialogs.push("confirm"),
+    },
+  };
+  return { handler, notes, dialogs, ctx, agentDir, cwd };
+}
+
+test("nudge: registers a session_start handler; reload and no-UI starts are inert", () => {
+  const n = nudgeSetup();
+  assert.equal(typeof n.handler, "function");
+  n.handler({ type: "session_start", reason: "reload" }, n.ctx);
+  assert.equal(n.notes.length, 0, "reload never nudges");
+  n.handler({ type: "session_start", reason: "startup" }, { ...n.ctx, hasUI: false });
+  assert.equal(n.notes.length, 0, "no UI, no nudge");
+  assert.equal(existsSync(join(n.agentDir, "pi-dispatch-setup.nudged")), false, "an inert start writes no marker");
+});
+
+test("nudge: fires once with notify only, then the marker suppresses it for good", () => {
+  const n = nudgeSetup();
+  n.handler({ type: "session_start", reason: "startup" }, n.ctx);
+  assert.equal(n.notes.length, 1);
+  assert.match(n.notes[0][0], /\/dispatch setup/);
+  assert.equal(n.notes[0][1], "info");
+  assert.equal(n.dialogs.length, 0, "notify-only: no dialog is ever raised at session start");
+  assert.equal(existsSync(join(n.agentDir, "pi-dispatch-setup.nudged")), true, "the once-ever marker exists");
+  n.handler({ type: "session_start", reason: "startup" }, n.ctx);
+  assert.equal(n.notes.length, 1, "the marker suppresses every later startup");
+});
+
+test("nudge: any configured signal — env sextet, pointer file, cwd scaffold — keeps it quiet", () => {
+  // VALKEY_URL is part of the NUDGE's sextet (unlike detection's env branch): no probe is allowed
+  // here, so an exported queue URL is the closest sync evidence of intent.
+  const withEnv = nudgeSetup({ env: { VALKEY_URL: "redis://127.0.0.1:1" } });
+  withEnv.handler({ type: "session_start", reason: "startup" }, withEnv.ctx);
+  assert.equal(withEnv.notes.length, 0, "an exported VALKEY_URL suppresses the nudge");
+
+  const withPointer = nudgeSetup();
+  writeFileSync(
+    join(withPointer.agentDir, "pi-dispatch-deployment.json"),
+    JSON.stringify({ version: 1, deploymentDir: "/srv/deploy", env: {} }),
+  );
+  withPointer.handler({ type: "session_start", reason: "startup" }, withPointer.ctx);
+  assert.equal(withPointer.notes.length, 0, "a present pointer suppresses the nudge");
+
+  const withScaffold = nudgeSetup({ scaffoldCwd: true });
+  withScaffold.handler({ type: "session_start", reason: "startup" }, withScaffold.ctx);
+  assert.equal(withScaffold.notes.length, 0, "a cwd scaffold suppresses the nudge");
+});

--- a/admin/test/wiring.test.mjs
+++ b/admin/test/wiring.test.mjs
@@ -17,6 +17,9 @@ import { join } from "node:path";
  * triggers) are covered in read-model.test.mjs, not here.
  */
 process.env.PI_LOGS_DIR = mkdtempSync(join(tmpdir(), "admin-wiring-"));
+// Hermeticity for the setup detection/nudge paths: pointerPath() and the nudge marker derive from
+// PI_CODING_AGENT_DIR, and no test run may ever read (or write!) the real ~/.pi/agent.
+process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), "admin-wiring-agent-"));
 
 const piRequire = createRequire(import.meta.resolve("@earendil-works/pi-coding-agent"));
 const { createJiti } = piRequire("jiti");
@@ -111,6 +114,50 @@ test("an unknown subcommand notifies and never touches the model channel", async
   await def.handler("bogus", unknown.ctx);
   assert.match(unknown.notes[0][0], /unknown subcommand/);
   assert.equal(calls.sendMessage.length, 0, "usage paths must not send into model context");
+});
+
+test("setup with a ctx lacking dialogs degrades to a notice, never the model channel", async () => {
+  const { calls, def } = await loadRegistered();
+  const ctx = fakeCtx({ withCustom: true }); // notify + custom, but no input/select/confirm
+  await def.handler("setup", ctx.ctx);
+  assert.ok(ctx.notes.some(([m]) => /dialogs|newer pi/.test(m)), "the missing-dialog notice is shown");
+  assert.equal(ctx.customCalls.length, 0, "no overlay opens for a wizard that cannot ask anything");
+  assert.equal(calls.sendMessage.length, 0);
+});
+
+/**
+ * The bare command on a host with NOTHING configured (issue #92): no pointer (agent dir is a pinned
+ * empty tmpdir), none of the path env vars, no cwd scaffold (the test runs from admin/), and a queue
+ * probe pinned to a dead port -- port 1 refuses immediately on every host, so the probe can never find
+ * a REAL dev Valkey on 6379 and go green under the test's feet. That state must surface the setup
+ * offer; a decline spawns nothing and degrades to the usage line. recordingPi still enforces USED_API
+ * throughout, so the detection/offer path cannot quietly grow a new pi member.
+ */
+test("bare /dispatch with nothing configured offers setup; a decline spawns nothing", async () => {
+  const keys = ["PI_LOGS_DIR", "PI_SETTINGS_FILE", "PI_TRIGGERS_FILE", "PI_PAUSE_WINDOWS_FILE", "PI_SUBSCRIPTIONS_FILE", "VALKEY_URL"];
+  const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  for (const k of keys) delete process.env[k];
+  process.env.VALKEY_URL = "redis://127.0.0.1:1";
+  try {
+    const { calls, def } = await loadRegistered();
+    const view = fakeCtx({ withCustom: true });
+    const confirms = [];
+    view.ctx.ui.confirm = async (title, message) => {
+      confirms.push([title, message]);
+      return false;
+    };
+    await def.handler("", view.ctx);
+    assert.equal(confirms.length, 1, "the offer confirm was shown exactly once");
+    assert.match(confirms[0][1], /No deployment found/);
+    assert.equal(view.customCalls.length, 0, "declined: no dashboard overlay, no wizard, nothing spawned");
+    assert.ok(view.notes.some(([m]) => /setup/.test(m)), "the decline degrades to the usage line naming setup");
+    assert.equal(calls.sendMessage.length, 0, "the offer path never touches the model channel");
+  } finally {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
 });
 
 /**
@@ -367,6 +414,8 @@ test("argument completion offers subcommands then run ids", async () => {
   const { def } = await loadRegistered();
   const subs = await def.getArgumentCompletions("s");
   assert.ok(Array.isArray(subs) && subs.some((i) => i.value === "status" || i.value === "settings"));
+  assert.ok(subs.some((i) => i.value === "setup"), "setup completes as a first token");
+  assert.deepEqual(await def.getArgumentCompletions("setu"), [{ value: "setup", label: "setup" }]);
   // Empty logs dir -> no ids to complete -> null (not []).
   assert.equal(await def.getArgumentCompletions("logs "), null);
   // No subcommand matches -> null.

--- a/specs/design.md
+++ b/specs/design.md
@@ -632,6 +632,47 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
 - **Traces to**: `DES-GH-APP-MANIFEST-SETUP` (`--no-webhook` mints the hook-inactive App this mode
   pairs with), `INT-WEBHOOK-PAYLOAD-SUBSET`, `REQ-DEDUP-BY-DELIVERY-GUID`, `DES-TRIGGER-OUTSIDE-PI`
 
+## DES-FIRST-RUN-SETUP-WIZARD
+
+- **Decision**: `/dispatch setup` (and, when bare `/dispatch` detects no deployment anywhere, an
+  offered confirm into the same flow) walks an operator from a console-only install to a working
+  deployment: choose a deployment dir (default `~/pi-dispatch`, never the repo) → consented
+  `npm install @edgehero/pi-dispatch@<RUNTIME_VERSION>` into it → hand the terminal to
+  `npx pi-dispatch up` → optional `service install` → write the deployment pointer
+  (`INT-DEPLOYMENT-POINTER-CONTRACT`, JSON shown verbatim) → provider key **printed, never
+  written** → optional `setup github` hand-off → optional first trigger for the repo the session
+  sits in (cron pre-filled with the folder, flow picked from its `.pi/skills/` via the shared
+  `SKILL_NAME_RE`, the in-place-edit warning printed, the `ai-trigger: allow` line **printed, never
+  written** — repo files stay the operator's, and the gate reads committed HEAD anyway) → the panel.
+  A once-ever `session_start` nudge (`reason: "startup"`, notify-only, marker-file latch) points at
+  the command. Every step is individually declinable and declines continue converge-style.
+- **Mechanics, chosen for pi's real constraints**: dialogs-first, **overlay-per-handoff** — the
+  wizard is a plain `ui.select/input/confirm` chain, and each terminal-needing child runs inside a
+  short-lived `ctx.ui.custom` overlay that exists only to hold the `tui` handle for the
+  suspend bracket (`tui.stop()` → `stdio:"inherit"` spawn → `finally` restore), because the handle
+  exists nowhere else, dialogs cannot run while an overlay captures focus, and stdin is unreadable
+  while suspended — the child's own prompts (up's y/N gates) own the terminal, which is exactly
+  right: **the child's consent gates are the host-mutation consents, and the wizard never forwards
+  `--yes` to anything**. The npm step follows import-pi's spawn doctrine (bare `npm`, win32
+  `npm.cmd`+`shell:true` only there, no filesystem path in argv — the dir rides in `cwd:`,
+  `--ignore-scripts`, post-install version assertion). `--ignore-scripts` on our *own* runtime is
+  safe by inspection: bullmq/ioredis are pure JS and msgpackr's native accelerator is an optional
+  dep (`--omit=optional`) with a JS fallback.
+- **Gate-ladder fit** (`DES-CLI-SURFACE`): the wizard adds **no new tier and no new powers** — it
+  sequences existing consented commands through their own gates, writes deployment config through
+  the same validated atomic writers the panel uses, and its only novel artifact is the pointer file,
+  which resolves paths and grants nothing. Operator-typed only: there is deliberately no
+  model-callable setup tool — the bundled skill tells the model to ask the operator to type it.
+- **Rejected**: a long-lived wizard overlay with hand-rolled input (reimplements dialogs, fights the
+  focus model); reusing a clone as the runtime (the persona has none; two code-delivery paths double
+  the matrix); a detached background worker (an unsupervised long-lived process nobody consented to
+  manage — the service step or a printed command instead); credential-entry dialogs (secrets never
+  transit the extension); auto-writing `ai-trigger: allow` into the operator's repo (the two-key
+  property — repo consent and operator trigger — must stay two keys).
+- **Traces to**: `INT-DEPLOYMENT-POINTER-CONTRACT`, `REQ-DEPLOYMENT-BOOTSTRAP`, `DES-CLI-SURFACE`,
+  `DES-GH-APP-MANIFEST-SETUP`, `DES-TRIGGER-OUTSIDE-PI` (the wizard bootstraps host processes; it
+  never hosts them)
+
 ## DES-WORKER-ON-HOST
 
 - **Decision**: The worker runs **on the host** (a Node process, `pi-dispatch worker` / `npm start`), not
@@ -1608,6 +1649,7 @@ a tunnel.
 
 | Date | Change |
 |---|---|
+| 2026-08-04 | The console becomes the front door (issue #92). Added **DES-FIRST-RUN-SETUP-WIZARD**: `/dispatch setup` + the bare-`/dispatch` no-deployment offer + a once-ever startup nudge, built as dialogs-first with **overlay-per-handoff** (the `tui` suspend handle exists only inside a `ctx.ui.custom` factory; dialogs cannot run under a capturing overlay; stdin is unreadable while suspended — so each attached child gets its own short-lived overlay, and the child's OWN consent gates are the host-mutation consents: the wizard forwards `--yes` to nothing). npm step under import-pi's spawn doctrine, with the recorded reasoning for `--ignore-scripts` on our own runtime (pure-JS deps; msgpackr's native accel is optional with a JS fallback). No new tier, no new powers, no model-callable tool; the only novel artifact is the pointer file (INT-DEPLOYMENT-POINTER-CONTRACT). Rejected on the record: long-lived wizard overlay, clone reuse, detached worker, credential dialogs, auto-writing `ai-trigger: allow` (two keys stay two keys). **DES-TRIGGER-OUTSIDE-PI UNCHANGED, checked**: the wizard bootstraps host processes, never hosts them. **DES-CLI-SURFACE UNCHANGED, checked**: every tier the wizard drives is entered through that entry's own gates. |
 | 2026-08-02 | The public URL becomes optional (issue #81, second half). Added **DES-GH-POLLING-TRANSPORT**: `pi-dispatch-receiver poll` synthesizes INT-WEBHOOK-PAYLOAD-SUBSET shapes from REST responses (issue events / comments / open PRs; ETag 304s are rate-limit-free; first boot never replays history; per-repo failures never kill the loop) and feeds the unchanged pure `filter()` + shared enqueue with `poll-*` delivery ids — the receiver stays the default and the low-latency path. Trust framing recorded: TLS with the operator's own credential replaces HMAC because authentication points the other way; `WEBHOOK_SECRET` is not required in poll mode, still hard-required for `serve`. The Actions-runner transport is rejected on the record (merge-gated workflow code executing on the worker host = merge-to-default becomes host code execution outside the container boundary). **DES-TRIGGER-OUTSIDE-PI UNCHANGED, checked**: the poller is the same always-on process class, just a different transport. **CONST-ISSUE-TEXT-IS-DATA UNCHANGED, checked**: the poller never interprets bodies. |
 | 2026-08-02 | The App path becomes the easy path (issue #81). Added **DES-GH-APP-MANIFEST-SETUP**: `pi-dispatch setup github` runs GitHub's App Manifest flow against a throwaway loopback listener — one browser click returns app id + PEM + webhook secret via the unauthenticated single-use conversion endpoint; every `.env` line is shown before one explicit consent, the PEM lands 0600 and never clobbers, an existing `WEBHOOK_SECRET` is kept (replacing it would invalidate working deliveries), installation-id discovery uses a deliberately hand-rolled ~15-line `node:crypto` RS256 JWT (auditable, once-at-setup; job-time minting stays `@octokit/auth-app`, unchanged), and `--no-webhook` creates the hook-inactive shape the polling transport will consume. No `--yes` on this wizard — these writes carry credentials. Rejected on the record: a maintainer-registered device-flow client (maintainer dependency in a self-hosted trust chain) and auto-installing the App (automating a consent screen defeats it). **CONST-TOKEN-SCOPED-PER-JOB UNCHANGED, checked**: the wizard changes how credentials are *acquired*, not how job tokens are minted or scoped. **CONST-HMAC-OVER-RAW-BODY UNCHANGED, checked**: the webhook secret the flow mints feeds the same verify path. |
 | 2026-08-02 | The receiver gets a container story (issue #82). Repo-layout `deploy/` line updated: `docker compose --profile receiver up` runs the receiver beside Valkey from a prebuilt `ghcr.io/edgehero/pi-dispatch-receiver` image (multi-arch, GITHUB_TOKEN-published like pi-job); the default `docker compose up` stays Valkey-only. The receiver was the natural candidate — `grep docker receiver/src` is empty, it is the only internet-facing process, and containerising it costs nothing the trust model cares about. **DES-WORKER-ON-HOST UNCHANGED, checked**: the worker remains a host process — no service in the compose file mounts docker.sock, and the profile's existence changes nothing about why the worker cannot be containerised (client-side path translation, local-folder bind mounts). SECURITY.md's trusted-components row holds verbatim: a containerised receiver still never executes agent-authored content, and HMAC-before-parse is unchanged. |

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -1871,6 +1871,50 @@ worker reads.
   file — the only reader is the admin extension. Given a duplicate `id` or an out-of-charset glob, when
   written through `writeSubscriptions`, then the write is rejected and the file is unchanged.
 
+## INT-DEPLOYMENT-POINTER-CONTRACT
+
+**setup wizard → admin extension.** The one file that lets `/dispatch` find a deployment built
+somewhere else. The worker and the receiver **never read it** — their truth is their own env (the
+deploy dir's `.env`, loaded by the service units/wrappers); the pointer only aims the *admin* at the
+same files. On drift the failure mode is the panel editing files the services do not read, and the
+recorded repair is re-running `/dispatch setup` (or editing the pointer by hand).
+
+- **Location**: `PI_DISPATCH_DEPLOYMENT_FILE`, defaulting to
+  `<PI_CODING_AGENT_DIR or ~/.pi/agent>/pi-dispatch-deployment.json` — pi's own agent dir, the
+  repo's one established home-dir pattern; a bespoke `~/.pi-dispatch/` tree is exactly the layout
+  invention this spec warns against elsewhere. Absent = `{ absent }`, the normal pre-wizard state.
+- **Shape**: `{ "version": 1, "deploymentDir": "<abs>", "env": { … } }`. `version` (required):
+  integer ≥ 1 — the one field that cannot be retrofitted. `env` is an **allowlisted map**:
+  `VALKEY_URL`, `PI_LOGS_DIR`, `PI_SETTINGS_FILE`, `PI_TRIGGERS_FILE`, `PI_PAUSE_WINDOWS_FILE`,
+  `PI_SUBSCRIPTIONS_FILE`; every path value must be **absolute** (a relative value would resolve
+  against whichever session happens to read it, i.e. silently wrong — dropped).
+- **What it may never carry, enforced by the read-side allowlist**: credentials of any kind, and
+  capability grants — `PI_DISPATCH_RUN_ROOTS` in this file has **no effect**, because a pointer that
+  could widen the AI-run allowlist would be a second, unreviewed door to a capability the panel
+  deliberately gates. The pointer resolves paths, full stop.
+- **Validation**: unknown top-level fields and unknown/disallowed env keys are silently dropped
+  (the operator-file policy); an unparseable file, a non-object, a missing/invalid `version`, or
+  `version` **higher** than the build's ⇒ the whole file is **ignored** and a one-line notice is
+  surfaced on the next `/dispatch` (naming both versions in the newer-file case). This is
+  deliberately weaker than `INT-SUBSCRIPTIONS-FILE-CONTRACT`'s loud refusal, and the reconciliation
+  is recorded here: the admin's read-model doctrine is *never throw, always degrade* — a broken
+  pointer must leave `/dispatch` exactly as functional as before the pointer existed (env → cwd
+  defaults), so fail-loud-on-newer becomes a **surfaced notice, never a throw**.
+- **Application**: layered into the process env once at extension load — **the operator's own env
+  always wins**, key by key; a later in-process re-apply (after the wizard rewrites the file) may
+  update only keys the pointer itself set, never one the operator exported. `resolvePaths` itself
+  stays env-only and untouched.
+- **Write protocol**: the wizard writes it behind a confirm showing the JSON verbatim; validated
+  through the same normalizer (a rejected pointer is never written), atomic tmp + rename;
+  hand-editable thereafter.
+- **Enforcement**: none at job time — no service reads it, no job input derives from it.
+- **Acceptance**: Given a pointer naming `PI_TRIGGERS_FILE` while the operator's env also sets it,
+  the env value is used. Given `version: 2`, `/dispatch` behaves as if no pointer existed and
+  surfaces one notice naming versions 2 and 1. Given `PI_DISPATCH_RUN_ROOTS` or a provider key in
+  `env`, the key is dropped and `dispatch_run`'s allowlist is unchanged. Given a relative
+  `PI_LOGS_DIR` value, the key is dropped. Given a deleted pointer, the next pi session resolves
+  exactly as today.
+
 ## INT-PRICING-EXPORT-CONTRACT
 
 **worker → admin extension.**
@@ -1915,6 +1959,7 @@ worker reads.
 
 | Date | Change |
 |---|---|
+| 2026-08-04 | The panel learns to find a deployment built elsewhere (issue #92). Added **INT-DEPLOYMENT-POINTER-CONTRACT**: `<agent dir>/pi-dispatch-deployment.json` (override `PI_DISPATCH_DEPLOYMENT_FILE`), an allowlisted absolute-paths-only env map layered UNDER the operator's env once at extension load — env wins key by key, the worker/receiver never read it, and `PI_DISPATCH_RUN_ROOTS`/credentials in the file have no effect by construction (a pointer that widened the AI-run allowlist would be a second unreviewed door to a gated capability). Deliberate divergence from INT-SUBSCRIPTIONS' loud version refusal, recorded in the entry: a broken/newer pointer degrades to exactly the pre-pointer behavior with a one-line surfaced notice, never a throw — the read-model's never-throw doctrine outranks fail-loud here because the pointer is an availability aid, not a data file. **INT-SUBSCRIPTIONS-FILE-CONTRACT / INT-CONFIG-OVERLAY-CONTRACT UNCHANGED, checked**: the pointer changes how their Locations are *found*, not what the files contain. |
 | 2026-08-02 | Polling producer (issue #81). **INT-WEBHOOK-PAYLOAD-SUBSET** amended: the subset may be synthesized from REST objects by `pi-dispatch-receiver poll` (`DES-GH-POLLING-TRANSPORT`), feeding the same pure `filter()` — parity pinned by dual-form tests; `poll-*` delivery ids share the `gh-` dedup space disjointly; the headers/HMAC row explicitly does not apply to synthesized subsets (no inbound delivery exists — TLS + the operator's credential is the transport trust). **REQ-DEDUP-BY-DELIVERY-GUID UNCHANGED, checked**: poll ids are stable across poller restarts by construction (event id / comment id / PR+head-sha), which is the retry-stability property the REQ demands of any id source. **INT-GITLAB/FORGEJO/AZURE-PAYLOAD-SUBSET UNCHANGED, checked**: polling is GitHub-only in this slice. |
 | 2026-08-02 | Receiver start path + triggers-default unification (issue #80). **INT-TRIGGERS-FILE-CONTRACT** amended: the receiver no longer *requires* `PI_TRIGGERS_FILE` — it falls back to `./triggers.json` in its working directory, the exact file `pi-dispatch init` scaffolds, and refuses to start when neither exists. The old default was the committed `deploy/triggers.json` (live demo triggers): an operator who edited the init scaffold and started the receiver without the env var silently ran the demo rules — a cwd default makes the reviewed file the operator just edited the one that fires. The admin extension's `resolvePaths` moves to the same cwd defaults for triggers/pause-windows/subscriptions (**INT-SUBSCRIPTIONS-FILE-CONTRACT** Location updated; **INT-PAUSE-WINDOWS-FILE-CONTRACT** UNCHANGED, checked — its Location is env-or-off for the *worker*, and the admin default is not part of that contract's shape). The receiver also gains its own bin, `pi-dispatch-receiver` (`receiver/src/cli.mjs`, `serve` by default): a `receiver` case in the worker CLI would invert the receiver→worker workspace dependency, and until now the only start command on record was inside `deploy/receiver.service`. **INT-WEBHOOK-PAYLOAD-SUBSET UNCHANGED, checked**: the bin changes how the process starts, not what it accepts or enqueues. |
 | 2026-08-01 | Pricing façade (issue #53, gaps 4/5 groundwork). Added **INT-PRICING-EXPORT-CONTRACT**: the worker's `./pricing` export is the admin's ONLY road to pi-ai's rate tables — `listPricedModels`/`getPricedModel`/`isZeroRated`/`piAiVersion`/`reprice`. Stream-time cost on the record stays the metered truth; the façade prices COUNTERFACTUALS only. `reprice` builds a fresh `Usage` with a zeroed cost skeleton every call (pi-ai's `calculateCost` mutates in place and TypeErrors without one — both pinned by test), inherits pi-ai's tier selection and 1h premium, and makes exactly one judgment: `cacheWrite1h` forwards only to `anthropic` targets, folded short for everyone else, because the premium is an Anthropic billing rule and applying it elsewhere would invent cost. The admin deliberately does NOT grow its own pi-ai pin (a fourth pin, a second drift axis); enumeration goes through the side-effect-free `providers/all`, never `./compat`. Enforcement is the pinned-artifact guard in `worker/test/pricing.test.mjs` — a pin bump that reshapes pricing fails the BUILD, not the screen. |

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -397,6 +397,12 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   false; print/headless). The operator-typed overlay CRUD and the confirm-gated tools reach the **same**
   validated, atomic `writeTriggers`/`writeSettings`. `dispatch_run` still takes **no spend-knob argument**
   (`model`/`maxTurns`/`dailyCap`/`concurrency`).
+  Since issue #92 the extension also carries the **first-run path**: `/dispatch setup`
+  (operator-typed only — deliberately no model-callable tool; `DES-FIRST-RUN-SETUP-WIZARD`), a
+  detection tree on bare `/dispatch` that offers setup **only** when no deployment exists anywhere
+  (pointer, env, cwd scaffold all absent AND the queue unreachable — an ops outage on a configured
+  deployment keeps the unreachable banner, never an offer), and a once-ever notify-only
+  `session_start` nudge.
 - **Scope**: The operator's interactive session on the worker host. The admin surface triggers no jobs
   except the gated `dispatch_run` enqueue, and is never materialised into a job's `/job` inputs —
   `INT-CONTAINER-JOB-INPUTS` mounts the serviced repo's own `.pi/` extensions, not this one.
@@ -431,7 +437,11 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   cap; given `/dispatch logs`, when
   the raw `.log` renders, then it renders in the overlay viewer and is never returned as a tool result or
   sent as a message into model context; given an operator pi whose API surface lacks any required member,
-  when the extension loads, then it registers nothing and reports the unsupported version loudly.
+  when the extension loads, then it registers nothing and reports the unsupported version loudly;
+  given bare `/dispatch` with no deployment anywhere and the setup offer **declined**, then nothing
+  was spawned and nothing was written; given a configured deployment whose queue is down, then the
+  panel opens with the unreachable banner and no setup offer; given a second pi startup after the
+  nudge fired once, then no nudge renders.
 
 ## REQ-AI-TRIGGERED-RUNS
 
@@ -954,7 +964,10 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   shipped deploy/ templates with computed absolutes (`process.execPath`, the real repo root — the
   shipped `/usr/bin/node` literal does not exist on an nvm host) and installs **user-level** by
   default; system-wide stays a printed sudo command, never executed. Not job execution, not
-  forge-side configuration (webhooks, branch protection, App installation), not the admin extension.
+  forge-side configuration (webhooks, branch protection, App installation). The admin extension's
+  `/dispatch setup` wizard (issue #92, `DES-FIRST-RUN-SETUP-WIZARD`) is **in scope as a driver, not
+  as a power**: it reaches these same CLI actions through their own consent gates and adds only the
+  deployment pointer (`INT-DEPLOYMENT-POINTER-CONTRACT`).
 - **Why**: The quickstart was five hand-typed infra chores whose commands were already fixed strings —
   automation removes typing, not decisions. The decisions stay human: every mutating action is printed
   verbatim and runs only on an explicit accept (y/N, default No, No on non-TTY), because "pulled onto
@@ -994,6 +1007,7 @@ wait-list working as designed, not a failure — see `README.md`.
 
 | Date | Change |
 |---|---|
+| 2026-08-04 | First-run setup joins the admin surface (issue #92). **REQ-ADMIN-VIA-PI-EXTENSION amended**: `/dispatch setup` (operator-typed only — deliberately no model-callable tool), the bare-`/dispatch` detection tree (the offer appears ONLY when pointer, env, and cwd scaffold are all absent AND the queue is unreachable — a configured deployment with a down queue keeps the banner, never an offer), and a once-ever notify-only `session_start` nudge; Acceptance gains declined-offer-⇒-nothing-spawned-nothing-written, no-offer-over-an-outage, and the nudge latch. **REQ-DEPLOYMENT-BOOTSTRAP Scope amended**: "not the admin extension" becomes the carve-in — the wizard is a *driver, not a power*: it reaches the same CLI actions through their own consent gates and adds only the deployment pointer. **CONST-BUDGET-BEFORE-TOKENS UNCHANGED, checked**: no wizard path reserves budget, enqueues, or spends — setup ends at the panel, not at a job. |
 | 2026-08-02 | Process supervision joins the bootstrap requirement (issue #80). **REQ-DEPLOYMENT-BOOTSTRAP Scope widened**: `pi-dispatch service` (render/install/uninstall/status/start/stop/restart `--drain`) — user-level by default, sudo commands printed never executed, per-OS honesty (macOS login-scoped because Docker Desktop is; Windows via operator-installed nssm, never Task Scheduler — its `TerminateProcess` hard-kill is the recorded rejection), `restart --drain` composing the durable pause → wait-idle → restart → resume ritual the README previously spelled out by hand, and a timed-out drain leaves the queue paused rather than un-pausing over a live job. **REQ-SPEND-CAPS-MULTI-WINDOW / CONST-BUDGET-BEFORE-TOKENS UNCHANGED, checked**: supervision changes when the worker runs, never what a run may spend. |
 | 2026-08-02 | Consented bootstrap (issue #80). Added **REQ-DEPLOYMENT-BOOTSTRAP**: `pi-dispatch up [--yes]` and `doctor --fix` take a fresh machine to a preflighted deployment through create-only scaffolds and per-action consented host mutations — every mutating command printed verbatim, y/N default No (No on non-TTY), closed fix tiers with an explicit never-set (malformed-config rewrites, triggers/pause-windows content, trigger-named `run.image`, semantic env guesses), `WEBHOOK_SECRET` set only when empty and never printed. Automation removes typing, never decisions: the consent keypress preserves SECURITY.md's "pulled onto that host yourself" property that a silent bootstrap would erase. **CONST-BUDGET-BEFORE-TOKENS UNCHANGED, checked**: no bootstrap path reserves budget, enqueues, or spends — `up` ends at doctor, not at a job. **REQ-GLOBAL-PI-OVERLAY UNCHANGED, checked**: doctor's overlay obligations are cited by the new REQ, not moved; `--fix`'s overlay actions (auth.json delete, import-pi restage) re-execute existing gates. |
 | 2026-08-02 | Doctor grows the missing receiver-side preflight (issue #80). **REQ-BRANCH-PROTECTION-PRECONDITION** amended: `doctor` now states at setup time that github branch protection cannot be preflighted statically (github triggers take their repo from each delivery — `run.repository` is azure-only) and names the actual enforcement point, per job pre-spend; a read-only capped `gh api` preflight helper ships for when repos are statically known, warn-never-fail, never offering to enable protection. Doctor also warns on the receiver-boot hard-requirements it previously ignored (WEBHOOK_SECRET; Forgejo and Azure credentials mirroring the existing GitLab block), gated on which forges the triggers file actually names, preserving warn-not-fail ("a deployment can legitimately be mid-setup") and presence-only secret checks. **REQ-TRIGGER-AUTHOR-GATE UNCHANGED, checked**: every new check reads state; none writes or gates anything. **CONST-MERGE-NEVER-AUTOMATIC UNCHANGED, checked**: the preflight surfaces the backstop's precondition earlier; the backstop itself is untouched. |

--- a/worker/src/cli.mjs
+++ b/worker/src/cli.mjs
@@ -36,7 +36,9 @@ const USAGE = `pi-dispatch — run pi coding-agent flows on your own folders
   pi-dispatch resume       resume taking jobs
   pi-dispatch status       show paused state + job counts
 
-Config comes from the environment (see .env.example); flags override it per run.`;
+Config comes from the environment (see .env.example); flags override it per run.
+Prefer being walked through all of this? The operator panel's /dispatch setup does every step
+with a consent per action:  pi install npm:@edgehero/pi-dispatch-admin`;
 
 export async function main(argv = process.argv.slice(2), env = process.env) {
 	const cmd = argv[0];

--- a/worker/src/flow-gate.mjs
+++ b/worker/src/flow-gate.mjs
@@ -30,10 +30,11 @@ const exec = promisify(execFile);
  */
 
 // The skill name charset: lowercase kebab/underscore, 1-64 chars, no dots (so no "..") and no
-// slashes. Mirrors materialize.mjs SKILL_NAME_RE (not exported there) — keep in sync. Validating
-// `flow` against it BEFORE building any path is the traversal choke point: a bad name is denied,
-// never interpolated into a git path.
-const SKILL_NAME_RE = /^[a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?$/;
+// slashes. Validating `flow` against it BEFORE building any path is the traversal choke point: a
+// bad name is denied, never interpolated into a git path. Exported as the single source of truth
+// (issue #92): materialize.mjs imports it, and the admin's setup wizard lists a repo's .pi/skills
+// through it — three keep-in-sync copies would drift exactly where a traversal guard cannot.
+export const SKILL_NAME_RE = /^[a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?$/;
 
 export async function readFlowGate({ folder, flow, sha, git = defaultGit }) {
 	// `sha` is REQUIRED and never defaulted: a missing SHA fails closed rather than resolving HEAD,

--- a/worker/src/init.mjs
+++ b/worker/src/init.mjs
@@ -73,5 +73,6 @@ Next:
   5. pi-dispatch worker                                 # drain the queue
 
 Operator panel (optional): pi install npm:@edgehero/pi-dispatch-admin   then   /dispatch
+  (or let the panel do all of the above: /dispatch setup walks these steps with a consent per action)
 `;
 }

--- a/worker/src/materialize.mjs
+++ b/worker/src/materialize.mjs
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative } from "node:path";
 import { promisify } from "node:util";
+import { SKILL_NAME_RE } from "./flow-gate.mjs";
 
 const exec = promisify(execFile);
 
@@ -29,9 +30,10 @@ const PI_DIR = ".pi";
 const APPEND_SYSTEM = `${PI_DIR}/APPEND_SYSTEM.md`;
 // A skill directory name: lowercase kebab/underscore, 1-64 chars, no dots (so no "..") and no
 // slashes. This is what makes a traversal name impossible at the source. Matched against the
-// CAPTURED segment only, never the whole path.
+// CAPTURED segment only, never the whole path. The name charset itself is imported from
+// flow-gate.mjs (the exported single source of truth, issue #92); the path form stays local
+// because only the materialiser walks whole tree paths.
 const SKILL_PATH_RE = /^\.pi\/skills\/([a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?)\/SKILL\.md$/;
-const SKILL_NAME_RE = /^[a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?$/;
 
 /**
  * Classify a git tree path into the destination we will WRITE, or null to reject.

--- a/worker/test/flow-gate.test.mjs
+++ b/worker/test/flow-gate.test.mjs
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
-import { readFlowGate } from "../src/flow-gate.mjs";
+import { SKILL_NAME_RE, readFlowGate } from "../src/flow-gate.mjs";
 
 // git is NEVER faked in this suite: readFlowGate's object-store discipline is only meaningfully
 // tested against a REAL repo with REAL tree modes (a genuine 120000 symlink, a real prior commit).
@@ -124,4 +124,11 @@ test("CRLF frontmatter with a quoted value -> allow (CRLF normalised, quote opti
 test("never throws even when the folder is not a git repo at all -> deny", async () => {
 	const notRepo = mkdtempSync(join(tmpdir(), "pi-notrepo-"));
 	assert.deepEqual(await readFlowGate({ folder: notRepo, flow: "tidy", sha: "0".repeat(40) }), { gate: "deny" });
+});
+
+test("SKILL_NAME_RE is exported as the single source of truth (issue #92) and holds its vectors", () => {
+	// materialize.mjs imports this regex and the admin's setup wizard lists .pi/skills through it, so
+	// the charset is API now: a loosening here loosens a traversal choke in three places at once.
+	for (const ok of ["tidy", "bug-fix", "a", "x_1", "a".repeat(64)]) assert.ok(SKILL_NAME_RE.test(ok), ok);
+	for (const bad of ["", "Tidy", "a..b", "a/b", "-lead", "trail-", ".hidden", "a".repeat(65)]) assert.ok(!SKILL_NAME_RE.test(bad), bad);
 });


### PR DESCRIPTION
Closes #92. The final UX on top of the #80–#82 ladder: an operator whose only install is `pi install npm:@edgehero/pi-dispatch-admin` types `/dispatch` in a repo, and the console takes them from nothing to a working deployment — with a consent per action — then lands in the panel.

Three commits:

## 1 — worker: `SKILL_NAME_RE` exported from flow-gate

The traversal-choke charset was duplicated in `materialize.mjs` with a keep-in-sync comment, and the wizard becomes a third reader. One export, two imports, one vector-pin test.

## 2 — the deployment pointer (`INT-DEPLOYMENT-POINTER-CONTRACT`)

`~/.pi/agent/pi-dispatch-deployment.json` (override `PI_DISPATCH_DEPLOYMENT_FILE`): an **allowlisted, absolute-paths-only** env map layered *under* the operator's env once at extension load — env wins key by key, the worker/receiver never read it, and `PI_DISPATCH_RUN_ROOTS` or credential-shaped keys in the file have **no effect by construction** (a pointer that widened the AI-run allowlist would be a second, unreviewed door to a gated capability). A broken or newer file degrades to exactly the pre-pointer behavior with a one-line surfaced notice — never a throw; the contract records this as the deliberate reconciliation of fail-loud-on-newer with the read-model's never-throw doctrine. `resolvePaths` stays env-only and untouched. This is what makes a wizard-built deployment visible to `/dispatch` from any directory — and it replaces the README's "hand-mirror five env vars into your pi session" paragraph.

## 3 — the wizard, detection, and the nudge

- **Detection on bare `/dispatch`** (cheapest-first): valid pointer or explicit env ⇒ panel exactly as before; cwd scaffold quadruple or a reachable queue ⇒ panel plus one hint; nothing anywhere **and** the queue unreachable ⇒ the offer. An exported `VALKEY_URL` is *probed, never trusted* — a dead URL still reaches the offer, and an ops outage on a configured deployment keeps today's banner, never a wizard prompt. Missing logs/settings dirs prove nothing (lazy OS-temp defaults) and are never consulted.
- **`/dispatch setup`** — dialogs-first, **overlay-per-handoff** (pi's `tui` suspend handle exists only inside a `ctx.ui.custom` factory; dialogs can't run under a capturing overlay; stdin belongs to the attached child): deploy dir (default `~/pi-dispatch`, never the repo) → consented `npm install @edgehero/pi-dispatch@0.1.0` under import-pi's spawn doctrine (bare `npm`, win32 `npm.cmd`+`shell:true` only there, **no filesystem path in argv**, `--ignore-scripts`, post-install version assertion that stops the wizard loudly) → the terminal handed to `pi-dispatch up`, whose own y/N gates **are** the host-mutation consents (`--yes` is forwarded to nothing) → optional user-level `service install` → the pointer written with its JSON shown verbatim, then re-applied in-process so the panel opens against it without restarting pi → provider key **printed, never written** → optional `setup github` hand-off → optional **first trigger for the repo the session sits in**: folder pre-filled, flow picked from that repo's `.pi/skills/` through the shared `SKILL_NAME_RE`, the in-place-edit warning printed, and the `ai-trigger: allow` line **printed for the operator to commit** — the wizard never writes into a repo. Then the panel.
- **Once-ever `session_start` nudge**: `reason: "startup"` only, `hasUI` only, sync-only checks (no queue probe at startup), marker-file latch, notify-only.
- Every step individually declinable; declines continue converge-style; headless refuses; `USED_API` is unchanged (spawns via `node:child_process`); `RUNTIME_VERSION` is pinned to the worker's version by an anti-drift test so release bumps stay atomic.

## Specs

New `DES-FIRST-RUN-SETUP-WIZARD` (with the recorded rejections: long-lived wizard overlay, clone reuse, detached worker, credential dialogs, auto-writing the repo's opt-in — two keys stay two keys) and `INT-DEPLOYMENT-POINTER-CONTRACT`; `REQ-ADMIN-VIA-PI-EXTENSION` amended (setup is operator-typed only — deliberately no model-callable tool; the skill's new chapter tells the model to ask the operator to type it); `REQ-DEPLOYMENT-BOOTSTRAP` Scope carve-in (the wizard is a driver, not a power). Revision History rows in interfaces/design/requirements; `DES-TRIGGER-OUTSIDE-PI` (bootstraps, never hosts), `DES-CLI-SURFACE`, `CONST-BUDGET-BEFORE-TOKENS` (no wizard path spends — setup ends at the panel, not at a job) — unchanged, checked.

## Tests

Full suite: **1843 tests, 1827 pass, 0 fail, 16 pre-existing skips** (+46 over main: 31 wizard, 12 pointer, wiring/pinned-api/flow-gate additions). Admin bundle rebuilt and smoke-loaded (both new modules inlined; factory registers `resources_discover` + `session_start`). CI greps clean.
