### PR TITLE
chore(release): pi-dispatch 0.7.0, admin 0.4.0, worker 0.1.1

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -48,7 +48,7 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
  * follows in the same change.
  */
-export const RUNTIME_VERSION = "0.1.0";
+export const RUNTIME_VERSION = "0.1.1";
 
 /** The pointer marker file suffix and the four-file cwd scaffold signature, shared by detect + nudge. */
 const NUDGE_MARKER_BASENAME = "pi-dispatch-setup.nudged";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",
@@ -4253,7 +4253,7 @@
     },
     "worker": {
       "name": "@edgehero/pi-dispatch",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Self-hosted job harness for the pi coding agent: a BullMQ worker that drains the queue, mints scoped forge tokens, and runs one container per job — plus the pi-dispatch CLI (init, up, doctor, service).",
   "keywords": [


### PR DESCRIPTION
Release bump for the first-run wizard (issue #92, PRs #93 + #94).

- **root 0.6.0 → 0.7.0**: repo-release.yml cuts `v0.7.0` on merge.
- **admin 0.3.0 → 0.4.0**: publishes `/dispatch setup`, the deployment pointer, detection, and the nudge.
- **worker 0.1.0 → 0.1.1**: publishes the `SKILL_NAME_RE` export and the setup cross-references in the CLI help; `RUNTIME_VERSION` bumps with it, enforced by the anti-drift test.
- Receiver stays 0.1.0 (untouched; its `^0.1.0` dep range covers 0.1.1).

Full suite on this branch: 1843 tests, 1827 pass, 0 fail.