### PR TITLE
feat: /dispatch as the default setup route, and a service-unit fix for npm deployments (issue #96)

### DIFF
--- a/.github/scripts/admin-pi-canary.mjs
+++ b/.github/scripts/admin-pi-canary.mjs
@@ -1,0 +1,231 @@
+/**
+ * The admin extension's pi canary (issue #96). Runs the admin's pinned-pi assumptions against an
+ * ARBITRARY pi install -- in CI, @latest -- so a breaking pi release fails a build here instead of
+ * an operator's /dispatch there.
+ *
+ * Why this exists at all: admin/package.json declares `"@earendil-works/pi-coding-agent": "*"` as
+ * its peer range. That is deliberate, and this header is where the reason is recorded (JSON takes
+ * no comments): pi's own packages doc prescribes `"*"` peers for host-provided packages -- pi never
+ * installs a peer, the host session IS the pi -- and an exact peer pin makes every plain-npm
+ * consumer ERESOLVE the moment their pi differs by a patch. The exact TESTED version still lives in
+ * two places locked to each other: `SUPPORTED_PI_VERSION` in admin/src/index.ts and the admin
+ * devDependency pin (admin/test/load.test.mjs asserts they cannot drift). A wildcard peer without a
+ * canary would be a hope; this script is what keeps it honest.
+ *
+ * Usage: node .github/scripts/admin-pi-canary.mjs <scratch-dir>
+ *   where <scratch-dir> holds an `npm install @earendil-works/pi-coding-agent` (any version, in CI
+ *   @latest) under <scratch-dir>/node_modules. Never point it at the repo root: the repo's hoisted
+ *   copy is the PIN the admin test suite anchors on, and canarying it would assert nothing.
+ *
+ * Asserts, against THAT install:
+ *   (a) every needle from the admin's pinned-api needle list appears in its
+ *       dist/core/extensions/types.d.ts
+ *   (b) every USED_API member is declared as a method on its `interface ExtensionAPI`
+ *   (c) `VERSION` is a runtime string export of the package root
+ *   (d) the BUILT admin bundle actually loads with that pi resolvable and registers exactly one
+ *       `dispatch` command with no stderr refusal line
+ *
+ * Resolution mechanics for (d): the bundle (admin/dist/index.mjs, pi kept external by
+ * admin/build.mjs) is COPIED into the scratch dir. ESM resolves a bare specifier against the
+ * IMPORTING FILE's own location, so the copy's `@earendil-works/pi-coding-agent` import walks up
+ * from <scratch-dir> and finds <scratch-dir>/node_modules -- the install under test -- never the
+ * repo's hoisted pin. bullmq/ioredis are external in the bundle too but are NOT under test; they
+ * are satisfied by symlinking the repo's own pinned copies into the scratch node_modules (offline,
+ * deterministic, no second install).
+ */
+
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, symlinkSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/**
+ * Source of truth: admin/test/pinned-extension-api.test.mjs. That test asserts these against the
+ * PINNED pi and may not import from (or be edited for) a CI script; this is a deliberate second
+ * copy, and admin/test/wiring.test.mjs is the anti-drift bolt: it imports these exports and fails
+ * the suite when they diverge from the pinned test's literals or from the real USED_API export.
+ */
+export const NEEDLES = [
+  "registerCommand(name",
+  "registerTool<TParams",
+  "sendMessage<T",
+  "getArgumentCompletions",
+  "custom<T>(",
+  "notify(message",
+  "confirm(title",
+  "select(title",
+  "input(title",
+  "session_start",
+  "executionMode",
+];
+
+/** Mirrors USED_API in admin/src/index.ts -- deepEqual-checked by wiring.test.mjs (same bolt). */
+export const USED_API_MEMBERS = ["registerCommand", "registerTool", "sendMessage", "on"];
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+
+/**
+ * Extract the body text of a named `interface X { ... }` by brace balancing. A copy of the helper
+ * in admin/test/pinned-extension-api.test.mjs (see the NEEDLES note on why a copy).
+ */
+function extractInterface(src, name) {
+  const start = src.indexOf(`interface ${name} {`);
+  if (start === -1) return null;
+  let depth = 0;
+  for (let i = src.indexOf("{", start); i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  return null;
+}
+
+let failures = 0;
+function fail(msg) {
+  failures++;
+  console.error(`canary FAIL: ${msg}`);
+}
+function ok(msg) {
+  console.log(`canary ok:   ${msg}`);
+}
+
+async function main(scratchArg) {
+  const scratch = resolve(scratchArg);
+  const piDir = join(scratch, "node_modules", "@earendil-works", "pi-coding-agent");
+  if (!existsSync(join(piDir, "package.json"))) {
+    console.error(`canary: no pi install at ${piDir} -- npm install @earendil-works/pi-coding-agent into the scratch dir first`);
+    process.exit(2);
+  }
+  const piPkg = JSON.parse(readFileSync(join(piDir, "package.json"), "utf8"));
+  console.log(`canary: probing @earendil-works/pi-coding-agent ${piPkg.version} at ${piDir}`);
+
+  // ---- (a) the needle list still appears in the install's extension types ----
+  const typesPath = join(piDir, "dist", "core", "extensions", "types.d.ts");
+  let typesSrc;
+  try {
+    typesSrc = readFileSync(typesPath, "utf8");
+  } catch (err) {
+    fail(`cannot read ${typesPath}: ${err.message} -- pi moved its extension type declarations`);
+  }
+  if (typesSrc !== undefined) {
+    const missing = NEEDLES.filter((needle) => !typesSrc.includes(needle));
+    if (missing.length > 0) {
+      fail(`extensions/types.d.ts no longer contains: ${missing.map((n) => JSON.stringify(n)).join(", ")}`);
+    } else {
+      ok(`(a) all ${NEEDLES.length} pinned-api needles present`);
+    }
+
+    // ---- (b) every USED_API member is a method on this install's ExtensionAPI ----
+    const block = extractInterface(typesSrc, "ExtensionAPI");
+    if (!block) {
+      fail("could not find `interface ExtensionAPI` in the install's types.d.ts");
+    } else {
+      let allMembers = true;
+      for (const member of USED_API_MEMBERS) {
+        if (!new RegExp(`\\b${member}\\s*[<(]`).test(block)) {
+          allMembers = false;
+          fail(`ExtensionAPI no longer declares "${member}" as a method`);
+        }
+      }
+      if (allMembers) ok(`(b) all ${USED_API_MEMBERS.length} USED_API members declared on ExtensionAPI`);
+    }
+  }
+
+  // ---- (c) VERSION is a runtime string export of the package root ----
+  const dot = piPkg.exports?.["."];
+  const entryRel = typeof dot === "string" ? dot : (dot?.import ?? dot?.default ?? piPkg.main ?? "./dist/index.js");
+  try {
+    const piMod = await import(pathToFileURL(join(piDir, entryRel)).href);
+    if (typeof piMod.VERSION === "string") {
+      ok(`(c) VERSION is exported and a string ("${piMod.VERSION}")`);
+    } else {
+      fail(`the package root exports VERSION as ${typeof piMod.VERSION}, want string -- the admin's runtime advisory depends on it`);
+    }
+  } catch (err) {
+    fail(`importing the package root (${entryRel}) threw: ${err.message}`);
+  }
+
+  // ---- (d) the built admin bundle loads with THIS pi and registers cleanly ----
+  const builtBundle = join(repoRoot, "admin", "dist", "index.mjs");
+  if (!existsSync(builtBundle)) {
+    console.error("canary: admin/dist/index.mjs is missing -- run `node admin/build.mjs` first");
+    process.exit(2);
+  }
+  // Always copy fresh so the probe can never run against a stale bundle left in the scratch dir.
+  const bundleCopy = join(scratch, "admin-bundle.mjs");
+  copyFileSync(builtBundle, bundleCopy);
+  // The bundle's other externals (heavy runtime deps, not under test) resolve to the repo's own
+  // pinned install via symlink -- nothing is ever network-installed here, and the scratch pi stays
+  // the only pi in the resolution path.
+  for (const dep of ["bullmq", "ioredis"]) {
+    const target = join(scratch, "node_modules", dep);
+    if (!existsSync(target)) symlinkSync(join(repoRoot, "node_modules", dep), target, "dir");
+  }
+  // Hermeticity: the factory layers the deployment pointer from pi's agent dir at load; pin that to
+  // an empty dir under the scratch so the probe can never read (or be steered by) a real ~/.pi/agent.
+  process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(scratch, "canary-agent-"));
+  delete process.env.PI_DISPATCH_DEPLOYMENT_FILE;
+
+  try {
+    const mod = await import(pathToFileURL(bundleCopy).href);
+    if (typeof mod.default !== "function") throw new Error("the bundle's default export is not a factory function");
+    if (JSON.stringify([...mod.USED_API].sort()) !== JSON.stringify([...USED_API_MEMBERS].sort())) {
+      fail(`the bundle's USED_API (${mod.USED_API}) differs from the canary's list (${USED_API_MEMBERS}) -- update USED_API_MEMBERS here`);
+    }
+
+    // A recording proxy exposing exactly the USED_API members; anything else the factory reaches
+    // for throws, mirroring admin/test/wiring.test.mjs's discipline.
+    const registered = [];
+    const pi = new Proxy(
+      {},
+      {
+        get(_target, key) {
+          if (typeof key !== "string") return undefined;
+          if (key === "registerCommand") return (name, def) => registered.push([name, def]);
+          if (USED_API_MEMBERS.includes(key)) return () => {};
+          throw new Error(`admin extension reached a non-USED_API pi member: ${key}`);
+        },
+      },
+    );
+    const stderrLines = [];
+    const origError = console.error;
+    console.error = (...a) => stderrLines.push(a.join(" "));
+    try {
+      mod.default(pi);
+    } finally {
+      console.error = origError;
+    }
+    if (stderrLines.length > 0) {
+      fail(`the factory printed to stderr (the refusal path fired?): ${stderrLines[0]}`);
+    } else if (registered.length !== 1 || registered[0][0] !== "dispatch") {
+      fail(`expected exactly one registerCommand("dispatch"), got: ${JSON.stringify(registered.map(([n]) => n))}`);
+    } else if (typeof registered[0][1]?.handler !== "function") {
+      fail("the registered dispatch command has no handler function");
+    } else {
+      ok(`(d) the built bundle loads against pi ${piPkg.version} and registers /dispatch cleanly`);
+    }
+  } catch (err) {
+    fail(`loading the admin bundle against pi ${piPkg.version} threw: ${err.message}`);
+  }
+
+  if (failures > 0) {
+    console.error(
+      `canary: ${failures} failure(s) against pi ${piPkg.version}. pi moved underneath the admin: ` +
+        "retest locally, bump SUPPORTED_PI_VERSION and the admin devDependency pin together " +
+        "(load.test.mjs locks them to each other), and republish @edgehero/pi-dispatch-admin.",
+    );
+    process.exit(1);
+  }
+  console.log(`canary: PASS against pi ${piPkg.version}`);
+}
+
+// Main-module guard: wiring.test.mjs imports this file for NEEDLES/USED_API_MEMBERS, and an import
+// must never run the probe.
+const isMain = process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isMain) {
+  const scratchArg = process.argv[2];
+  if (!scratchArg) {
+    console.error("usage: node .github/scripts/admin-pi-canary.mjs <scratch-dir>");
+    process.exit(2);
+  }
+  await main(scratchArg);
+}

--- a/.github/workflows/pi-upgrade-check.yml
+++ b/.github/workflows/pi-upgrade-check.yml
@@ -20,21 +20,25 @@ on:
       - "image/**"
       - "worker/**"
       - "receiver/**"
+      - "admin/**"
       - "guardrails/**"
       - "package.json"
       - "pi-packages.example.json"
       - "triggers.example.json"
       - ".github/workflows/pi-upgrade-check.yml"
+      - ".github/scripts/admin-pi-canary.mjs"
   pull_request:
     paths:
       - "image/**"
       - "worker/**"
       - "receiver/**"
+      - "admin/**"
       - "guardrails/**"
       - "package.json"
       - "pi-packages.example.json"
       - "triggers.example.json"
       - ".github/workflows/pi-upgrade-check.yml"
+      - ".github/scripts/admin-pi-canary.mjs"
   schedule:
     # Weekly: pi ships breaking changes between minors and its HEAD moved within 24h of this
     # project's design being written. A pin that is never exercised rots silently.
@@ -400,3 +404,58 @@ jobs:
           docker run --rm --network none -e PROBE="$PROBE" \
             --entrypoint sh "$IMAGE_REF" -c 'node --input-type=module -e "$PROBE"' \
             || { echo "::error::The usage meter no longer offers pi-coding-agent's NESTED pi-ai first in this image. That copy owns the module-level api-provider registry every session dispatches through, so it is the only one worth metering; installProcessUsageMeter still DECIDES by runtime mutation probe and would fall back, so this step is about the ORDER and the surface, not the decision. If the layout moved, re-verify in this order: resolvePiAiCompat's nested-path derivation in image/runner/src/usage-meter.mjs, the compat exports the probe and the wrapper call (getApiProvider/getApiProviders/registerApiProvider/resetApiProviders, createAssistantMessageEventStream), trap (g) in specs/interfaces.md, and image/runner/test/pinned-api.test.mjs -- which pins the dual-copy layout in contract-tests, where the worker's hoisted pi-ai is installed too."; exit 1; }
+
+  admin-extension-canary:
+    # The admin extension is the default front door (issue #96): it is TESTED against an exact pi
+    # (SUPPORTED_PI_VERSION, locked to the admin devDependency pin by admin/test/load.test.mjs) but
+    # declares a "*" peer, because pi never installs peers for host-provided packages and an exact
+    # peer pin ERESOLVEs every plain-npm consumer whose pi differs by a patch -- the full reasoning
+    # lives in .github/scripts/admin-pi-canary.mjs's header. A wildcard peer without a canary is a
+    # hope; this job is the canary. It installs pi@latest into a SCRATCH dir and asserts the admin's
+    # pinned assumptions against THAT install: the pinned-api needle list, the USED_API members on
+    # ExtensionAPI, the runtime VERSION export, and an actual load-and-register of the built bundle.
+    #
+    # Failure protocol: a red run here means pi moved underneath the admin. Retest locally against
+    # the new pi, bump SUPPORTED_PI_VERSION and the admin devDependency pin TOGETHER (load.test.mjs
+    # locks them to each other), and republish @edgehero/pi-dispatch-admin.
+    name: the admin extension survives latest pi (canary)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      # NEVER install anything extra into the repo root. admin/test/load.test.mjs and
+      # admin/test/pinned-extension-api.test.mjs anchor on the HOISTED PIN the lockfile resolves; a
+      # root `npm install @earendil-works/pi-coding-agent@latest` would silently flip both from
+      # pinned-version assertions into HEAD assertions -- green-lighting exactly the drift they
+      # exist to catch. The @latest copy goes into a mktemp scratch dir outside the checkout.
+      - run: npm ci --no-audit --no-fund
+
+      - run: node admin/build.mjs
+
+      - name: Install pi@latest into a scratch dir (never the repo)
+        run: |
+          SCRATCH=$(mktemp -d)
+          echo "SCRATCH=$SCRATCH" >> "$GITHUB_ENV"
+          cd "$SCRATCH"
+          npm init -y >/dev/null
+          # Distinguish failures (release.yml's npm-view doctrine): an install error here is
+          # infrastructure -- network, registry, npm itself -- NOT a canary verdict about pi, and
+          # reading it as either "pi broke us" or "all clear" would be a guess. Fail loudly instead.
+          if ! npm install @earendil-works/pi-coding-agent@latest --no-audit --no-fund; then
+            echo "::error::npm install @earendil-works/pi-coding-agent@latest failed -- an infrastructure failure, not a pi-drift verdict. Re-run before reading anything into it."
+            exit 1
+          fi
+          node -p "'canary pi: ' + require('$SCRATCH/node_modules/@earendil-works/pi-coding-agent/package.json').version"
+
+      - name: Run the canary against the scratch pi
+        run: |
+          # The bundle is copied INTO the scratch dir so its bare pi import resolves against
+          # scratch/node_modules -- ESM resolves bare specifiers from the importing file's own
+          # location, which is what keeps the repo's hoisted pin out of the probe entirely. The
+          # canary script re-copies fresh and asserts (a)-(d); see its header for the mechanics.
+          cp admin/dist/index.mjs "$SCRATCH/admin-bundle.mjs"
+          node .github/scripts/admin-pi-canary.mjs "$SCRATCH"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,26 @@ system. pi-dispatch is exactly that missing operational layer, and nothing else:
 ## Quickstart
 
 You need **Docker**, **Node 22.19 or newer**, and a provider API key (Anthropic, OpenAI, and about 30
-others). No clone needed:
+others).
+
+### From pi (the default route)
+
+You already run pi, so let the console do everything:
+
+```bash
+pi install npm:@edgehero/pi-dispatch-admin   # then, inside pi:  /dispatch
+```
+
+With nothing configured, `/dispatch` takes you straight into guided setup: it creates a deployment
+folder, installs the pinned runtime, runs the same consented `up` pass described below in your
+terminal, optionally installs the worker as a service and the receiver as your trigger edge, and lands
+you in the admin panel, with an optional first trigger for the repo you are sitting in. Every step
+shows what it will do, asks first, and can be declined; nothing is written into your repo and no
+credential passes through a dialog.
+
+### Servers and headless
+
+The same setup as plain commands. No clone needed:
 
 ```bash
 mkdir my-dispatch && cd my-dispatch
@@ -110,9 +129,11 @@ pi-dispatch service status    # which unit exists, in which scope, and whether i
 pi-dispatch service restart --drain   # pause, wait until nothing is in flight, restart, resume
 ```
 
-`install` renders the [`deploy/`](deploy/) templates with computed paths and installs without sudo
-(`--system` on Linux prints the sudo commands instead of running them; `--receiver` installs the
-receiver unit). It refuses a second worker unit in another scope: one worker per docker daemon, because
+`install` renders the [`deploy/`](deploy/) templates and installs without sudo (`--system` on Linux
+prints the sudo commands instead of running them; `--receiver` installs the receiver unit when the
+receiver package is installed alongside). Units anchor on your deployment folder: `WorkingDirectory`
+and `.env` point at the folder you run the command from, and the exec paths point at the installed
+package, so the same command is correct from a checkout and from an npm install. It refuses a second worker unit in another scope: one worker per docker daemon, because
 the boot reaper would treat the other's containers as strays. Honesty notes: on macOS and Windows the
 service is login-scoped, because Docker Desktop is; and a policy refusal (exit 2) never relaunches, on
 any OS, so no supervisor loops against a paid provider. The templates remain hand-editable examples if
@@ -134,13 +155,16 @@ pi install npm:@edgehero/pi-dispatch-admin   # then, in pi:  /dispatch
 ```
 
 **No deployment yet? The console builds one.** When `/dispatch` finds nothing (no config, no env, queue
-unreachable) it offers **`/dispatch setup`**: pick a deployment folder, consent to an npm install of the
-pinned runtime, watch `pi-dispatch up` run its own prompts in your terminal, optionally install the
-worker as a service, and land in the panel, with an optional first trigger for the repo you are sitting
-in. Every step shows what it will do and asks first; every step can be declined; nothing is ever written
-into your repo, and no credential passes through a dialog. Setup writes a small **deployment pointer**
-(`~/.pi/agent/pi-dispatch-deployment.json`, paths only, never credentials) so the panel finds the
-deployment from any directory afterwards. Your own env vars always win over it, key by key.
+unreachable) it takes you straight into **`/dispatch setup`**, described in the Quickstart above: an
+opening choice, a deployment folder, the pinned runtime, a Docker check, `pi-dispatch up` in your
+terminal, an optional worker service, an optional trigger edge (receiver service, compose profile, or
+the polling command), and an optional first trigger for this repo. Every step asks first and can be
+declined; nothing is written into your repo, and no credential passes through a dialog. Setup writes a
+small **deployment pointer** (`~/.pi/agent/pi-dispatch-deployment.json`, paths only, never credentials)
+so the panel finds the deployment from any directory afterwards. Your own env vars always win over it,
+key by key, and when the deployed runtime falls behind the console's pin, one notice points you back at
+`/dispatch setup` to upgrade. A configured deployment whose queue is merely down keeps the unreachable
+banner: setup is offered when there is nothing, never over an outage.
 
 Inside the panel: `p`/`r` pause and resume the queue, arrows and `Enter` drill into triggers and runs,
 `a`/`e`/`x` add, edit and delete triggers (validated, atomic, reloaded live by both services), `s` edits
@@ -269,10 +293,12 @@ before one consent, the key lands with mode 0600, and no secret is ever printed.
 strongest auth source (per-repo one-hour tokens); `gh` and fine-grained PATs also work
 (`GITHUB_AUTH_SOURCE`).
 
-**Three ways to run the trigger edge**, pick one:
+**Three ways to run the trigger edge**, pick one (or let `/dispatch setup` walk you through the choice,
+which is what it offers right after the credentials step):
 
 1. **Webhook receiver on the host** (lowest latency): `npx pi-dispatch-receiver` from your deployment
-   folder. Your reverse proxy or tunnel does the public exposure.
+   folder, or `pi-dispatch service install --receiver` to run it as a user-level service. Your reverse
+   proxy or tunnel does the public exposure.
 2. **Webhook receiver in a container**: `docker compose -f deploy/docker-compose.yml --profile receiver
    up -d` runs the prebuilt
    [`ghcr.io/edgehero/pi-dispatch-receiver`](https://github.com/edgehero/pi-dispatch/pkgs/container/pi-dispatch-receiver)

--- a/admin/README.md
+++ b/admin/README.md
@@ -58,7 +58,7 @@ One command puts a live TUI over the whole deployment:
 pi install npm:@edgehero/pi-dispatch-admin   # then, in pi:  /dispatch
 ```
 
-**No deployment yet? The console builds one.** When `/dispatch` finds nothing, it offers `/dispatch setup`: pick a folder, consent to an npm install of the pinned runtime, watch `pi-dispatch up` run its own prompts, optionally install the worker as a service, and land in the panel. Every step asks first and can be declined; nothing is written into your repo and no credential passes through a dialog.
+**This is the default way to set up pi-dispatch.** With nothing configured, `/dispatch` takes you straight into guided setup: an opening choice, a deployment folder, a consented npm install of the pinned runtime, a Docker check with per-OS pointers if it is missing, `pi-dispatch up` running its own prompts in your terminal, an optional worker service, an optional trigger edge (receiver service, docker compose profile, or the polling command), and an optional first trigger for the repo you are sitting in. Every step shows what it will do, asks first, and can be declined; nothing is written into your repo and no credential passes through a dialog. A deployment whose queue is merely down keeps the unreachable banner instead: setup appears when there is nothing, never over an outage.
 
 Already have a deployment? The panel finds it through the deployment pointer setup writes, or through the same env vars your worker uses (`VALKEY_URL`, `PI_LOGS_DIR`, `PI_SETTINGS_FILE`, `PI_TRIGGERS_FILE`, `PI_PAUSE_WINDOWS_FILE`, `PI_SUBSCRIPTIONS_FILE`). Your env always wins.
 

--- a/admin/package.json
+++ b/admin/package.json
@@ -54,7 +54,7 @@
     "ioredis": "5.11.1"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "0.80.7"
+    "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "0.80.7",

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -34,9 +34,11 @@
  * the model how to use those human-in-the-loop write gates.
  *
  * `/dispatch setup` (issue #92) runs the guided deployment wizard (setup-wizard.ts); a bare
- * `/dispatch` on a host with no deployment at all offers it, and a one-time session_start
- * nudge names it on a fresh host. The wizard sequences the worker CLI's own consented
- * commands and writes the deployment pointer this factory applies above.
+ * `/dispatch` on a host with no deployment at all ENTERS it directly -- the wizard's own first
+ * select is the consent -- and a one-time session_start nudge names it on a fresh host. The
+ * wizard sequences the worker CLI's own consented commands and writes the deployment pointer
+ * this factory applies above. A bare `/dispatch` against a POINTED-AT deployment whose installed
+ * runtime differs from the pinned one says so once per process, and names setup as the fix.
  *
  * Tested pi version: 0.80.7 (SUPPORTED_PI_VERSION). The gate is the capability
  * probe, not the version: the factory registers nothing unless every API member
@@ -78,7 +80,14 @@ import {
 // extension at a deployment built in another directory. Layered into process.env once at factory load
 // (the operator's env always wins), so resolvePaths stays env-only by contract while every one of its
 // call sites below is covered without a signature change.
-import { applyDeploymentPointer, takePointerNotice } from "./deployment-pointer.mjs";
+// readPointer/pointerPath join the import for ONE reader: the bare command's version-skew notice, which
+// needs the pointed-at `deploymentDir` to find the deployment's installed runtime. readPointer stays pure
+// (it never stats that dir) -- the stat lives at the call site below, which is exactly where the pointer
+// module's documented purity says it belongs.
+import { applyDeploymentPointer, pointerPath, readPointer, takePointerNotice } from "./deployment-pointer.mjs";
+// The only fs use in this module: the skew notice reads one package.json through the wizard's own reader.
+// Everything else fs-shaped goes through read-model.mjs by design.
+import * as nodeFs from "node:fs";
 import { foldCosts, whatIfFlow } from "./costs.mjs";
 // The REAL pricing façade. costs.mjs may not hold a module-scope worker/pricing import by contract (the
 // fold is pure; tests inject a canned fake) -- index.ts is where the fs-adjacent assembly lives, so the
@@ -123,6 +132,14 @@ export function computePiVersionAdvisory(version: string, supported: string): st
 // the operator already saw.
 let piVersionAdvisory: string | undefined;
 let piVersionCheckDone = false;
+
+/**
+ * The deployment/console skew latch -- piVersionAdvisory's twin, and once per PROCESS for the same
+ * reason: the two versions cannot change under a running pi, so saying it on every bare `/dispatch`
+ * would be nagging, not informing. Set only when the notice actually fires, so a session that never
+ * had skew never burns the latch.
+ */
+let runtimeSkewNoticed = false;
 
 /** TEST-ONLY: arm the advisory directly (under the pinned devDep pi the natural computation is a no-op). */
 export function _setPiVersionAdvisoryForTests(message: string | undefined): void {
@@ -810,23 +827,44 @@ async function dispatch(pi: ExtensionAPI, args: string, ctx: any): Promise<void>
   if (sub === "") {
     // Detection decides what a bare /dispatch means (issue #92). Lazy import: the wizard module loads
     // only on the bare command and `setup`, never for the read subcommands or the LLM tools.
-    const { detectDeployment, runSetupWizard } = await import("./setup-wizard.ts");
+    const { detectDeployment, runSetupWizard, readInstalledVersion, runtimeDirFor, RUNTIME_VERSION } = await import(
+      "./setup-wizard.ts"
+    );
     const det = await detectDeployment({ env: process.env, cwd: ctx?.cwd });
     if (det.state === "none") {
-      // Nothing anywhere: offer the wizard instead of opening a panel onto an empty deployment. The
-      // confirm is the offer -- a decline (or a build without dialogs) degrades to the usage line.
-      if (typeof ctx?.ui?.confirm === "function") {
-        const ok = await ctx.ui.confirm(
-          "pi-dispatch setup",
-          "No deployment found (no pointer, no env, no config here, queue unreachable). Set one up now?",
-        );
-        if (ok) {
-          await runSetupWizard(paths, ctx, notify, { openDashboardFn: openDashboard });
-          return;
-        }
-      }
-      notify?.(`${USAGE} — run /dispatch setup when you are ready`, "info");
+      // Nothing anywhere: the wizard IS what a bare /dispatch means here, so it is entered DIRECTLY.
+      // There used to be a confirm in front of it ("…set one up now?"); it is gone on purpose. The
+      // wizard's own step-1 select -- Guided setup / Open the panel anyway / Cancel -- is the consent,
+      // and it is a better one: it offers the panel as a real third answer instead of dead-ending a
+      // decline at a usage line. A confirm asking permission to ask was one keypress that bought
+      // nothing, and nothing is spawned or written before that select answers.
+      //
+      // The degrade for a ctx without dialogs is the wizard's own capability gate (it notifies once and
+      // returns), so there is deliberately NO notify here: two notices for one degrade reads like two
+      // separate failures. `initialDetection` hands over the verdict just computed -- one keypress must
+      // not cost two detections, queue probe included.
+      await runSetupWizard(paths, ctx, notify, { openDashboardFn: openDashboard, initialDetection: det });
       return;
+    }
+    if (det.state === "pointer" && !runtimeSkewNoticed) {
+      // Version skew between the deployment and this console (issue #96's other half): the pointer names
+      // the folder, the folder's `node_modules` names the runtime version it actually runs, and this
+      // admin pins the version it was reviewed against. Different is worth ONE line -- `/dispatch setup`
+      // converges it, because its install step is a no-op when the pin already matches.
+      //
+      // Absent or unreadable ⇒ SILENCE, deliberately: an operator running the worker straight from a
+      // clone has no `node_modules/@edgehero/pi-dispatch` to read, has made a deliberate choice, and
+      // would be scolded for it every session by a notice that guessed instead of knowing.
+      const ptrRes: any = readPointer({ path: pointerPath(process.env) });
+      const deploymentDir = ptrRes.pointer?.deploymentDir;
+      const installed = deploymentDir ? readInstalledVersion(nodeFs, runtimeDirFor(deploymentDir)) : undefined;
+      if (typeof installed === "string" && installed !== RUNTIME_VERSION) {
+        runtimeSkewNoticed = true;
+        notify?.(
+          `deployment runtime ${installed}, this console pins ${RUNTIME_VERSION} — run /dispatch setup to upgrade`,
+          "warning",
+        );
+      }
     }
     if (det.state === "cwd" || det.state === "reachable") {
       // A deployment that works only from this directory (cwd scaffold) or was merely probed

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -38,11 +38,19 @@
  * nudge names it on a fresh host. The wizard sequences the worker CLI's own consented
  * commands and writes the deployment pointer this factory applies above.
  *
- * Supported pi version: 0.80.7. The factory registers nothing unless every API
- * member it consumes is present; on a miss it names the member and the
- * supported version on stderr and returns.
+ * Tested pi version: 0.80.7 (SUPPORTED_PI_VERSION). The gate is the capability
+ * probe, not the version: the factory registers nothing unless every API member
+ * it consumes is present; on a miss it names the member and the tested version
+ * on stderr and returns. A pi that DIFFERS from the pin but passes the probe
+ * loads normally -- the mismatch becomes a one-line info advisory drained by the
+ * next /dispatch, never a refusal (issue #96: a merely newer pi must not scare
+ * or block anyone).
  */
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+// A VALUE import, deliberately its own line: the type-only line above is regex-anchored by
+// pinned-extension-api.test.mjs and must keep its exact shape. VERSION is the HOST's pi version --
+// build.mjs keeps pi external, so this resolves against whatever pi actually loaded the extension.
+import { VERSION } from "@earendil-works/pi-coding-agent";
 import { fileURLToPath } from "node:url";
 import { Type } from "typebox";
 import {
@@ -93,6 +101,34 @@ export const USED_API = ["registerCommand", "registerTool", "sendMessage", "on"]
 
 export const SUPPORTED_PI_VERSION = "0.80.7";
 
+/**
+ * The advisory for running on a pi that is not the tested pin (issue #96). Pure over its two inputs
+ * so the comparison is unit-testable without faking a pi install. Equal versions mean nothing to
+ * say; pi's own "0.0.0" fallback (config.js: `VERSION = pkg.version || "0.0.0"` when its
+ * package.json is unreadable) means UNKNOWN, not different -- comparing it would report a bogus
+ * mismatch on an install the capability probe already vets for real.
+ */
+export function computePiVersionAdvisory(version: string, supported: string): string | undefined {
+  if (version === supported || version === "0.0.0") return undefined;
+  return (
+    `pi-dispatch admin: running on pi ${version}, tested with pi ${supported} — things should ` +
+    `work; report anything odd, and check for a newer @edgehero/pi-dispatch-admin`
+  );
+}
+
+// The retained advisory, drained once by the next /dispatch (the takePointerNotice idiom). Computed
+// at factory time but NEVER printed there: a successful load is silent, and load.test.mjs pins the
+// refusal path to exactly one stderr line. Memoized like deployment-pointer's appliedOnce -- pi may
+// in principle evaluate the factory more than once, and a re-evaluation must not re-arm an advisory
+// the operator already saw.
+let piVersionAdvisory: string | undefined;
+let piVersionCheckDone = false;
+
+/** TEST-ONLY: arm the advisory directly (under the pinned devDep pi the natural computation is a no-op). */
+export function _setPiVersionAdvisoryForTests(message: string | undefined): void {
+  piVersionAdvisory = message;
+}
+
 const CHANNEL = "pi-dispatch-admin";
 
 const REBUILT_NOTICE = (reason: string) =>
@@ -126,6 +162,15 @@ export default function admin(pi: ExtensionAPI): void {
       );
       return;
     }
+  }
+
+  // The probe above is the gate; the version is only an advisory (issue #96). A pi that differs
+  // from the tested pin yet still carries every consumed member must not scare or block anyone, so
+  // the mismatch is computed here -- after the probe PASSES, so a refused load stays a one-line
+  // no-op -- and surfaced by the next /dispatch, never printed at load.
+  if (!piVersionCheckDone) {
+    piVersionCheckDone = true;
+    piVersionAdvisory = computePiVersionAdvisory(VERSION, SUPPORTED_PI_VERSION);
   }
 
   // Layer the setup wizard's deployment pointer into process.env exactly once, before anything can call
@@ -753,6 +798,14 @@ async function dispatch(pi: ExtensionAPI, args: string, ctx: any): Promise<void>
   // never into model context.
   const pnote = takePointerNotice();
   if (pnote) notify?.(pnote, "warning");
+
+  // Drain the factory's version advisory the same way, once per process -- and at "info", not
+  // "warning": a different-but-capable pi is a heads-up, not a defect (issue #96). Sits before the
+  // sub dispatch below, so every subcommand (and the bare command) passes it.
+  if (piVersionAdvisory) {
+    notify?.(piVersionAdvisory, "info");
+    piVersionAdvisory = undefined;
+  }
 
   if (sub === "") {
     // Detection decides what a bare /dispatch means (issue #92). Lazy import: the wizard module loads

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -5,19 +5,23 @@
  * Division of labor, deliberately: the WORKER's CLI (`up`, `service`, `setup github`) stays the one
  * place host mutations happen -- the wizard only sequences those commands, attached to the operator's
  * terminal, with a confirm in front of each spawn showing the exact command. The wizard's OWN writes
- * are three files, each tame: the deployment dir's private `package.json` (never clobbered), the
- * deployment pointer (via `writePointer`'s validating normalizer), and one appended trigger entry (via
- * the validated, atomic `writeTriggers`). Secrets are never touched: the provider-key step is a notice
- * naming the file, nothing more.
+ * are four files, each tame: the deployment dir's private `package.json` (never clobbered), the
+ * deployment pointer (via `writePointer`'s validating normalizer), one appended trigger entry (via the
+ * validated, atomic `writeTriggers`), and -- only on the compose answer to the trigger-edge step -- a
+ * `docker-compose.yml` COPIED create-only out of the installed runtime's own `deploy/`. Secrets are
+ * never touched: the provider-key step is a notice naming the file, nothing more.
  *
  * Every step is declinable and a decline CONTINUES to the next step (converge-style, like `up` itself):
- * an operator who already ran half the quickstart by hand skips the steps that are done. The only hard
- * stop is the post-install version assertion -- a wrong runtime version poisons every later step, so
- * that failure is loud and final (worker/src/import-pi.mjs:334-341 idiom).
+ * an operator who already ran half the quickstart by hand skips the steps that are done. Two exceptions,
+ * both deliberate: the RUNTIME's post-install version assertion is a hard stop -- a wrong runtime
+ * version poisons every later step, so that failure is loud and final (worker/src/import-pi.mjs:334-341
+ * idiom) -- and the docker pre-check's "Stop" is an operator-chosen early exit taken before anything has
+ * been downloaded. The receiver's own version assertion is NOT a stop: the receiver is optional, so a
+ * bad receiver install skips its unit and the wizard carries on.
  */
 
 import * as nodeFs from "node:fs";
-import { spawn as nodeSpawn } from "node:child_process";
+import { execFileSync, spawn as nodeSpawn } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 // The single source of truth for skill-directory names -- the same regex the worker's flow gate applies
@@ -49,6 +53,20 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * follows in the same change.
  */
 export const RUNTIME_VERSION = "0.1.1";
+
+/**
+ * The `@edgehero/pi-dispatch-receiver` version the trigger-edge step installs -- pinned for exactly the
+ * reasons RUNTIME_VERSION is, and with the same anti-drift test (this literal against the in-repo
+ * `receiver/package.json`), so a receiver release bump cannot land without this line following it in the
+ * same change. Its own literal rather than a reuse of RUNTIME_VERSION: the two packages version
+ * independently (the receiver's dependency range on the runtime is `^`), and pretending otherwise would
+ * install a version that does not exist the first time they diverge.
+ */
+export const RECEIVER_VERSION = "0.1.0";
+
+/** The two npm package names, spelled once. Literals of this module -- see npmInstallArgsFor's argument. */
+const RUNTIME_PKG = "@edgehero/pi-dispatch";
+const RECEIVER_PKG = "@edgehero/pi-dispatch-receiver";
 
 /** The pointer marker file suffix and the four-file cwd scaffold signature, shared by detect + nudge. */
 const NUDGE_MARKER_BASENAME = "pi-dispatch-setup.nudged";
@@ -194,22 +212,25 @@ export async function runAttached(
 }
 
 /**
- * The exact npm argv for installing the pinned runtime. Pure, and NO filesystem path in argv: the
+ * The exact npm argv for installing ONE pinned package. Pure, and NO filesystem path in argv: the
  * install target is the spawn's `cwd`, never a `--prefix <dir>` pair. That absence is what makes
  * `shell: true` safe on win32 (npmSpawnOptions below): argv holds only literal flags spelled out here
- * plus one `name@version` token whose both halves are literals of this module -- no operator-supplied
+ * plus one `name@version` token -- and BOTH halves of that token are literals of this module at every
+ * call site (RUNTIME_PKG/RUNTIME_VERSION, RECEIVER_PKG/RECEIVER_VERSION), so no operator-supplied
  * string can reach the command line as shell syntax (worker/src/import-pi.mjs:400-419 carries the full
- * argument; re-introducing a path here breaks it and must be revisited together with that comment).
+ * argument; passing a caller-shaped name or re-introducing a path here breaks it and must be revisited
+ * together with that comment). The parameters exist so the two packages share one reviewed argv, not so
+ * arbitrary names can be installed.
  *
  * `--ignore-scripts` is load-bearing exactly as in import-pi: without it, lifecycle scripts of the
  * package and every transitive dependency run as the operator at install time. No `--omit=peer` /
  * `--install-strategy=nested` here, deliberately: this is a normal application install resolved by
  * node's own algorithm at run time, not a staged self-contained overlay.
  */
-export function npmInstallArgs(): string[] {
+export function npmInstallArgsFor(pkgName: string, version: string): string[] {
   return [
     "install",
-    `@edgehero/pi-dispatch@${RUNTIME_VERSION}`,
+    `${pkgName}@${version}`,
     "--omit=dev",
     "--omit=optional",
     "--ignore-scripts",
@@ -219,10 +240,119 @@ export function npmInstallArgs(): string[] {
   ];
 }
 
+/** The runtime's own install argv -- the pinned pair applied to the shared shape above. */
+export function npmInstallArgs(): string[] {
+  return npmInstallArgsFor(RUNTIME_PKG, RUNTIME_VERSION);
+}
+
+/** The receiver's install argv, same shape, its own pin (the trigger-edge step's service answer). */
+export function receiverInstallArgs(): string[] {
+  return npmInstallArgsFor(RECEIVER_PKG, RECEIVER_VERSION);
+}
+
+/** How many probes one wizard run will ever make -- the "Re-check" loop's bound (see ensureDocker). */
+const DOCKER_PROBE_ROUNDS = 5;
+
+/** Long enough for a cold Docker Desktop VM to answer, short enough that a wedged socket is not a freeze. */
+const DOCKER_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Is docker usable RIGHT NOW? `docker version` is the cheapest question that reaches the daemon: the
+ * client prints its own version without one, so a zero exit means the CLI exists AND something answered.
+ * DELIBERATELY the same command `up` itself gates on (worker/src/up.mjs:88), so this step and the child
+ * it precedes can never disagree about what "docker is ready" means.
+ * Output is discarded (`stdio: "ignore"`) -- this is a yes/no, and the wizard must not paint docker's
+ * banner over pi's TUI. `exec` is injectable exactly as read-model.mjs:145's revParseHead does it, so
+ * every test drives this without a docker on the box.
+ *
+ * Three outcomes, because they have three different remedies:
+ *   `{ ok: true }`            -- CLI present, daemon answering
+ *   `{ missing: true }`       -- no `docker` binary on PATH at all (spawn ENOENT)
+ *   `{ daemonDown: reason }`  -- the CLI ran and refused: installed, but the daemon/VM is not up
+ * Never throws: an unusable docker is a state to report, not an exception to raise.
+ *
+ * The `timeout` is the one thing this does that revParseHead does not, and it is not decoration: this is
+ * a SYNCHRONOUS exec on the path of a TUI dialog, so a docker CLI wedged on an unresponsive VM socket
+ * would freeze pi's render loop for as long as it hung. A timeout kill lands in the daemonDown branch,
+ * which is exactly the right verdict for it.
+ */
+export function probeDocker(
+  execFn: any = execFileSync,
+): { ok: true } | { missing: true } | { daemonDown: string } {
+  try {
+    execFn("docker", ["version"], { stdio: "ignore", timeout: DOCKER_PROBE_TIMEOUT_MS });
+    return { ok: true };
+  } catch (err: any) {
+    // ENOENT is the spawn failing to find the binary -- which is also exactly what "not on PATH" looks
+    // like, on every platform. A numeric `status` means the binary DID run and exited nonzero.
+    if (err?.code === "ENOENT" || err?.errno === "ENOENT") return { missing: true };
+    if (typeof err?.status === "number") return { daemonDown: `\`docker version\` exited ${err.status}` };
+    return { daemonDown: err?.message ?? String(err) };
+  }
+}
+
+/**
+ * Per-OS pointer text for getting docker running. Vendor instructions ONLY, deliberately never a command
+ * to run and NEVER a piped installer (a download-into-shell one-liner on the operator's own host,
+ * printed by a wizard, is exactly the habit this project refuses to teach): the operator fetches and
+ * verifies their own engine, the same division of labor as the provider-key step.
+ */
+export function dockerHint(platform: string): string {
+  if (platform === "darwin") {
+    return "macOS: install and START Docker Desktop (docs.docker.com/desktop/install/mac-install) or OrbStack (orbstack.dev) — either one provides the `docker` CLI and a running daemon.";
+  }
+  if (platform === "win32") {
+    return "Windows: install and START Docker Desktop (docs.docker.com/desktop/install/windows-install) — it provides the `docker` CLI and a running daemon.";
+  }
+  return "Linux: install the docker engine from your distribution's own packages, following docs.docker.com/engine/install, then start and enable its daemon.";
+}
+
+/**
+ * Step 3's body: docker is the one host prerequisite every later step leans on, so it is asked about
+ * BEFORE anything is downloaded. `up` already refuses on its own when docker is missing (up.mjs:85-95,
+ * the same `docker version` gate) -- this step adds no enforcement, it moves the SAME verdict earlier and
+ * into the wizard's own voice, where it costs the operator no npm install and no child-process output to
+ * read.
+ *
+ * Returns whether to continue. "Re-check" re-probes (bounded: at most DOCKER_PROBE_ROUNDS probes per
+ * run, so a wizard driven by a stuck answer source cannot spin), "Continue anyway" continues, "Stop"
+ * (and a cancelled dialog, and the exhausted bound) returns false having spawned nothing at all.
+ */
+async function ensureDocker(ui: any, notify: Notify, { platform, probeDockerFn }: any): Promise<boolean> {
+  for (let round = 1; ; round++) {
+    const probe = probeDockerFn();
+    if (probe.ok) return true;
+    const why = probe.missing
+      ? "no `docker` on PATH"
+      : `docker is installed but not answering (${probe.daemonDown})`;
+    // The pointer text goes out FIRST, at warning: whatever the operator answers next, the remedy is
+    // already on screen -- and a select's own title is too small a place for an install instruction.
+    notify?.(`docker check: ${why}. ${dockerHint(platform)}`, "warning");
+    if (round >= DOCKER_PROBE_ROUNDS) {
+      notify?.(
+        `docker still not ready after ${DOCKER_PROBE_ROUNDS} checks — stopping setup before anything was installed. Re-run /dispatch setup once \`docker version\` answers.`,
+        "error",
+      );
+      return false;
+    }
+    const choice = await ui.select("Docker is not ready", ["Re-check", "Continue anyway", "Stop"]);
+    if (choice === "Re-check") continue;
+    if (choice === "Continue anyway") {
+      // Deliberately permitted: `up` runs its own docker checks and refuses on its own, so this step is
+      // a BETTER MESSAGE EARLIER, never the enforcement. An operator installing docker in the next
+      // window over -- or driving a daemon this probe cannot see -- must not be locked out by our probe.
+      notify?.("continuing without a docker answer — `up` runs its own docker checks and refuses there if it is still missing", "info");
+      return true;
+    }
+    notify?.("setup stopped before anything was installed — re-run /dispatch setup when docker is ready", "info");
+    return false;
+  }
+}
+
 /**
  * The npm binary + spawn options for one platform. win32 needs BOTH `npm.cmd` and `shell: true`
  * (CVE-2024-27980: Node refuses to spawn a `.cmd` without a shell -- worker/src/import-pi.mjs:400-419),
- * and that is safe here ONLY because npmInstallArgs keeps every path out of argv; everywhere else it is
+ * and that is safe here ONLY because npmInstallArgsFor keeps every path out of argv; everywhere else it is
  * plain `npm` with the target dir as cwd.
  */
 export function npmSpawnOptions(platform: string, dir: string): { bin: string; options: { cwd: string; shell?: true } } {
@@ -247,13 +377,40 @@ export function listRepoSkills(cwd: string, fs: any = nodeFs): string[] {
   }
 }
 
-/** The installed runtime's version inside `dir`, or undefined when absent/unreadable/shapeless. */
-function readInstalledVersion(fs: any, runtimeDir: string): string | undefined {
+/**
+ * Where npm puts one of our packages inside a deployment dir. One spelling for both packages and for
+ * both readers (this module's install assertions and index.ts's skew notice), so "the deployment's
+ * runtime lives HERE" is a fact stated once. Not a path the wizard writes -- npm owns that tree.
+ */
+export function runtimeDirFor(dir: string, pkg: string = "pi-dispatch"): string {
+  return join(dir, "node_modules", "@edgehero", pkg);
+}
+
+/**
+ * The installed version of the package at `runtimeDir`, or undefined when absent/unreadable/shapeless.
+ * Exported because index.ts asks the same question of a POINTED-AT deployment (the skew notice) that the
+ * install steps ask of the one they just built -- and an absent answer must mean the same silence there.
+ */
+export function readInstalledVersion(fs: any, runtimeDir: string): string | undefined {
   try {
     const pkg = JSON.parse(fs.readFileSync(join(runtimeDir, "package.json"), "utf8"));
     return typeof pkg?.version === "string" ? pkg.version : undefined;
   } catch {
     return undefined;
+  }
+}
+
+/**
+ * A private root `package.json` pins npm's idea of "the project" to the deployment dir, so an install run
+ * there cannot walk up into (or read config from) whatever happens to be above it. IF ABSENT only -- the
+ * import-pi.mjs:294 idiom: a file the operator may have edited is never clobbered. BOTH install steps
+ * call it (runtime, receiver), because either one can be the first npm run in a fresh dir -- a receiver
+ * install after a declined runtime install must not be the one that escapes.
+ */
+function ensureDeploymentPackageJson(fs: any, dir: string): void {
+  const rootPkg = join(dir, "package.json");
+  if (!fs.existsSync(rootPkg)) {
+    fs.writeFileSync(rootPkg, `${JSON.stringify({ name: "pi-dispatch-deployment", private: true }, null, 2)}\n`);
   }
 }
 
@@ -265,9 +422,10 @@ const CRON_ID_RE = /^[A-Za-z0-9._-]+$/;
  * sequence offline with recording fakes; production passes only `openDashboardFn` (index.ts's own
  * dashboard opener -- handed in rather than imported to keep the module cycle call-time-only).
  *
- * Steps (each declinable; a decline continues): (1) detect + intent, (2) deployment dir, (3) pinned
- * npm install with post-install version assertion, (4) `up`, (5) deployment pointer, (6) provider-key
- * notice, (7) worker service, (8) github credentials, (9) first cron trigger for ctx.cwd, (10)
+ * Steps (each declinable; a decline continues): (1) detect + intent, (2) deployment dir, (3) docker
+ * pre-check, (4) pinned npm install with post-install version assertion, (5) `up`, (6) deployment
+ * pointer, (7) provider-key notice, (8) worker service, (9) github credentials, (10) the trigger edge
+ * (receiver unit / receiver container / polling command), (11) first cron trigger for ctx.cwd, (12)
  * re-detect + open the panel.
  */
 export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps: any = {}): Promise<void> {
@@ -286,6 +444,8 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
     resolvePathsFn = resolvePaths,
     listRepoSkillsFn = listRepoSkills,
     existsSyncFn = (p: string) => fs.existsSync(p),
+    probeDockerFn = probeDocker,
+    initialDetection,
   } = deps;
   const ui = ctx?.ui;
 
@@ -297,7 +457,12 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
   }
 
   // ── (1) detection + intent ─────────────────────────────────────────────────────────────────────
-  const det = await detectFn({ env, cwd: ctx?.cwd, fs });
+  // `initialDetection` is the caller's ALREADY-COMPUTED verdict, reused rather than recomputed: a bare
+  // `/dispatch` detects to decide that this host has nothing configured and then enters the wizard
+  // directly, and one keypress must not cost two detections -- the second would repeat the queue probe
+  // (a network round-trip) to re-derive an answer the caller is handing over. Absent it (the `/dispatch
+  // setup` path, and every test that wants the seam), the wizard detects for itself as before.
+  const det = initialDetection ?? (await detectFn({ env, cwd: ctx?.cwd, fs }));
   notify?.(`pi-dispatch setup — detected: ${det.detail}`, "info");
   const intent = await ui.select("pi-dispatch setup", ["Guided setup", "Open the panel anyway", "Cancel"]);
   if (intent === "Open the panel anyway") {
@@ -320,10 +485,16 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
     notify?.(`could not create ${dir}: ${err?.message ?? err} — setup cannot continue`, "error");
     return;
   }
-  const runtimeDir = join(dir, "node_modules", "@edgehero", "pi-dispatch");
+  const runtimeDir = runtimeDirFor(dir);
   const cliPath = join(runtimeDir, "src", "cli.mjs");
 
-  // ── (3) install the pinned runtime ─────────────────────────────────────────────────────────────
+  // ── (3) docker: the one host prerequisite, asked about before anything is downloaded ───────────
+  // Placed AFTER the dir step (so a Stop here still leaves the operator's chosen dir created and named,
+  // which is harmless and idempotent) and BEFORE the install: the point is to spend nobody's bandwidth
+  // on a host where `up` cannot work anyway.
+  if (!(await ensureDocker(ui, notify, { platform, probeDockerFn }))) return;
+
+  // ── (4) install the pinned runtime ─────────────────────────────────────────────────────────────
   if (readInstalledVersion(fs, runtimeDir) === RUNTIME_VERSION) {
     // Convergence, said out loud: a re-run of the wizard must not re-download a runtime that is
     // already the pinned version -- and must SAY it skipped, so the operator is not left wondering.
@@ -338,13 +509,7 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
     if (!okInstall) {
       notify?.(`install skipped — later steps assume the runtime at ${runtimeDir}`, "info");
     } else {
-      // A private root package.json pins npm's idea of "the project" to the deployment dir, so the
-      // install cannot walk up into (or read config from) whatever happens to be above it. IF ABSENT
-      // only -- the import-pi.mjs:294 idiom: a file the operator may have edited is never clobbered.
-      const rootPkg = join(dir, "package.json");
-      if (!fs.existsSync(rootPkg)) {
-        fs.writeFileSync(rootPkg, `${JSON.stringify({ name: "pi-dispatch-deployment", private: true }, null, 2)}\n`);
-      }
+      ensureDeploymentPackageJson(fs, dir);
       const res = await runAttachedFn(ctx, {
         title: `npm install @edgehero/pi-dispatch@${RUNTIME_VERSION} — in ${dir}`,
         argv0: bin,
@@ -370,7 +535,7 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
     }
   }
 
-  // ── (4) up: image, Valkey, init, doctor — the worker's own consented pass ──────────────────────
+  // ── (5) up: image, Valkey, init, doctor — the worker's own consented pass ──────────────────────
   // NEVER `--yes`: up's per-mutation y/N prompts ARE the host-mutation consents (docker pull, docker
   // run). The wizard's confirm approves STARTING the pass; auto-accepting the child's gates would
   // collapse per-action consent into one blanket yes the operator never gave.
@@ -397,7 +562,7 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
     }
   }
 
-  // ── (5) the deployment pointer ─────────────────────────────────────────────────────────────────
+  // ── (6) the deployment pointer ─────────────────────────────────────────────────────────────────
   // Only the three cwd-default files need pointing: resolvePaths defaults them to "./" (right only
   // when pi runs FROM the deployment dir), while logsDir/settingsFile default to absolute OS-temp
   // locations and VALKEY_URL's default already matches the container up starts. Absolute paths by
@@ -429,7 +594,7 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
     }
   }
 
-  // ── (6) provider key: notice only, never-tier ──────────────────────────────────────────────────
+  // ── (7) provider key: notice only, never-tier ──────────────────────────────────────────────────
   // Deliberately NO dialog and NO write: a secret must never transit a wizard dialog (dialog text is
   // not a credential channel) nor a wizard-written file. The operator edits the named file themselves,
   // or leans on the already-logged-into-pi fallback the worker honours.
@@ -438,7 +603,7 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
     "info",
   );
 
-  // ── (7) the worker ─────────────────────────────────────────────────────────────────────────────
+  // ── (8) the worker ─────────────────────────────────────────────────────────────────────────────
   const workerChoice = await ui.select("Run the worker", [
     "Install as an OS service (user-level)",
     "I'll run it myself",
@@ -457,7 +622,7 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
     notify?.(`run: node ${cliPath} worker  (in ${dir}; keep it running — its own terminal, tmux, …)`, "info");
   }
 
-  // ── (8) github credentials (optional) ──────────────────────────────────────────────────────────
+  // ── (9) github credentials (optional) ──────────────────────────────────────────────────────────
   // Phrased so declining is obviously fine: local cron triggers -- the first-trigger step right below
   // -- need none of this, and the command is named for later.
   const okGithub = await ui.confirm(
@@ -476,14 +641,20 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
     notify?.(`later: node ${cliPath} setup github  (in ${dir})`, "info");
   }
 
-  // ── (9) a first trigger for the repo pi is sitting in ──────────────────────────────────────────
+  // ── (10) the trigger edge: how a forge event actually reaches the queue ─────────────────────────
+  // Credentials (step 9) mint the App; they do not make a delivery arrive. This step closes that gap,
+  // which was previously left to the README: a receiver UNIT, a receiver CONTAINER, or polling (no
+  // public URL at all). Every answer -- including Skip -- continues to the next step.
+  await offerTriggerEdge(dir, ctx, ui, notify, { fs, platform, env, execPath, cliPath, runAttachedFn });
+
+  // ── (11) a first trigger for the repo pi is sitting in ──────────────────────────────────────────
   // Offered only when ctx.cwd names an existing directory: the trigger's folder is the one hard
   // precondition (the worker refuses a missing run.folder at load), so no folder, no offer.
   if (typeof ctx?.cwd === "string" && ctx.cwd !== "" && existsSyncFn(ctx.cwd)) {
     await offerFirstTrigger(ctx.cwd, dir, ui, notify, { fs, listRepoSkillsFn, writeTriggersFn });
   }
 
-  // ── (10) re-detect + open the panel ────────────────────────────────────────────────────────────
+  // ── (12) re-detect + open the panel ────────────────────────────────────────────────────────────
   const finalDet = await detectFn({ env, cwd: ctx?.cwd, fs });
   notify?.(`setup finished — ${finalDet.detail}`, "info");
   if (typeof openDashboardFn === "function") {
@@ -493,10 +664,150 @@ export async function runSetupWizard(paths: any, ctx: any, notify: Notify, deps:
   }
 }
 
+/** The four trigger-edge answers, spelled once so the flow below and its tests read the same strings. */
+const EDGE_SERVICE = "Install the webhook receiver as a service";
+const EDGE_COMPOSE = "Run the receiver with docker compose";
+const EDGE_POLL = "Show the polling command";
+
 /**
- * Step 9's body: pick a flow (the repo's own skills first, free text as the escape), then id/pattern/
+ * Step 10's body: the trigger EDGE. A GitHub App with credentials still delivers nowhere until something
+ * is listening (or asking), and until now the wizard stopped one step short of that -- so an operator who
+ * accepted every offer still had a deployment no label could reach. The three real shapes, in the order
+ * they cost:
+ *
+ *   - a receiver SERVICE on this host: the pinned receiver package plus `service install --receiver`.
+ *     Correct only since the unit renderer started anchoring on the deployment folder and resolving the
+ *     receiver's own `./start` export from there (the `service` fix that ships alongside this step);
+ *     before it, a unit installed here would have pointed at a guessed repo root.
+ *   - a receiver CONTAINER via the runtime's own shipped compose file and its opt-in `receiver` profile.
+ *   - POLLING: no inbound delivery at all, so no public URL, DNS or tunnel -- printed, never started,
+ *     because a poller belongs in a supervisor the operator chose, not in a wizard's child process.
+ *
+ * Declining or skipping is fine and says so: local cron triggers need none of this.
+ */
+async function offerTriggerEdge(
+  dir: string,
+  ctx: any,
+  ui: any,
+  notify: Notify,
+  { fs, platform, env, execPath, cliPath, runAttachedFn }: any,
+): Promise<void> {
+  const choice = await ui.select("How should GitHub events reach the queue?", [
+    EDGE_SERVICE,
+    EDGE_COMPOSE,
+    EDGE_POLL,
+    "Skip",
+  ]);
+
+  if (choice === EDGE_SERVICE) {
+    const args = receiverInstallArgs();
+    const { bin, options } = npmSpawnOptions(platform, dir);
+    const unitHint = `node ${cliPath} service install --receiver  (in ${dir})`;
+    const ok = await ui.confirm(
+      "Install the webhook receiver",
+      `Run in ${dir}:\n  ${bin} ${args.join(" ")}\n\nthen, in the same folder:\n  ${execPath} ${cliPath} service install --receiver\n\n(scripts disabled; installs the pinned ${RECEIVER_PKG}@${RECEIVER_VERSION}, then renders a user-level receiver unit for this host)`,
+    );
+    if (!ok) {
+      notify?.(`receiver skipped — later: ${bin} ${args.join(" ")}  (in ${dir}), then ${unitHint}`, "info");
+      return;
+    }
+    // Same project pin as the runtime install: this may be the FIRST npm run in this dir (the operator
+    // could have declined step 4 and installed the runtime by hand).
+    ensureDeploymentPackageJson(fs, dir);
+    const res = await runAttachedFn(ctx, {
+      title: `npm install ${RECEIVER_PKG}@${RECEIVER_VERSION} — in ${dir}`,
+      argv0: bin,
+      args,
+      cwd: options.cwd,
+      shell: options.shell,
+      env,
+    });
+    // The same artifact-not-exit-code assertion the runtime install makes -- but NOT a hard stop. The
+    // receiver is optional: a deployment whose cron triggers work is still a working deployment, so a
+    // bad receiver install costs the operator this step and nothing else. What it must never do is
+    // install a UNIT pointing at a package that is absent or the wrong version -- `service install`
+    // would either refuse (commit 1's loud hint) or pin a boot-time failure into launchd/systemd.
+    const installed = readInstalledVersion(fs, runtimeDirFor(dir, "pi-dispatch-receiver"));
+    if (installed !== RECEIVER_VERSION) {
+      const how = res?.error ? `npm could not run: ${res.error.message}` : `npm exited ${res?.code}`;
+      notify?.(
+        `${how}; installed receiver version is ${installed ?? "(absent)"}, not the pinned ${RECEIVER_VERSION} — skipping the receiver unit (the rest of the deployment is unaffected). Fix the install, then run: ${unitHint}`,
+        "error",
+      );
+      return;
+    }
+    await runAttachedFn(ctx, {
+      title: `pi-dispatch service install --receiver — in ${dir}`,
+      argv0: execPath,
+      args: [cliPath, "service", "install", "--receiver"],
+      cwd: dir,
+      env,
+    });
+    return;
+  }
+
+  if (choice === EDGE_COMPOSE) {
+    // The compose file the RUNTIME ships (worker/deploy/docker-compose.yml, published in its `files`),
+    // copied beside the deployment's own config so `-f` names a stable path the operator can edit and
+    // keep. CREATE-ONLY, the import-pi.mjs:294 idiom the root package.json already follows: an operator
+    // who tuned their compose file must never lose it to a re-run of the wizard.
+    const src = join(runtimeDirFor(dir), "deploy", "docker-compose.yml");
+    const dest = join(dir, "docker-compose.yml");
+    if (fs.existsSync(dest)) {
+      notify?.(`${dest} already exists — keeping yours as it is (setup never overwrites a compose file you may have edited)`, "info");
+    } else {
+      try {
+        fs.copyFileSync(src, dest);
+        notify?.(`copied the runtime's compose file to ${dest}`, "info");
+      } catch (err: any) {
+        notify?.(
+          `could not copy ${src}: ${err?.message ?? err} — the receiver profile needs that file; skipping this step (install the runtime first, or copy it by hand)`,
+          "error",
+        );
+        return;
+      }
+    }
+    // `--profile receiver` is what makes the receiver container OPT-IN: the same compose file's plain
+    // `up` is Valkey-only, which is what a worker-on-host deployment wants.
+    const args = ["compose", "-f", dest, "--profile", "receiver", "up", "-d"];
+    const ok = await ui.confirm(
+      "Start the receiver container",
+      `Run in ${dir}:\n  docker ${args.join(" ")}\n\nthe receiver profile reads ${join(dir, ".env")} — WEBHOOK_SECRET and the forge credentials must be in there, or the container refuses to boot.`,
+    );
+    if (!ok) {
+      notify?.(`later: docker ${args.join(" ")}  (in ${dir})`, "info");
+      return;
+    }
+    await runAttachedFn(ctx, {
+      title: `docker compose --profile receiver up -d — in ${dir}`,
+      argv0: "docker",
+      args,
+      cwd: dir,
+      env,
+    });
+    return;
+  }
+
+  if (choice === EDGE_POLL) {
+    // Print-only by design: `poll` is a long-running producer, and starting it inside the wizard's
+    // attached overlay would tie the operator's whole session to it. Both commands, in order.
+    notify?.(
+      `polling needs no public URL, no DNS and no tunnel — two commands, in ${dir}:\n  1) node ${cliPath} setup github --no-webhook   (mints the App with its webhook INACTIVE — the polling-ready shape)\n  2) npx pi-dispatch-receiver poll   (the producer; run it from the deployment folder, under whatever keeps it alive)`,
+      "info",
+    );
+    return;
+  }
+
+  notify?.(
+    `trigger edge left for later — all three ways stay open from ${dir}: \`service install --receiver\` (a receiver unit on this host), \`docker compose --profile receiver up -d\` (a receiver container), or \`pi-dispatch-receiver poll\` (no public URL at all). Local cron triggers need none of them.`,
+    "info",
+  );
+}
+
+/**
+ * Step 11's body: pick a flow (the repo's own skills first, free text as the escape), then id/pattern/
  * task with the same defaults the add-trigger dialog uses, then write ONE cron entry -- into the
- * DEPLOYMENT dir's triggers.json, deliberately not `paths.triggersPath`: the pointer written in step 5
+ * DEPLOYMENT dir's triggers.json, deliberately not `paths.triggersPath`: the pointer written in step 6
  * aims the panel (and the worker's init scaffold) at the deployment dir, and a trigger written to
  * wherever the pre-wizard env happened to point would land in a file the new deployment never reads.
  * Any cancel or invalid answer skips the step; the wizard continues.

--- a/admin/test/setup-wizard.test.mjs
+++ b/admin/test/setup-wizard.test.mjs
@@ -56,7 +56,13 @@ function wizardUi({ select = [], input = [], confirm = [] } = {}) {
   return { ui, notes, seen };
 }
 
-/** Common recording deps for the step engine; every host-touching seam is a fake that records. */
+/**
+ * Common recording deps for the step engine; every host-touching seam is a fake that records.
+ *
+ * `probeDockerFn` defaults to a green answer for the same reason detectFn is canned: the docker
+ * pre-check (step 3) would otherwise exec a REAL `docker version` on whatever box runs the suite, which
+ * is neither offline nor deterministic. The docker step's own tests override it.
+ */
 function wizardDeps(overrides = {}) {
   const attached = [];
   const pointerWrites = [];
@@ -68,6 +74,7 @@ function wizardDeps(overrides = {}) {
     execPath: "/usr/bin/node-under-test",
     homedirFn: () => mkdtempSync(join(tmpdir(), "admin-setup-home-")),
     detectFn: async () => ({ state: "none", detail: "canned detection" }),
+    probeDockerFn: () => ({ ok: true }),
     runAttachedFn: async (_ctx, opts) => {
       attached.push(opts);
       return { code: 0 };
@@ -257,17 +264,116 @@ test("npmInstallArgs: the exact pinned, script-less argv with no filesystem path
   assert.ok(!args.some((a) => a.includes("--prefix")), "the install target is the spawn cwd, never a --prefix path");
 });
 
+test("npmInstallArgsFor: the SAME pinned, path-free argv for both packages, wrappers included", () => {
+  // The generalization must not weaken the win32 `shell: true` argument for EITHER package: the whole
+  // safety rests on argv carrying no filesystem path and one `name@version` token of module literals.
+  assert.deepEqual(
+    mod.npmInstallArgs(),
+    mod.npmInstallArgsFor("@edgehero/pi-dispatch", mod.RUNTIME_VERSION),
+    "the runtime wrapper is exactly the shared shape applied to its pin",
+  );
+  assert.deepEqual(
+    mod.receiverInstallArgs(),
+    mod.npmInstallArgsFor("@edgehero/pi-dispatch-receiver", mod.RECEIVER_VERSION),
+    "and so is the receiver's",
+  );
+  assert.equal(mod.receiverInstallArgs()[1], `@edgehero/pi-dispatch-receiver@${mod.RECEIVER_VERSION}`);
+  for (const args of [mod.npmInstallArgs(), mod.receiverInstallArgs()]) {
+    assert.equal(args[0], "install");
+    for (const flag of ["--omit=dev", "--omit=optional", "--ignore-scripts", "--no-audit", "--no-fund", "--loglevel=error"]) {
+      assert.ok(args.includes(flag), `${flag} survives for ${args[1]}`);
+    }
+    for (const a of args) {
+      assert.ok(!a.startsWith("/") && !a.startsWith(".") && !a.startsWith("\\"), `no path token in argv: ${a}`);
+      assert.ok(!a.includes("\\"), `no backslash in argv: ${a}`);
+    }
+    assert.ok(!args.some((a) => a.includes("--prefix")), "the install target is the spawn cwd, never a --prefix path");
+  }
+});
+
 test("npmSpawnOptions: npm.cmd + shell on win32, plain npm elsewhere, cwd is the deployment dir", () => {
   assert.deepEqual(mod.npmSpawnOptions("win32", "C:\\deploy"), { bin: "npm.cmd", options: { cwd: "C:\\deploy", shell: true } });
   assert.deepEqual(mod.npmSpawnOptions("linux", "/deploy"), { bin: "npm", options: { cwd: "/deploy" } });
   assert.deepEqual(mod.npmSpawnOptions("darwin", "/deploy"), { bin: "npm", options: { cwd: "/deploy" } });
 });
 
-// ── RUNTIME_VERSION anti-drift ───────────────────────────────────────────────────────────────────
+test("runtimeDirFor + readInstalledVersion: one spelling for both packages; absent/garbage is undefined", () => {
+  const dir = emptyDir();
+  assert.equal(mod.runtimeDirFor(dir), join(dir, "node_modules", "@edgehero", "pi-dispatch"), "the runtime is the default");
+  assert.equal(mod.runtimeDirFor(dir, "pi-dispatch-receiver"), join(dir, "node_modules", "@edgehero", "pi-dispatch-receiver"));
+  assert.equal(mod.readInstalledVersion(realFs, mod.runtimeDirFor(dir)), undefined, "absent reads undefined, never throws");
+  plantRuntime(dir, "0.0.9");
+  assert.equal(mod.readInstalledVersion(realFs, mod.runtimeDirFor(dir)), "0.0.9");
+  writeFileSync(join(mod.runtimeDirFor(dir), "package.json"), "{ not json");
+  assert.equal(mod.readInstalledVersion(realFs, mod.runtimeDirFor(dir)), undefined, "unparseable is undefined too — the skew notice's silence");
+});
+
+// ── the docker probe: three outcomes, three remedies ─────────────────────────────────────────────
+
+test("probeDocker: asks `docker version` with output discarded and sorts the two failure kinds", () => {
+  const calls = [];
+  assert.deepEqual(
+    mod.probeDocker((bin, args, opts) => {
+      calls.push([bin, args, opts]);
+      return "";
+    }),
+    { ok: true },
+  );
+  // The timeout is load-bearing: this is a SYNC exec on a dialog path, so a wedged docker socket must
+  // not be able to freeze pi's render loop.
+  assert.deepEqual(
+    calls,
+    [["docker", ["version"], { stdio: "ignore", timeout: 10_000 }]],
+    "the cheapest question, output discarded, bounded in time",
+  );
+
+  const killed = mod.probeDocker(() => {
+    throw Object.assign(new Error("spawnSync docker ETIMEDOUT"), { killed: true, signal: "SIGTERM" });
+  });
+  assert.match(killed.daemonDown, /ETIMEDOUT/, "a timeout kill is 'installed but not answering', not 'missing'");
+
+  const missing = mod.probeDocker(() => {
+    throw Object.assign(new Error("spawnSync docker ENOENT"), { code: "ENOENT" });
+  });
+  assert.deepEqual(missing, { missing: true }, "no binary on PATH");
+
+  const down = mod.probeDocker(() => {
+    throw Object.assign(new Error("Cannot connect to the Docker daemon"), { status: 1 });
+  });
+  assert.match(down.daemonDown, /exited 1/, "the CLI ran and refused: installed, daemon not up");
+
+  const odd = mod.probeDocker(() => {
+    throw new Error("something else entirely");
+  });
+  assert.match(odd.daemonDown, /something else entirely/, "an unclassifiable failure is still a state, never a throw");
+});
+
+test("dockerHint: per-OS vendor instructions, and NEVER a piped installer command", () => {
+  assert.match(mod.dockerHint("darwin"), /Docker Desktop/);
+  assert.match(mod.dockerHint("darwin"), /orbstack/i, "macOS gets the OrbStack alternative too");
+  assert.match(mod.dockerHint("win32"), /Docker Desktop/);
+  assert.match(mod.dockerHint("linux"), /docs\.docker\.com\/engine\/install/, "linux points at the distro-package docs");
+  for (const platform of ["darwin", "win32", "linux", "freebsd"]) {
+    const hint = mod.dockerHint(platform);
+    assert.ok(hint.length > 0, `${platform} still gets text (unknown platforms fall back)`);
+    assert.ok(
+      !/curl|wget|\|\s*(ba)?sh\b|Invoke-WebRequest|\biwr\b/i.test(hint),
+      `a wizard must never print a piped installer: ${hint}`,
+    );
+  }
+});
+
+// ── RUNTIME_VERSION / RECEIVER_VERSION anti-drift ────────────────────────────────────────────────
 
 test("RUNTIME_VERSION matches the in-repo worker/package.json version (release bumps stay atomic)", () => {
   const workerPkg = JSON.parse(readFileSync(fileURLToPath(new URL("../../worker/package.json", import.meta.url)), "utf8"));
   assert.equal(mod.RUNTIME_VERSION, workerPkg.version);
+});
+
+test("RECEIVER_VERSION matches the in-repo receiver/package.json version (same atomic-bump bolt)", () => {
+  const receiverPkg = JSON.parse(readFileSync(fileURLToPath(new URL("../../receiver/package.json", import.meta.url)), "utf8"));
+  assert.equal(mod.RECEIVER_VERSION, receiverPkg.version);
+  assert.equal(receiverPkg.name, "@edgehero/pi-dispatch-receiver", "and the package name the argv pins");
 });
 
 // ── runAttached: the suspend/spawn/restore bracket ───────────────────────────────────────────────
@@ -372,10 +478,123 @@ test("wizard: 'Open the panel anyway' short-circuits to the dashboard with the o
   assert.equal(seen.input.length, 0, "no later step ran");
 });
 
+test("wizard: initialDetection is honored — the caller's verdict is never re-detected", async () => {
+  // The bare-/dispatch caller detected already; one keypress must not cost two detections (queue probe
+  // included). detectFn THROWS here, so a re-detect fails the test instead of quietly costing a probe.
+  const { ui, notes } = wizardUi({ select: ["Cancel"] });
+  const { deps } = wizardDeps({
+    detectFn: async () => {
+      throw new Error("the wizard re-detected instead of using initialDetection");
+    },
+    initialDetection: { state: "none", detail: "handed over by the caller" },
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.ok(notes.some((n) => /handed over by the caller/.test(n.m)), "the handed-over detail is what the operator reads");
+});
+
+// ── the docker pre-check (step 3) ─────────────────────────────────────────────────────────────────
+
+test("wizard: a green docker pre-check asks nothing and says nothing", async () => {
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  let probes = 0;
+  const { ui, notes, seen } = wizardUi({
+    select: ["Guided setup", "Skip", "Skip"], // intent, worker, trigger edge
+    input: [dir],
+    confirm: [false, false, false], // up, pointer, github — all declined
+  });
+  const { deps } = wizardDeps({
+    probeDockerFn: () => {
+      probes++;
+      return { ok: true };
+    },
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.equal(probes, 1, "probed exactly once");
+  assert.ok(!seen.select.some((s) => /Docker/.test(s.title)), "a healthy host is never asked about docker");
+  // No noise from THIS step (the later trigger-edge notice legitimately names `docker compose`).
+  assert.ok(
+    !notes.some((n) => /docker check|Docker is not ready|without a docker answer/.test(n.m)),
+    "a green probe says nothing at all",
+  );
+});
+
+test("wizard: a missing docker notifies the per-OS pointer text; 'Continue anyway' still installs", async () => {
+  const dir = emptyDir();
+  const { ui, notes, seen } = wizardUi({
+    select: ["Guided setup", "Continue anyway", "Skip", "Skip"], // intent, DOCKER GATE, worker, trigger edge
+    input: [dir],
+    confirm: [true, false, false, false], // install ACCEPTED, up/pointer/github declined
+  });
+  const { deps, attached } = wizardDeps({
+    platform: "darwin",
+    probeDockerFn: () => ({ missing: true }),
+    runAttachedFn: async (_ctx, opts) => {
+      attached.push(opts);
+      plantRuntime(dir, mod.RUNTIME_VERSION);
+      return { code: 0 };
+    },
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  const gate = seen.select.find((s) => /Docker is not ready/.test(s.title));
+  assert.deepEqual(gate.options, ["Re-check", "Continue anyway", "Stop"]);
+  const warned = notes.find((n) => /docker check/.test(n.m));
+  assert.equal(warned.t, "warning", "the remedy is on screen before the question is answered");
+  assert.match(warned.m, /no `docker` on PATH/);
+  assert.match(warned.m, /Docker Desktop/, "the macOS pointer text, per the injected platform");
+  assert.ok(!/curl|wget/i.test(warned.m), "never a piped installer");
+  // "Continue anyway" is not enforcement-by-our-probe: up runs its own docker checks and refuses there.
+  assert.equal(attached.length, 1, "the install step still ran");
+  assert.deepEqual(attached[0].args, mod.npmInstallArgs());
+});
+
+test("wizard: 'Stop' at the docker gate ends the wizard having spawned nothing", async () => {
+  const dir = emptyDir();
+  const { ui, notes, seen } = wizardUi({
+    select: ["Guided setup", "Stop"], // intent, DOCKER GATE
+    input: [dir],
+    confirm: [], // no consent gate is ever reached
+  });
+  const { deps, attached, pointerWrites, dashboards } = wizardDeps({
+    platform: "linux",
+    probeDockerFn: () => ({ daemonDown: "`docker version` exited 1" }),
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.equal(attached.length, 0, "nothing spawned");
+  assert.equal(pointerWrites.length, 0, "nothing written");
+  assert.equal(seen.confirm.length, 0, "no consent gate was reached");
+  assert.equal(dashboards.length, 0, "and no panel — a Stop is a stop");
+  assert.ok(notes.some((n) => /not answering/.test(n.m) && /docs\.docker\.com\/engine\/install/.test(n.m)), "the linux pointer text");
+  assert.ok(notes.some((n) => /stopped before anything was installed/.test(n.m)), "and says nothing was installed");
+});
+
+test("wizard: 'Re-check' re-probes, bounded — five probes, then it stops like Stop", async () => {
+  const dir = emptyDir();
+  let probes = 0;
+  const { ui, notes, seen } = wizardUi({
+    // One more Re-check than the bound can consume: the cap, not the answer source, must end this.
+    select: ["Guided setup", "Re-check", "Re-check", "Re-check", "Re-check", "Re-check"], // intent, then five Re-checks
+    input: [dir],
+    confirm: [], // no consent gate is ever reached
+  });
+  const { deps, attached, dashboards } = wizardDeps({
+    probeDockerFn: () => {
+      probes++;
+      return { missing: true };
+    },
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui), ui.notify, deps);
+  assert.equal(probes, 5, "bounded at five probes — a stuck answer source cannot spin the wizard");
+  assert.equal(seen.select.filter((s) => /Docker is not ready/.test(s.title)).length, 4, "four gates for five probes");
+  assert.equal(attached.length, 0, "nothing was ever spawned");
+  assert.equal(dashboards.length, 0);
+  assert.ok(notes.some((n) => n.t === "error" && /still not ready after 5 checks/.test(n.m)), "the exhausted bound is said out loud");
+});
+
 test("wizard: declined confirms spawn NOTHING, and every step is still offered", async () => {
   const dir = emptyDir();
   const { ui, notes, seen } = wizardUi({
-    select: ["Guided setup", "Skip"],
+    select: ["Guided setup", "Skip", "Skip"], // intent, worker, trigger edge
     input: [dir],
     confirm: [false, false, false, false], // install, up, pointer, github -- all declined
   });
@@ -384,7 +603,7 @@ test("wizard: declined confirms spawn NOTHING, and every step is still offered",
   assert.equal(attached.length, 0, "a declined confirm never reaches a spawn");
   assert.equal(pointerWrites.length, 0, "a declined pointer confirm writes nothing");
   assert.equal(seen.confirm.length, 4, "all four consent gates were offered despite the declines");
-  assert.equal(seen.select.length, 2, "intent + worker choice");
+  assert.equal(seen.select.length, 3, "intent + worker choice + trigger edge");
   assert.ok(notes.some((n) => /provider key/.test(n.m)), "the never-tier provider-key notice still fires");
   assert.ok(notes.some((n) => /setup finished/.test(n.m)));
   assert.equal(dashboards.length, 1, "the wizard still ends at the panel");
@@ -395,9 +614,9 @@ test("wizard: an accepted install spawns the exact npm shape and never clobbers 
   const dir = emptyDir();
   writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "custom-root" }));
   const { ui, seen } = wizardUi({
-    select: ["Guided setup", "Skip"],
+    select: ["Guided setup", "Skip", "Skip"], // intent, worker, trigger edge
     input: [dir],
-    confirm: [true, false, false, false],
+    confirm: [true, false, false, false], // install ACCEPTED, up, pointer, github declined
   });
   const { deps, attached, dashboards } = wizardDeps({
     runAttachedFn: async (_ctx, opts) => {
@@ -421,7 +640,7 @@ test("wizard: an accepted install spawns the exact npm shape and never clobbers 
 test("wizard: a post-install version mismatch stops the wizard loudly — no later step runs", async () => {
   const dir = emptyDir();
   const { ui, notes, seen } = wizardUi({
-    select: ["Guided setup"],
+    select: ["Guided setup"], // intent only — the mismatch below stops the wizard
     input: [dir],
     confirm: [true], // accept the install; nothing later should be asked
   });
@@ -445,7 +664,7 @@ test("wizard: an already-pinned runtime skips the install silently-but-said", as
   const dir = emptyDir();
   plantRuntime(dir, mod.RUNTIME_VERSION);
   const { ui, notes, seen } = wizardUi({
-    select: ["Guided setup", "Skip"],
+    select: ["Guided setup", "Skip", "Skip"], // intent, worker, trigger edge
     input: [dir],
     confirm: [false, false, false], // up, pointer, github — no install confirm expected
   });
@@ -460,7 +679,7 @@ test("wizard: up runs without --yes; a nonzero exit gates on Continue/Stop, and 
   const dir = emptyDir();
   plantRuntime(dir, mod.RUNTIME_VERSION);
   const { ui, seen } = wizardUi({
-    select: ["Guided setup", "Stop"],
+    select: ["Guided setup", "Stop"], // intent, then the up-failure gate
     input: [dir],
     confirm: [true], // accept up; it fails; Stop
   });
@@ -484,7 +703,7 @@ test("wizard: a failed up with 'Continue anyway' proceeds to the pointer step", 
   const dir = emptyDir();
   plantRuntime(dir, mod.RUNTIME_VERSION);
   const { ui, seen } = wizardUi({
-    select: ["Guided setup", "Continue anyway", "Skip"],
+    select: ["Guided setup", "Continue anyway", "Skip", "Skip"], // intent, up-failure gate, worker, trigger edge
     input: [dir],
     confirm: [true, false, false], // up (fails), pointer declined, github declined
   });
@@ -500,7 +719,7 @@ test("wizard: the pointer is written only after a confirm showing the JSON verba
   const dir = emptyDir();
   plantRuntime(dir, mod.RUNTIME_VERSION);
   const { ui, seen } = wizardUi({
-    select: ["Guided setup", "Skip"],
+    select: ["Guided setup", "Skip", "Skip"], // intent, worker, trigger edge
     input: [dir],
     confirm: [false, true, false], // up declined, POINTER ACCEPTED, github declined
   });
@@ -520,6 +739,203 @@ test("wizard: the pointer is written only after a confirm showing the JSON verba
   assert.ok(pointerConfirm.message.includes(JSON.stringify(pointer, null, 2)), "the confirm shows the exact JSON-to-be");
   assert.ok(pointerConfirm.message.includes(dir), "including the deploymentDir");
   assert.deepEqual(order, ["write", "reapply"], "re-applied AFTER the write, so this session picks it up");
+});
+
+// ── the trigger-edge step (step 10) ──────────────────────────────────────────────────────────────
+
+const EDGE_TITLE = "How should GitHub events reach the queue?";
+const EDGE_SERVICE = "Install the webhook receiver as a service";
+const EDGE_COMPOSE = "Run the receiver with docker compose";
+const EDGE_POLL = "Show the polling command";
+const RECEIVER_PKG = "@edgehero/pi-dispatch-receiver";
+
+/** Plant an installed receiver of `version` — what the edge step's npm install would produce. */
+function plantReceiver(dir, version) {
+  const d = join(dir, "node_modules", "@edgehero", "pi-dispatch-receiver");
+  mkdirSync(d, { recursive: true });
+  writeFileSync(join(d, "package.json"), JSON.stringify({ name: RECEIVER_PKG, version }));
+  return d;
+}
+
+/**
+ * The FIFO answers that walk an already-pinned deployment to the trigger-edge step and out the other
+ * side: intent, worker Skip, the chosen `edge` answer, then Skip at the first trigger. Confirms are
+ * up/pointer/github (all declined) followed by whatever the chosen edge answer asks for -- so every
+ * assertion below is about the edge answer alone.
+ */
+function edgeAnswers(dir, edge, edgeConfirms = []) {
+  return {
+    select: ["Guided setup", "Skip", edge, "Skip"], // intent, worker, TRIGGER EDGE, first trigger
+    input: [dir],
+    confirm: [false, false, false, ...edgeConfirms], // up, pointer, github declined; then the edge's own
+  };
+}
+
+/** Did the wizard walk PAST the edge step into step 11? Every one of the four answers must. */
+function reachedFirstTrigger(seen) {
+  return seen.select.some((s) => /First trigger/.test(s.title));
+}
+
+test("wizard: the trigger-edge step offers exactly the three shapes plus Skip", async () => {
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, seen } = wizardUi(edgeAnswers(dir, "Skip"));
+  const { deps } = wizardDeps();
+  await mod.runSetupWizard({}, tuiCtx(ui, mkdtempSync(join(tmpdir(), "admin-setup-repo-"))), ui.notify, deps);
+  const edge = seen.select.find((s) => s.title === EDGE_TITLE);
+  assert.deepEqual(edge.options, [EDGE_SERVICE, EDGE_COMPOSE, EDGE_POLL, "Skip"]);
+});
+
+test("wizard: the edge's service answer installs the PINNED receiver, then the --receiver unit", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "admin-setup-repo-"));
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, seen } = wizardUi(edgeAnswers(dir, EDGE_SERVICE, [true])); // + the receiver install confirm
+  const { deps, attached, dashboards } = wizardDeps({
+    runAttachedFn: async (_ctx, opts) => {
+      attached.push(opts);
+      if (opts.args.includes(`${RECEIVER_PKG}@${mod.RECEIVER_VERSION}`)) plantReceiver(dir, mod.RECEIVER_VERSION);
+      return { code: 0 };
+    },
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui, repo), ui.notify, deps);
+
+  assert.equal(attached.length, 2, "the npm install and the unit install — nothing else");
+  assert.equal(attached[0].argv0, "npm", "posix npm, per npmSpawnOptions");
+  assert.deepEqual(attached[0].args, mod.npmInstallArgsFor(RECEIVER_PKG, mod.RECEIVER_VERSION));
+  assert.ok(attached[0].args.includes(`${RECEIVER_PKG}@0.1.0`), "the pinned name@version token, spelled out");
+  assert.equal(attached[0].cwd, dir, "installed into the deployment dir, by cwd");
+  assert.deepEqual(
+    JSON.parse(readFileSync(join(dir, "package.json"), "utf8")),
+    { name: "pi-dispatch-deployment", private: true },
+    "the receiver install pins npm's project to the deployment dir too — it may be the first npm run here",
+  );
+  // Commit 1's service fix is what makes THIS correct: the unit anchors on the deployment folder and
+  // resolves the receiver's own ./start export from there.
+  assert.equal(attached[1].argv0, "/usr/bin/node-under-test");
+  assert.deepEqual(attached[1].args, [cliPathOf(dir), "service", "install", "--receiver"]);
+  assert.equal(attached[1].cwd, dir);
+
+  const c = seen.confirm.find((x) => /receiver/i.test(x.title));
+  assert.match(c.message, new RegExp(`${RECEIVER_PKG.replace("/", "\\/")}@0\\.1\\.0`), "the confirm shows the exact pin");
+  assert.match(c.message, /service install --receiver/, "and the unit command it will run after");
+  assert.ok(c.message.includes(dir), "and names the cwd");
+  assert.ok(reachedFirstTrigger(seen), "the wizard continued to step 11");
+  assert.equal(dashboards.length, 1);
+});
+
+test("wizard: a receiver version mismatch skips the UNIT and the wizard CONTINUES (unlike the runtime's)", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "admin-setup-repo-"));
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, notes, seen } = wizardUi(edgeAnswers(dir, EDGE_SERVICE, [true]));
+  const { deps, attached, dashboards } = wizardDeps({
+    runAttachedFn: async (_ctx, opts) => {
+      attached.push(opts);
+      plantReceiver(dir, "9.9.9"); // npm "succeeded" with the wrong artifact
+      return { code: 0 };
+    },
+  });
+  await mod.runSetupWizard({}, tuiCtx(ui, repo), ui.notify, deps);
+  assert.equal(attached.length, 1, "the npm spawn only — never a unit pointing at the wrong version");
+  assert.ok(
+    notes.some((n) => n.t === "error" && /9\.9\.9/.test(n.m) && /not the pinned/.test(n.m) && /skipping the receiver unit/.test(n.m)),
+    "the error names both versions and what it skipped",
+  );
+  assert.ok(reachedFirstTrigger(seen), "the receiver is OPTIONAL: a bad install costs this step, not the wizard");
+  assert.equal(dashboards.length, 1, "and the panel still opens");
+});
+
+test("wizard: a declined receiver confirm spawns nothing and names both commands for later", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "admin-setup-repo-"));
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, notes, seen } = wizardUi(edgeAnswers(dir, EDGE_SERVICE, [false]));
+  const { deps, attached } = wizardDeps();
+  await mod.runSetupWizard({}, tuiCtx(ui, repo), ui.notify, deps);
+  assert.equal(attached.length, 0);
+  assert.ok(notes.some((n) => /receiver skipped/.test(n.m) && /service install --receiver/.test(n.m)));
+  assert.ok(reachedFirstTrigger(seen));
+});
+
+test("wizard: the edge's compose answer copies the runtime's compose file CREATE-ONLY, then runs it", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "admin-setup-repo-"));
+  const dir = emptyDir();
+  const runtimeDir = plantRuntime(dir, mod.RUNTIME_VERSION);
+  mkdirSync(join(runtimeDir, "deploy"), { recursive: true });
+  writeFileSync(join(runtimeDir, "deploy", "docker-compose.yml"), "# the runtime's own compose file\n");
+  const dest = join(dir, "docker-compose.yml");
+
+  const first = wizardUi(edgeAnswers(dir, EDGE_COMPOSE, [true])); // + the compose up confirm
+  const rec = wizardDeps({
+    runAttachedFn: async (_ctx, opts) => {
+      rec.attached.push(opts);
+      return { code: 0 };
+    },
+  });
+  await mod.runSetupWizard({}, tuiCtx(first.ui, repo), first.ui.notify, rec.deps);
+  assert.equal(readFileSync(dest, "utf8"), "# the runtime's own compose file\n", "copied out of the installed runtime");
+  assert.equal(rec.attached.length, 1);
+  assert.equal(rec.attached[0].argv0, "docker");
+  assert.deepEqual(rec.attached[0].args, ["compose", "-f", dest, "--profile", "receiver", "up", "-d"], "the opt-in receiver profile");
+  assert.equal(rec.attached[0].cwd, dir);
+  assert.match(first.seen.confirm.at(-1).message, /--profile receiver up -d/, "the confirm shows the exact command");
+  assert.ok(reachedFirstTrigger(first.seen));
+
+  // Second pass over the SAME dir: the operator may have edited that file, so it is never clobbered.
+  writeFileSync(dest, "# MINE — edited by the operator\n");
+  const second = wizardUi(edgeAnswers(dir, EDGE_COMPOSE, [false])); // decline the up: only the copy matters here
+  const rec2 = wizardDeps();
+  await mod.runSetupWizard({}, tuiCtx(second.ui, repo), second.ui.notify, rec2.deps);
+  assert.equal(readFileSync(dest, "utf8"), "# MINE — edited by the operator\n", "create-only: an existing compose file survives");
+  assert.ok(second.notes.some((n) => /already exists/.test(n.m) && /keeping yours/.test(n.m)), "and the skip is said out loud");
+  assert.equal(rec2.attached.length, 0, "a declined up spawns nothing");
+  assert.ok(reachedFirstTrigger(second.seen));
+});
+
+test("wizard: the edge's compose answer degrades when the runtime ships no compose file", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "admin-setup-repo-"));
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION); // no deploy/ inside it: the install was declined earlier
+  const { ui, notes, seen } = wizardUi(edgeAnswers(dir, EDGE_COMPOSE, [true]));
+  const { deps, attached, dashboards } = wizardDeps();
+  await mod.runSetupWizard({}, tuiCtx(ui, repo), ui.notify, deps);
+  assert.equal(attached.length, 0, "no compose spawn without a compose file");
+  assert.ok(notes.some((n) => n.t === "error" && /could not copy/.test(n.m)), "the failure is named, not swallowed");
+  assert.ok(reachedFirstTrigger(seen), "and it is still only this step that is skipped");
+  assert.equal(dashboards.length, 1);
+});
+
+test("wizard: the edge's polling answer PRINTS both commands and spawns nothing", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "admin-setup-repo-"));
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, notes, seen } = wizardUi(edgeAnswers(dir, EDGE_POLL));
+  const { deps, attached } = wizardDeps();
+  await mod.runSetupWizard({}, tuiCtx(ui, repo), ui.notify, deps);
+  assert.equal(attached.length, 0, "a long-running poller is never started from the wizard's overlay");
+  const note = notes.find((n) => /pi-dispatch-receiver poll/.test(n.m));
+  assert.ok(note, "the producer command is named");
+  assert.match(note.m, /setup github --no-webhook/, "and the hook-inactive App mint that goes with it");
+  assert.ok(note.m.includes(dir), "both from the deployment folder");
+  assert.equal(seen.confirm.length, 3, "print-only: no consent gate of its own (up/pointer/github only)");
+  assert.ok(reachedFirstTrigger(seen));
+});
+
+test("wizard: the edge's Skip says one line naming all three options, and spawns nothing", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "admin-setup-repo-"));
+  const dir = emptyDir();
+  plantRuntime(dir, mod.RUNTIME_VERSION);
+  const { ui, notes, seen } = wizardUi(edgeAnswers(dir, "Skip"));
+  const { deps, attached } = wizardDeps();
+  await mod.runSetupWizard({}, tuiCtx(ui, repo), ui.notify, deps);
+  assert.equal(attached.length, 0);
+  const note = notes.find((n) => /trigger edge left for later/.test(n.m));
+  assert.ok(note, "the deferral is said once");
+  for (const needle of ["service install --receiver", "--profile receiver up -d", "pi-dispatch-receiver poll"]) {
+    assert.ok(note.m.includes(needle), `the deferral names ${needle}`);
+  }
+  assert.ok(reachedFirstTrigger(seen));
 });
 
 // ── the first-trigger step ───────────────────────────────────────────────────────────────────────
@@ -561,9 +977,9 @@ test("wizard: the first trigger targets ctx.cwd, lists real repo skills, and wri
   const dir = emptyDir();
   plantRuntime(dir, mod.RUNTIME_VERSION);
   const { ui, notes, seen } = wizardUi({
-    select: ["Guided setup", "Skip", "A cron trigger for this repo", "nightly-tidy"],
+    select: ["Guided setup", "Skip", "Skip", "A cron trigger for this repo", "nightly-tidy"], // intent, worker, trigger edge, first trigger, flow
     input: [dir, "", "", ""], // dir, id blank→nightly, pattern blank→0 3 * * *, task blank→run the flow
-    confirm: [false, false, false],
+    confirm: [false, false, false], // up, pointer, github — all declined
   });
   const rec = recordingFs();
   const triggerWrites = [];
@@ -601,10 +1017,10 @@ test("wizard: an invalid cron id refuses at the dialog and skips the trigger", a
   const dir = emptyDir();
   plantRuntime(dir, mod.RUNTIME_VERSION);
   const { ui, notes } = wizardUi({
-    select: ["Guided setup", "Skip", "A cron trigger for this repo"],
+    select: ["Guided setup", "Skip", "Skip", "A cron trigger for this repo"], // intent, worker, trigger edge, first trigger
     // No .pi/skills in this repo, so flow is a free input: dir, flow, then the bad id.
     input: [dir, "tidy", "night:ly"],
-    confirm: [false, false, false],
+    confirm: [false, false, false], // up, pointer, github — all declined
   });
   const triggerWrites = [];
   const { deps } = wizardDeps({
@@ -623,9 +1039,9 @@ test("wizard: no first-trigger offer when ctx.cwd is unset or missing on disk", 
   plantRuntime(dir, mod.RUNTIME_VERSION);
   for (const cwd of [undefined, join(emptyDir(), "absent-subdir")]) {
     const { ui, seen } = wizardUi({
-      select: ["Guided setup", "Skip"],
+      select: ["Guided setup", "Skip", "Skip"], // intent, worker, trigger edge
       input: [dir],
-      confirm: [false, false, false],
+      confirm: [false, false, false], // up, pointer, github — all declined
     });
     const triggerWrites = [];
     const { deps } = wizardDeps({

--- a/admin/test/wiring.test.mjs
+++ b/admin/test/wiring.test.mjs
@@ -509,3 +509,80 @@ test("unset removes a key, leaving a valid empty overlay", async () => {
   assert.match(ctx.notes[0][0], /unset model/);
   assert.deepEqual(JSON.parse(readFileSync(file, "utf8")), {}, "empty overlay is a valid written state");
 });
+
+/**
+ * The runtime version advisory (issue #96): a pi that differs from the tested pin loads normally
+ * and says so ONCE, at "info" -- a heads-up, not a warning, and never a refusal. The comparison is
+ * the exported pure computePiVersionAdvisory (unit-testable without faking a pi install); the drain
+ * lives in dispatch() before the sub switch, so any subcommand passes it. Under the pinned devDep
+ * pi VERSION === SUPPORTED_PI_VERSION and the natural advisory is unset, so the drain is armed via
+ * the obviously-test-only setter (deployment-pointer's resetForTests precedent).
+ */
+test("the version advisory: pure comparison, and the drain fires once per process at info", async () => {
+  const { mod, def } = await loadRegistered();
+
+  assert.equal(mod.computePiVersionAdvisory("0.80.7", "0.80.7"), undefined, "equal versions: nothing to say");
+  assert.equal(
+    mod.computePiVersionAdvisory("0.0.0", "0.80.7"),
+    undefined,
+    "pi's own unreadable-package fallback means UNKNOWN, not different -- no bogus mismatch",
+  );
+  const msg = mod.computePiVersionAdvisory("0.99.0", "0.80.7");
+  assert.match(msg, /running on pi 0\.99\.0/, "names the runtime version");
+  assert.match(msg, /tested with pi 0\.80\.7/, "names the tested version");
+  assert.match(msg, /things should work/, "reassures rather than scares");
+  assert.match(msg, /@edgehero\/pi-dispatch-admin/, "points at the upgrade that resolves it");
+
+  mod._setPiVersionAdvisoryForTests("canned version advisory");
+  const first = fakeCtx();
+  await def.handler("runs", first.ctx);
+  const drained = first.notes.filter(([m]) => m === "canned version advisory");
+  assert.equal(drained.length, 1, "surfaced exactly once");
+  assert.equal(drained[0][1], "info", "an advisory, not a warning");
+  const second = fakeCtx();
+  await def.handler("runs", second.ctx);
+  assert.equal(
+    second.notes.filter(([m]) => m === "canned version advisory").length,
+    0,
+    "once per process: the second /dispatch stays quiet",
+  );
+});
+
+/**
+ * The CI canary (.github/scripts/admin-pi-canary.mjs) keeps its OWN copies of the pinned-api needle
+ * list and the USED_API member list -- pinned-extension-api.test.mjs asserts the PIN and cannot be
+ * imported by a CI script without becoming one. This test is the anti-drift bolt both directions:
+ * the canary's members must deepEqual the real USED_API export, and its needles must deepEqual the
+ * literals in pinned-extension-api.test.mjs (parsed from the test's own source -- reading it is
+ * fine, editing it is not) AND still appear in the pinned types.d.ts. A stale canary list fails the
+ * suite here instead of silently probing the wrong surface in CI.
+ */
+test("the canary's needle/member lists cannot drift from the pinned test or USED_API", async () => {
+  const { mod } = await loadRegistered();
+  const canary = await import(new URL("../../.github/scripts/admin-pi-canary.mjs", import.meta.url));
+
+  assert.deepEqual(
+    [...canary.USED_API_MEMBERS].sort(),
+    [...mod.USED_API].sort(),
+    "the canary's USED_API_MEMBERS drifted from the real USED_API export",
+  );
+
+  const pinnedTestSrc = readFileSync(fileURLToPath(new URL("./pinned-extension-api.test.mjs", import.meta.url)), "utf8");
+  const needleBlock = pinnedTestSrc.match(/const needles = \[([\s\S]*?)\];/);
+  assert.ok(needleBlock, "could not find the needles literal in pinned-extension-api.test.mjs");
+  const pinnedNeedles = [...needleBlock[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  assert.ok(pinnedNeedles.length > 0, "expected at least one pinned needle");
+  assert.deepEqual(
+    [...canary.NEEDLES].sort(),
+    [...pinnedNeedles].sort(),
+    "the canary's NEEDLES drifted from pinned-extension-api.test.mjs's list",
+  );
+
+  const typesSrc = readFileSync(
+    fileURLToPath(new URL("../../node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/types.d.ts", import.meta.url)),
+    "utf8",
+  );
+  for (const needle of canary.NEEDLES) {
+    assert.ok(typesSrc.includes(needle), `canary needle "${needle}" is not in the PINNED types.d.ts`);
+  }
+});

--- a/admin/test/wiring.test.mjs
+++ b/admin/test/wiring.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -25,6 +25,9 @@ const piRequire = createRequire(import.meta.resolve("@earendil-works/pi-coding-a
 const { createJiti } = piRequire("jiti");
 const jiti = createJiti(import.meta.url);
 const indexPath = fileURLToPath(new URL("../src/index.ts", import.meta.url));
+// The wizard module through the SAME loader, for its exported pins (the skew notice compares against
+// RUNTIME_VERSION, and a test restating the literal would drift from it).
+const wizard = await jiti.import(fileURLToPath(new URL("../src/setup-wizard.ts", import.meta.url)));
 
 /**
  * A recording `pi` whose get-trap throws on any function member NOT in USED_API, so a handler that reached
@@ -129,34 +132,118 @@ test("setup with a ctx lacking dialogs degrades to a notice, never the model cha
  * The bare command on a host with NOTHING configured (issue #92): no pointer (agent dir is a pinned
  * empty tmpdir), none of the path env vars, no cwd scaffold (the test runs from admin/), and a queue
  * probe pinned to a dead port -- port 1 refuses immediately on every host, so the probe can never find
- * a REAL dev Valkey on 6379 and go green under the test's feet. That state must surface the setup
- * offer; a decline spawns nothing and degrades to the usage line. recordingPi still enforces USED_API
- * throughout, so the detection/offer path cannot quietly grow a new pi member.
+ * a REAL dev Valkey on 6379 and go green under the test's feet.
+ *
+ * That state now lands the operator IN the wizard, not in front of a confirm asking whether they want
+ * one: the wizard's own first select IS the consent, and it offers the panel as a real third answer.
+ * The load-bearing part is what a "Cancel" costs -- nothing: no spawn, no write, no overlay. recordingPi
+ * still enforces USED_API throughout, so the direct-entry path cannot quietly grow a new pi member.
  */
-test("bare /dispatch with nothing configured offers setup; a decline spawns nothing", async () => {
+test("bare /dispatch with nothing configured lands in the wizard select; Cancel spawns nothing", async () => {
   const keys = ["PI_LOGS_DIR", "PI_SETTINGS_FILE", "PI_TRIGGERS_FILE", "PI_PAUSE_WINDOWS_FILE", "PI_SUBSCRIPTIONS_FILE", "VALKEY_URL"];
   const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
   for (const k of keys) delete process.env[k];
   process.env.VALKEY_URL = "redis://127.0.0.1:1";
+  const agentDirBefore = readdirSync(process.env.PI_CODING_AGENT_DIR);
   try {
     const { calls, def } = await loadRegistered();
     const view = fakeCtx({ withCustom: true });
+    const selects = [];
     const confirms = [];
+    const inputs = [];
+    view.ctx.ui.select = async (title, options) => {
+      selects.push([title, options]);
+      return "Cancel";
+    };
     view.ctx.ui.confirm = async (title, message) => {
       confirms.push([title, message]);
       return false;
     };
+    view.ctx.ui.input = async (title, placeholder) => {
+      inputs.push([title, placeholder]);
+      return undefined;
+    };
     await def.handler("", view.ctx);
-    assert.equal(confirms.length, 1, "the offer confirm was shown exactly once");
-    assert.match(confirms[0][1], /No deployment found/);
-    assert.equal(view.customCalls.length, 0, "declined: no dashboard overlay, no wizard, nothing spawned");
-    assert.ok(view.notes.some(([m]) => /setup/.test(m)), "the decline degrades to the usage line naming setup");
-    assert.equal(calls.sendMessage.length, 0, "the offer path never touches the model channel");
+    assert.equal(selects.length, 1, "exactly one dialog: the wizard's own intent select");
+    assert.match(selects[0][0], /pi-dispatch setup/, "and it is the wizard's, not an offer confirm");
+    assert.deepEqual(selects[0][1], ["Guided setup", "Open the panel anyway", "Cancel"], "three answers, the panel among them");
+    assert.equal(confirms.length, 0, "no confirm asks permission to ask");
+    assert.equal(inputs.length, 0, "Cancel stops before the deployment-dir input");
+    assert.equal(view.customCalls.length, 0, "Cancel: no dashboard overlay, no attached spawn");
+    assert.equal(calls.sendMessage.length, 0, "the direct-entry path never touches the model channel");
+    assert.deepEqual(readdirSync(process.env.PI_CODING_AGENT_DIR), agentDirBefore, "and wrote nothing (no pointer, no marker)");
+
+    // Same state, a pi build with no dialog primitives: the degrade is the WIZARD's own capability gate,
+    // said exactly once. The bare branch deliberately adds no second notice -- two notices for one
+    // degrade reads like two separate failures.
+    const noDialogs = fakeCtx({ withCustom: true }); // notify + custom only
+    await def.handler("", noDialogs.ctx);
+    assert.equal(noDialogs.notes.length, 1, "exactly one notice, not two");
+    assert.match(noDialogs.notes[0][0], /dialogs|newer pi/);
+    assert.equal(noDialogs.customCalls.length, 0, "and no overlay for a wizard that cannot ask anything");
+    assert.equal(calls.sendMessage.length, 0);
   } finally {
     for (const k of keys) {
       if (saved[k] === undefined) delete process.env[k];
       else process.env[k] = saved[k];
     }
+  }
+});
+
+/**
+ * A bare `/dispatch` against a POINTED-AT deployment whose installed runtime is not the version this
+ * console pins: worth exactly one line, once per process, naming setup as the fix (its install step is a
+ * no-op when the pin already matches, so the advice converges). The pointer file is written into a temp
+ * PI_DISPATCH_DEPLOYMENT_FILE rather than the shared agent dir so no later test inherits a pointer.
+ *
+ * The two silences are the interesting half: a MATCHING version says nothing, and an ABSENT/unreadable
+ * one says nothing either -- an operator running the worker from a clone has no installed package to
+ * read and must not be nagged for it every session.
+ */
+test("bare /dispatch on a pointed-at deployment: version skew notifies once, silence otherwise", async () => {
+  const { def } = await loadRegistered();
+  const pinned = wizard.RUNTIME_VERSION;
+  const prev = process.env.PI_DISPATCH_DEPLOYMENT_FILE;
+  const home = mkdtempSync(join(tmpdir(), "admin-skew-"));
+  const pointerFile = join(home, "pointer.json");
+  const deploymentDir = join(home, "deploy");
+  const runtimeDir = join(deploymentDir, "node_modules", "@edgehero", "pi-dispatch");
+  // An empty pointer `env` on purpose: this test is about the version read, and layering paths into
+  // process.env would change what the OTHER tests in this file resolve.
+  writeFileSync(pointerFile, JSON.stringify({ version: 1, deploymentDir, env: {} }));
+  process.env.PI_DISPATCH_DEPLOYMENT_FILE = pointerFile;
+  const skews = (notes) => notes.filter(([m]) => /run \/dispatch setup to upgrade/.test(m));
+  try {
+    // 1. No installed runtime at all: silence (a clone-run worker is a deliberate choice, not a defect).
+    mkdirSync(deploymentDir, { recursive: true });
+    const absent = fakeCtx({ withCustom: true });
+    await def.handler("", absent.ctx);
+    assert.equal(skews(absent.notes).length, 0, "an absent version is silent");
+
+    // 2. The pinned version: nothing to say.
+    mkdirSync(runtimeDir, { recursive: true });
+    writeFileSync(join(runtimeDir, "package.json"), JSON.stringify({ version: pinned }));
+    const same = fakeCtx({ withCustom: true });
+    await def.handler("", same.ctx);
+    assert.equal(skews(same.notes).length, 0, "a matching version is silent");
+
+    // 3. An older deployment: one warning naming both versions and the fix.
+    writeFileSync(join(runtimeDir, "package.json"), JSON.stringify({ version: "0.0.1" }));
+    const older = fakeCtx({ withCustom: true });
+    await def.handler("", older.ctx);
+    const [[message, type]] = skews(older.notes);
+    assert.equal(skews(older.notes).length, 1, "exactly one line");
+    assert.match(message, /deployment runtime 0\.0\.1/, "names the deployment's version");
+    assert.match(message, new RegExp(`this console pins ${pinned.replace(/\./g, "\\.")}`), "and the pinned one");
+    assert.equal(type, "warning");
+
+    // 4. Once per PROCESS: the latch keeps the second /dispatch quiet (the advisory latch's twin).
+    const second = fakeCtx({ withCustom: true });
+    await def.handler("", second.ctx);
+    assert.equal(skews(second.notes).length, 0, "the latch holds for the rest of the process");
+  } finally {
+    if (prev === undefined) delete process.env.PI_DISPATCH_DEPLOYMENT_FILE;
+    else process.env.PI_DISPATCH_DEPLOYMENT_FILE = prev;
   }
 });
 

--- a/deploy/com.pi-dispatch.worker.plist
+++ b/deploy/com.pi-dispatch.worker.plist
@@ -5,10 +5,18 @@
   unit. Adapt it. The Linux/systemd equivalent is deploy/worker.service.
 
   ProgramArguments points at deploy/worker-env-wrapper.sh; that wrapper is what loads `.env`, because
-  launchd has no EnvironmentFile mechanism. NO secrets are inlined here: there is deliberately no
-  EnvironmentVariables dict, since that would commit credentials into this file. The wrapper reads
-  `.env` at runtime instead (note the ANTHROPIC_OAUTH_TOKEN over ANTHROPIC_API_KEY precedence trap
-  documented in the wrapper).
+  launchd has no EnvironmentFile mechanism. The wrapper's contract (issue #96; see its header): it
+  sources ./.env from the WorkingDirectory below (which makes that key load-bearing, not a nicety)
+  and then runs the REST of ProgramArguments as the command. When hand-editing this template, append
+  the command after the wrapper path, e.g.
+      <string>/usr/bin/node</string>
+      <string>/opt/pi-dispatch/worker/src/cli.mjs</string>
+      <string>worker</string>
+  (`pi-dispatch service render` composes exactly that argv with this host's real paths; the wrapper
+  refuses an empty argv rather than guessing what to run). NO secrets are inlined here: there is
+  deliberately no EnvironmentVariables dict, since that would commit credentials into this file. The
+  wrapper reads `.env` at runtime instead (note the ANTHROPIC_OAUTH_TOKEN over ANTHROPIC_API_KEY
+  precedence trap documented in the wrapper).
 
   Graceful shutdown needs NO macOS-specific code: `launchctl bootout` sends SIGTERM, which the wrapper
   forwards to node (a trap + kill; its former `exec` is gone, see the wrapper's own comments), and the
@@ -21,8 +29,10 @@
   (exit 2, a determinate config/budget refusal) into a clean exit 0: a policy refusal stays stopped
   instead of relaunch-looping against a paid provider.
 
-  Per-host PLACEHOLDERS: replace /opt/pi-dispatch (the repo root, used in ProgramArguments and
-  WorkingDirectory) and /opt/pi-dispatch/logs (StandardOutPath, StandardErrorPath) with your paths.
+  Per-host PLACEHOLDERS: replace /opt/pi-dispatch (the deployment folder, used in ProgramArguments and
+  WorkingDirectory; the folder that holds your `.env`) and /opt/pi-dispatch/logs (StandardOutPath,
+  StandardErrorPath; create the directory yourself, launchd will not) with your paths, and append the
+  command argv to ProgramArguments as described above.
 
   One worker per host (DES-CONCURRENCY-3): parallelism is PI_CONCURRENCY inside the one process.
   Requires the AOF-enabled Valkey from deploy/docker-compose.yml.

--- a/deploy/worker-env-wrapper.cmd
+++ b/deploy/worker-env-wrapper.cmd
@@ -2,10 +2,21 @@
 REM UNTESTED EXAMPLE -- a starting point for a Windows service, not a shipped, verified unit. Adapt it.
 REM
 REM pi-dispatch launcher for Windows service managers (nssm; see deploy/nssm-install.cmd). Windows
-REM services have no `.env` mechanism, so this wrapper loads `.env` from the repo root itself, then
-REM launches node. It reads ONLY the declared `.env` (see `.env.example`), never the host user profile:
-REM the container-boundary rules require an explicit, auditable variable set. Nothing here contains a
-REM credential -- the secrets live in `.env`, which is gitignored and read at runtime.
+REM services have no `.env` mechanism, so this wrapper loads `.env` from the current directory itself,
+REM then runs the command it was handed. It reads ONLY the declared `.env` (see `.env.example`), never
+REM the host user profile: the container-boundary rules require an explicit, auditable variable set.
+REM Nothing here contains a credential -- the secrets live in `.env`, which is gitignored and read at
+REM runtime.
+REM
+REM CONTRACT (issue #96 -- mirrors the .sh twin; nothing is guessed from this script's location):
+REM   - The current directory IS the deployment folder. nssm's AppDirectory guarantees it, set both by
+REM     deploy/nssm-install.cmd and by `pi-dispatch service install`. The old `cd /d "%~dp0.."`
+REM     self-guess was right only in a repo checkout; under `npm install` this script lives at
+REM     node_modules\@edgehero\pi-dispatch\deploy\, whose parent is the package -- no `.env` there.
+REM   - The arguments ARE the command, e.g.:  C:\path\to\node.exe C:\...\src\cli.mjs worker
+REM     `pi-dispatch service install` passes them via nssm AppParameters. This wrapper no longer
+REM     decides WHAT to run -- only the env it runs in and what its exit code means -- so an empty
+REM     argument list is a configuration error, refused below.
 REM
 REM TRAP: inside pi, ANTHROPIC_OAUTH_TOKEN silently takes precedence over ANTHROPIC_API_KEY. Set exactly
 REM one in `.env`.
@@ -20,23 +31,21 @@ REM multiple services. Requires the AOF-enabled Valkey from deploy/docker-compos
 
 setlocal
 
-REM Resolve repo root relative to this script (deploy\ is one level down).
-cd /d "%~dp0.." || exit /b 1
+if "%~1"=="" (
+  echo worker-env-wrapper: no command given -- expected: worker-env-wrapper.cmd node-path script-path [args...]; re-render with: pi-dispatch service render 1>&2
+  exit /b 1
+)
 
 if not exist ".env" (
-  echo worker-env-wrapper: .env not found in "%CD%" 1>&2
+  echo worker-env-wrapper: .env not found in "%CD%" -- this wrapper must be started in the deployment folder, the service's nssm AppDirectory; it no longer guesses a location from its own path 1>&2
   exit /b 1
 )
 
 for /f "usebackq eol=# tokens=1,* delims==" %%A in (".env") do set "%%A=%%B"
 
-REM One wrapper serves both daemons (see the .sh twin): no argument runs the worker; `receiver`
-REM (passed by `pi-dispatch service --receiver`) runs the webhook receiver.
-if "%~1"=="receiver" (
-  node receiver\src\start.mjs
-) else (
-  node worker\src\cli.mjs worker
-)
+REM The argv runs verbatim -- absolute node, absolute script, composed by `pi-dispatch service` (see
+REM the .sh twin for the whole contract).
+%*
 set "RC=%ERRORLEVEL%"
 
 REM Exit 2 is EXIT_POLICY (worker\src\exit-code.mjs): a determinate config/budget refusal. nssm's

--- a/deploy/worker-env-wrapper.sh
+++ b/deploy/worker-env-wrapper.sh
@@ -1,9 +1,20 @@
 #!/bin/sh
 # pi-dispatch launcher for daemon managers that have NO EnvironmentFile mechanism. systemd reads
 # `.env` for you via `EnvironmentFile=` (see deploy/worker.service); launchd (macOS) has no equivalent --
-# a plist's ProgramArguments cannot name a `.env`. This wrapper closes that gap: launchd execs THIS
-# script, which loads the explicit `.env` from the repo root and then runs node. Its exit-code
-# conversion and signal forwarding are exercised under `sh` by worker/test/service.test.mjs.
+# a plist's ProgramArguments cannot name a `.env`. This wrapper closes that gap: it sources `./.env`
+# from the directory it is STARTED IN, then runs the command it was handed. Its exit-code conversion
+# and signal forwarding are exercised under `sh` by worker/test/service.test.mjs.
+#
+# CONTRACT (issue #96 -- nothing here is guessed from this script's own location any more):
+#   - The current directory IS the deployment folder. The daemon manager guarantees it: launchd sets
+#     the plist's WorkingDirectory, nssm sets AppDirectory. The old `cd "$(dirname "$0")/.."` self-guess
+#     was right only in a repo checkout; under `npm install` this script lives at
+#     node_modules/@edgehero/pi-dispatch/deploy/, whose parent is the package -- no `.env` there, ever.
+#   - "$@" IS the command, e.g.:  /path/to/node /abs/path/to/src/cli.mjs worker
+#     `pi-dispatch service` composes it with absolute paths (the same node that rendered, the worker
+#     package's own cli.mjs or the receiver package's start.mjs) and puts it in the unit's
+#     ProgramArguments / AppParameters. This wrapper no longer decides WHAT to run -- only the env it
+#     runs in and what its exit code means -- so an empty argv is a configuration error, refused below.
 #
 # It sources ONLY the declared `.env` (see `.env.example`), never the host login shell: the
 # container-boundary rules require an explicit, auditable variable set, not whatever the operator's
@@ -17,19 +28,15 @@
 # One worker per host (DES-CONCURRENCY-3): parallelism is PI_CONCURRENCY inside the single process, not
 # multiple daemons. Requires the AOF-enabled Valkey from deploy/docker-compose.yml.
 
-# Resolve repo root relative to this script (deploy/ is one level down).
-cd "$(dirname "$0")/.." || exit 1
-if [ ! -f .env ]; then echo "worker-env-wrapper: .env not found in $(pwd)" >&2; exit 1; fi
-set -a; . ./.env; set +a
-
-# One wrapper serves both daemons, because the gap it closes (no EnvironmentFile under launchd/nssm)
-# is identical for both: no argument runs the worker; `receiver` (passed by the derived receiver
-# units `pi-dispatch service` renders) runs the webhook receiver.
-if [ "$1" = "receiver" ]; then
-	set -- node receiver/src/start.mjs
-else
-	set -- node worker/src/cli.mjs worker
+if [ "$#" -eq 0 ]; then
+	echo "worker-env-wrapper: no command given -- expected: worker-env-wrapper.sh /path/to/node /path/to/script [args...]; the unit's ProgramArguments/AppParameters carry these (re-render with: pi-dispatch service render)" >&2
+	exit 1
 fi
+if [ ! -f ./.env ]; then
+	echo "worker-env-wrapper: .env not found in $PWD -- this wrapper must be started in the deployment folder (the unit's WorkingDirectory / nssm AppDirectory); it no longer guesses a location from its own path" >&2
+	exit 1
+fi
+set -a; . ./.env; set +a
 
 # `exec` is deliberately GONE here (it used to hand this shell's pid straight to node): intercepting
 # the exit code needs a parent still alive after node exits. launchd's KeepAlive/SuccessfulExit=false

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -26,6 +26,15 @@ CLI, a cron schedule, or a GitHub issue. You bake your own toolchain into the im
 Chromium, so a flow can build a frontend, screenshot it, and iterate on the render), and a live `/dispatch`
 admin panel shows the queue, spend meters, run history, and triggers.
 
+**The install line** (use this everywhere; the scoped form only, per the naming rule above):
+
+```
+pi install npm:@edgehero/pi-dispatch-admin      # then, in pi:  /dispatch
+```
+
+With nothing configured, `/dispatch` walks the whole setup with a consent per step. For servers and
+headless hosts the same setup is `npx @edgehero/pi-dispatch up` in a fresh folder.
+
 ---
 
 ## Show HN
@@ -54,6 +63,11 @@ pi-dispatch is the operational layer that closes them, and nothing else:
 - A live admin panel (a pi extension): queue state, day/week/month spend meters, run history
   with per-job token+cost accounting, and editable triggers — plus per-repo "quiet hours" that
   defer runs between certain times and resume automatically.
+
+Setup is the panel's job too. `pi install npm:@edgehero/pi-dispatch-admin`, then `/dispatch`:
+with nothing configured it walks the whole deployment with a consent per step, and lands you in
+the panel. Servers and headless hosts get the same thing as plain commands
+(`npx @edgehero/pi-dispatch up`).
 
 I've tried to be honest about the threat model rather than hand-wave it: the whole thing runs
 untrusted, adversarial input through an unrestricted agent on purpose, so SECURITY.md states

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typebox": "1.1.38"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": "0.80.7"
+        "@earendil-works/pi-coding-agent": "*"
       }
     },
     "image/runner": {

--- a/specs/design.md
+++ b/specs/design.md
@@ -634,18 +634,32 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
 
 ## DES-FIRST-RUN-SETUP-WIZARD
 
-- **Decision**: `/dispatch setup` (and, when bare `/dispatch` detects no deployment anywhere, an
-  offered confirm into the same flow) walks an operator from a console-only install to a working
-  deployment: choose a deployment dir (default `~/pi-dispatch`, never the repo) → consented
+- **Decision**: `/dispatch setup` is **the default setup route** (issue #96): when bare `/dispatch`
+  detects no deployment anywhere, it lands **directly in the wizard's opening choice** — the select
+  (Guided setup / Open the panel anyway / Cancel) *is* the consent, replacing the earlier yes/no
+  offer; a configured deployment with a down queue still never enters the wizard (the unreachable
+  banner rule is load-bearing and unchanged). The flow: choose a deployment dir (default
+  `~/pi-dispatch`, never the repo) → **Docker pre-check** (a capture probe distinguishing
+  not-on-PATH from daemon-down; on failure a Re-check / Continue anyway / Stop loop with per-OS
+  pointers — never a piped installer; `up`'s own hard refusal stays as defense in depth) → consented
   `npm install @edgehero/pi-dispatch@<RUNTIME_VERSION>` into it → hand the terminal to
   `npx pi-dispatch up` → optional `service install` → write the deployment pointer
   (`INT-DEPLOYMENT-POINTER-CONTRACT`, JSON shown verbatim) → provider key **printed, never
-  written** → optional `setup github` hand-off → optional first trigger for the repo the session
-  sits in (cron pre-filled with the folder, flow picked from its `.pi/skills/` via the shared
-  `SKILL_NAME_RE`, the in-place-edit warning printed, the `ai-trigger: allow` line **printed, never
-  written** — repo files stay the operator's, and the gate reads committed HEAD anyway) → the panel.
+  written** → optional `setup github` hand-off → **trigger-edge choice** (install the webhook
+  receiver as a service — a consented `npm install @edgehero/pi-dispatch-receiver@<RECEIVER_VERSION>`
+  then `service install --receiver`; or run it with docker compose — the compose file ships in the
+  runtime package and is copied create-only into the deployment dir before a consented
+  `--profile receiver up -d`; or show the polling command; or skip) → optional first trigger for the
+  repo the session sits in (cron pre-filled with the folder, flow picked from its `.pi/skills/` via
+  the shared `SKILL_NAME_RE`, the in-place-edit warning printed, the `ai-trigger: allow` line
+  **printed, never written** — repo files stay the operator's, and the gate reads committed HEAD
+  anyway) → the panel.
   A once-ever `session_start` nudge (`reason: "startup"`, notify-only, marker-file latch) points at
-  the command. Every step is individually declinable and declines continue converge-style.
+  the command, and a once-per-process **skew notice** on bare `/dispatch` says when the deployed
+  runtime is older than the console's pin ("run /dispatch setup to upgrade" — re-running setup is
+  the upgrade path, made safe by the post-install version assertion). Both version pins carry
+  anti-drift tests (`RUNTIME_VERSION` ↔ worker, `RECEIVER_VERSION` ↔ receiver). Every step is
+  individually declinable and declines continue converge-style.
 - **Mechanics, chosen for pi's real constraints**: dialogs-first, **overlay-per-handoff** — the
   wizard is a plain `ui.select/input/confirm` chain, and each terminal-needing child runs inside a
   short-lived `ctx.ui.custom` overlay that exists only to hold the `tui` handle for the
@@ -1649,6 +1663,7 @@ a tunnel.
 
 | Date | Change |
 |---|---|
+| 2026-08-04 | The front door becomes the default route (issue #96). **DES-FIRST-RUN-SETUP-WIZARD amended**: bare `/dispatch` with nothing configured lands directly in the wizard's opening select — the select is the consent, replacing the yes/no offer; the outage rule is restated load-bearing (a configured deployment with a down queue keeps the banner, never the wizard). Two steps join the flow: a Docker pre-check (capture probe, Re-check/Continue/Stop loop, per-OS pointers, never a piped installer) and a trigger-edge choice (receiver as a service via a consented pinned `@edgehero/pi-dispatch-receiver` install + `service install --receiver`; compose profile with the compose file now shipped in the runtime package and copied create-only; or the polling command printed). A once-per-process skew notice makes re-running setup the visible upgrade path. **Fixed in the same change, recorded plainly**: `service` units were broken for every npm deployment — the renderer derived a "repo root" two directories above its module, which in an npm install is the scope directory, so ExecStart/EnvironmentFile/wrapper paths all pointed at nothing; units now anchor on the deployment dir (WorkingDirectory, `.env`, logs) and resolved script paths (the CLI beside the service module; the receiver via `import.meta.resolve`), the wrapper execs the argv the render substituted instead of guessing, and npm-layout fixtures now exist so the seam that masked this cannot mask it again. **CONST-RETRY-INFRA-ONLY UNCHANGED, checked**: the exit-2 conversion survives the wrapper contract change, asserted against the real shipped wrapper. pi compatibility becomes strategy instead of luck: the peer widens to the `"*"` range pi's own packages doc prescribes for host-provided packages (the exact devDep pin stays the tested marker), a runtime advisory names an untested pi version on first `/dispatch` (never a refusal — the capability probe stays the only hard gate), and a weekly canary installs latest pi into a scratch dir (never the repo root — the pinned assertions must keep asserting the pin) and fails CI when any used API member or type needle disappears. |
 | 2026-08-04 | The console becomes the front door (issue #92). Added **DES-FIRST-RUN-SETUP-WIZARD**: `/dispatch setup` + the bare-`/dispatch` no-deployment offer + a once-ever startup nudge, built as dialogs-first with **overlay-per-handoff** (the `tui` suspend handle exists only inside a `ctx.ui.custom` factory; dialogs cannot run under a capturing overlay; stdin is unreadable while suspended — so each attached child gets its own short-lived overlay, and the child's OWN consent gates are the host-mutation consents: the wizard forwards `--yes` to nothing). npm step under import-pi's spawn doctrine, with the recorded reasoning for `--ignore-scripts` on our own runtime (pure-JS deps; msgpackr's native accel is optional with a JS fallback). No new tier, no new powers, no model-callable tool; the only novel artifact is the pointer file (INT-DEPLOYMENT-POINTER-CONTRACT). Rejected on the record: long-lived wizard overlay, clone reuse, detached worker, credential dialogs, auto-writing `ai-trigger: allow` (two keys stay two keys). **DES-TRIGGER-OUTSIDE-PI UNCHANGED, checked**: the wizard bootstraps host processes, never hosts them. **DES-CLI-SURFACE UNCHANGED, checked**: every tier the wizard drives is entered through that entry's own gates. |
 | 2026-08-02 | The public URL becomes optional (issue #81, second half). Added **DES-GH-POLLING-TRANSPORT**: `pi-dispatch-receiver poll` synthesizes INT-WEBHOOK-PAYLOAD-SUBSET shapes from REST responses (issue events / comments / open PRs; ETag 304s are rate-limit-free; first boot never replays history; per-repo failures never kill the loop) and feeds the unchanged pure `filter()` + shared enqueue with `poll-*` delivery ids — the receiver stays the default and the low-latency path. Trust framing recorded: TLS with the operator's own credential replaces HMAC because authentication points the other way; `WEBHOOK_SECRET` is not required in poll mode, still hard-required for `serve`. The Actions-runner transport is rejected on the record (merge-gated workflow code executing on the worker host = merge-to-default becomes host code execution outside the container boundary). **DES-TRIGGER-OUTSIDE-PI UNCHANGED, checked**: the poller is the same always-on process class, just a different transport. **CONST-ISSUE-TEXT-IS-DATA UNCHANGED, checked**: the poller never interprets bodies. |
 | 2026-08-02 | The App path becomes the easy path (issue #81). Added **DES-GH-APP-MANIFEST-SETUP**: `pi-dispatch setup github` runs GitHub's App Manifest flow against a throwaway loopback listener — one browser click returns app id + PEM + webhook secret via the unauthenticated single-use conversion endpoint; every `.env` line is shown before one explicit consent, the PEM lands 0600 and never clobbers, an existing `WEBHOOK_SECRET` is kept (replacing it would invalidate working deliveries), installation-id discovery uses a deliberately hand-rolled ~15-line `node:crypto` RS256 JWT (auditable, once-at-setup; job-time minting stays `@octokit/auth-app`, unchanged), and `--no-webhook` creates the hook-inactive shape the polling transport will consume. No `--yes` on this wizard — these writes carry credentials. Rejected on the record: a maintainer-registered device-flow client (maintainer dependency in a self-hosted trust chain) and auto-installing the App (automating a consent screen defeats it). **CONST-TOKEN-SCOPED-PER-JOB UNCHANGED, checked**: the wizard changes how credentials are *acquired*, not how job tokens are minted or scoped. **CONST-HMAC-OVER-RAW-BODY UNCHANGED, checked**: the webhook secret the flow mints feeds the same verify path. |

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -438,10 +438,15 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   the raw `.log` renders, then it renders in the overlay viewer and is never returned as a tool result or
   sent as a message into model context; given an operator pi whose API surface lacks any required member,
   when the extension loads, then it registers nothing and reports the unsupported version loudly;
-  given bare `/dispatch` with no deployment anywhere and the setup offer **declined**, then nothing
-  was spawned and nothing was written; given a configured deployment whose queue is down, then the
-  panel opens with the unreachable banner and no setup offer; given a second pi startup after the
-  nudge fired once, then no nudge renders.
+  given an operator pi whose API surface is complete but whose version differs from the tested pin,
+  then the extension loads normally and the first `/dispatch` surfaces one info-level advisory naming
+  both versions — an untested pi is a notice, never a refusal (issue #96);
+  given bare `/dispatch` with no deployment anywhere, then it lands directly in the wizard's opening
+  select, and answering **Cancel** spawns nothing and writes nothing (the select is the consent —
+  issue #96 made this the default route); given a configured deployment whose queue is down, then the
+  panel opens with the unreachable banner and never the wizard; given a second pi startup after the
+  nudge fired once, then no nudge renders; given a deployment whose installed runtime is older than
+  the console's pin, then bare `/dispatch` surfaces one skew notice pointing at `/dispatch setup`.
 
 ## REQ-AI-TRIGGERED-RUNS
 
@@ -1007,6 +1012,7 @@ wait-list working as designed, not a failure — see `README.md`.
 
 | Date | Change |
 |---|---|
+| 2026-08-04 | The wizard becomes the default route (issue #96). **REQ-ADMIN-VIA-PI-EXTENSION Acceptance amended**: bare `/dispatch` with nothing configured lands directly in the wizard's opening select (Cancel spawns nothing, writes nothing — the select is the consent); an untested-but-complete pi version is one info advisory on first `/dispatch`, never a refusal; a runtime older than the console's pin is one skew notice pointing at `/dispatch setup`. The outage and nudge-latch clauses are unchanged in substance and restated. **CONST-BUDGET-BEFORE-TOKENS UNCHANGED, checked**: the new steps (Docker pre-check, trigger-edge choice) spawn only consented infrastructure commands; nothing reserves budget or enqueues. **REQ-DEPLOYMENT-BOOTSTRAP UNCHANGED, checked**: the wizard still drives the CLI's own gates; the service-unit re-anchoring fix (recorded in design.md) changes where units point, not what may be automated. |
 | 2026-08-04 | First-run setup joins the admin surface (issue #92). **REQ-ADMIN-VIA-PI-EXTENSION amended**: `/dispatch setup` (operator-typed only — deliberately no model-callable tool), the bare-`/dispatch` detection tree (the offer appears ONLY when pointer, env, and cwd scaffold are all absent AND the queue is unreachable — a configured deployment with a down queue keeps the banner, never an offer), and a once-ever notify-only `session_start` nudge; Acceptance gains declined-offer-⇒-nothing-spawned-nothing-written, no-offer-over-an-outage, and the nudge latch. **REQ-DEPLOYMENT-BOOTSTRAP Scope amended**: "not the admin extension" becomes the carve-in — the wizard is a *driver, not a power*: it reaches the same CLI actions through their own consent gates and adds only the deployment pointer. **CONST-BUDGET-BEFORE-TOKENS UNCHANGED, checked**: no wizard path reserves budget, enqueues, or spends — setup ends at the panel, not at a job. |
 | 2026-08-02 | Process supervision joins the bootstrap requirement (issue #80). **REQ-DEPLOYMENT-BOOTSTRAP Scope widened**: `pi-dispatch service` (render/install/uninstall/status/start/stop/restart `--drain`) — user-level by default, sudo commands printed never executed, per-OS honesty (macOS login-scoped because Docker Desktop is; Windows via operator-installed nssm, never Task Scheduler — its `TerminateProcess` hard-kill is the recorded rejection), `restart --drain` composing the durable pause → wait-idle → restart → resume ritual the README previously spelled out by hand, and a timed-out drain leaves the queue paused rather than un-pausing over a live job. **REQ-SPEND-CAPS-MULTI-WINDOW / CONST-BUDGET-BEFORE-TOKENS UNCHANGED, checked**: supervision changes when the worker runs, never what a run may spend. |
 | 2026-08-02 | Consented bootstrap (issue #80). Added **REQ-DEPLOYMENT-BOOTSTRAP**: `pi-dispatch up [--yes]` and `doctor --fix` take a fresh machine to a preflighted deployment through create-only scaffolds and per-action consented host mutations — every mutating command printed verbatim, y/N default No (No on non-TTY), closed fix tiers with an explicit never-set (malformed-config rewrites, triggers/pause-windows content, trigger-named `run.image`, semantic env guesses), `WEBHOOK_SECRET` set only when empty and never printed. Automation removes typing, never decisions: the consent keypress preserves SECURITY.md's "pulled onto that host yourself" property that a silent bootstrap would erase. **CONST-BUDGET-BEFORE-TOKENS UNCHANGED, checked**: no bootstrap path reserves budget, enqueues, or spends — `up` ends at doctor, not at a job. **REQ-GLOBAL-PI-OVERLAY UNCHANGED, checked**: doctor's overlay obligations are cited by the new REQ, not moved; `--fix`'s overlay actions (auth.json delete, import-pi restage) re-execute existing gates. |

--- a/worker/deploy/com.pi-dispatch.worker.plist
+++ b/worker/deploy/com.pi-dispatch.worker.plist
@@ -5,10 +5,18 @@
   unit. Adapt it. The Linux/systemd equivalent is deploy/worker.service.
 
   ProgramArguments points at deploy/worker-env-wrapper.sh; that wrapper is what loads `.env`, because
-  launchd has no EnvironmentFile mechanism. NO secrets are inlined here: there is deliberately no
-  EnvironmentVariables dict, since that would commit credentials into this file. The wrapper reads
-  `.env` at runtime instead (note the ANTHROPIC_OAUTH_TOKEN over ANTHROPIC_API_KEY precedence trap
-  documented in the wrapper).
+  launchd has no EnvironmentFile mechanism. The wrapper's contract (issue #96; see its header): it
+  sources ./.env from the WorkingDirectory below (which makes that key load-bearing, not a nicety)
+  and then runs the REST of ProgramArguments as the command. When hand-editing this template, append
+  the command after the wrapper path, e.g.
+      <string>/usr/bin/node</string>
+      <string>/opt/pi-dispatch/worker/src/cli.mjs</string>
+      <string>worker</string>
+  (`pi-dispatch service render` composes exactly that argv with this host's real paths; the wrapper
+  refuses an empty argv rather than guessing what to run). NO secrets are inlined here: there is
+  deliberately no EnvironmentVariables dict, since that would commit credentials into this file. The
+  wrapper reads `.env` at runtime instead (note the ANTHROPIC_OAUTH_TOKEN over ANTHROPIC_API_KEY
+  precedence trap documented in the wrapper).
 
   Graceful shutdown needs NO macOS-specific code: `launchctl bootout` sends SIGTERM, which the wrapper
   forwards to node (a trap + kill; its former `exec` is gone, see the wrapper's own comments), and the
@@ -21,8 +29,10 @@
   (exit 2, a determinate config/budget refusal) into a clean exit 0: a policy refusal stays stopped
   instead of relaunch-looping against a paid provider.
 
-  Per-host PLACEHOLDERS: replace /opt/pi-dispatch (the repo root, used in ProgramArguments and
-  WorkingDirectory) and /opt/pi-dispatch/logs (StandardOutPath, StandardErrorPath) with your paths.
+  Per-host PLACEHOLDERS: replace /opt/pi-dispatch (the deployment folder, used in ProgramArguments and
+  WorkingDirectory; the folder that holds your `.env`) and /opt/pi-dispatch/logs (StandardOutPath,
+  StandardErrorPath; create the directory yourself, launchd will not) with your paths, and append the
+  command argv to ProgramArguments as described above.
 
   One worker per host (DES-CONCURRENCY-3): parallelism is PI_CONCURRENCY inside the one process.
   Requires the AOF-enabled Valkey from deploy/docker-compose.yml.

--- a/worker/deploy/docker-compose.yml
+++ b/worker/deploy/docker-compose.yml
@@ -1,0 +1,66 @@
+# pi-dispatch's worker runs on the HOST, not in a container: it drives the `docker` CLI to launch
+# job containers, and the CLI is what translates bind-mount paths cross-platform (Windows/macOS/
+# Linux) -- see DES-WORKER-ON-HOST. That is settled doctrine, and it is why no service here mounts
+# docker.sock: a socket mount is root-equivalent access to the host, and nothing in this stack needs it.
+#
+# The RECEIVER may run either way. It is the one internet-facing process and needs no Docker access at
+# all, so a container suits it -- but the host mode (`pi-dispatch-receiver`, deploy/receiver.service)
+# stays first-class. The `receiver` profile keeps the container OPT-IN: a plain `up` stays Valkey-only,
+# so worker-on-host deployments that already run the receiver on the host gain no second copy.
+#
+#   docker compose -f deploy/docker-compose.yml up -d                     # start Valkey (default)
+#   docker compose -f deploy/docker-compose.yml --profile receiver up -d  # Valkey + receiver container
+#   pi-dispatch worker                                                    # drain the queue (host)
+
+services:
+  valkey:
+    image: valkey/valkey:8
+    # AOF on: the wait-list must survive a reboot (REQ-QUEUE-BURST-NO-DROP).
+    command: valkey-server --appendonly yes
+    # Bound to localhost only -- the queue is not a public surface.
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - valkey-data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  # The containerized receiver (issue #82): the always-on webhook edge, prebuilt for amd64+arm64.
+  # Build locally instead with:  docker build -f receiver/Dockerfile -t pi-dispatch-receiver .
+  #
+  # Relative paths below resolve against THIS FILE's directory (deploy/), not the caller's cwd --
+  # that is the Compose spec for both env_file and bind mounts -- so `../` reaches the repo root
+  # regardless of where `docker compose -f deploy/docker-compose.yml ...` is run from.
+  receiver:
+    profiles: ["receiver"]
+    image: ghcr.io/edgehero/pi-dispatch-receiver:latest
+    # The operator's .env at the repo root, same file the host services read (WEBHOOK_SECRET, github
+    # auth, forge blocks). Compose refuses to start the profile when it is missing -- correctly: a
+    # receiver without WEBHOOK_SECRET refuses to boot anyway, so fail at the clearer message.
+    env_file: ../.env
+    # `environment` OVERRIDES env_file, deliberately: a host .env says redis://127.0.0.1:6379, which
+    # inside a container is the container itself. Service DNS is the container-side truth.
+    environment:
+      VALKEY_URL: redis://valkey:6379
+      PI_TRIGGERS_FILE: /config/triggers.json
+    # The repo-root triggers.json (`pi-dispatch init` scaffolds it -- run that first: mounting a path
+    # that does not exist makes Docker create it as a DIRECTORY and the boot fails confusingly).
+    # Read-only: the receiver live-reloads this file on change; it never writes it.
+    volumes:
+      - ../triggers.json:/config/triggers.json:ro
+    # Loopback only, like Valkey's port above: the operator's reverse proxy or tunnel (TLS, public
+    # hostname) is what faces the internet -- never this port raw. Assumes the in-container default
+    # RECEIVER_PORT=3000; if your .env overrides it, adjust the right-hand side to match.
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on:
+      valkey:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  valkey-data:

--- a/worker/deploy/worker-env-wrapper.cmd
+++ b/worker/deploy/worker-env-wrapper.cmd
@@ -2,10 +2,21 @@
 REM UNTESTED EXAMPLE -- a starting point for a Windows service, not a shipped, verified unit. Adapt it.
 REM
 REM pi-dispatch launcher for Windows service managers (nssm; see deploy/nssm-install.cmd). Windows
-REM services have no `.env` mechanism, so this wrapper loads `.env` from the repo root itself, then
-REM launches node. It reads ONLY the declared `.env` (see `.env.example`), never the host user profile:
-REM the container-boundary rules require an explicit, auditable variable set. Nothing here contains a
-REM credential -- the secrets live in `.env`, which is gitignored and read at runtime.
+REM services have no `.env` mechanism, so this wrapper loads `.env` from the current directory itself,
+REM then runs the command it was handed. It reads ONLY the declared `.env` (see `.env.example`), never
+REM the host user profile: the container-boundary rules require an explicit, auditable variable set.
+REM Nothing here contains a credential -- the secrets live in `.env`, which is gitignored and read at
+REM runtime.
+REM
+REM CONTRACT (issue #96 -- mirrors the .sh twin; nothing is guessed from this script's location):
+REM   - The current directory IS the deployment folder. nssm's AppDirectory guarantees it, set both by
+REM     deploy/nssm-install.cmd and by `pi-dispatch service install`. The old `cd /d "%~dp0.."`
+REM     self-guess was right only in a repo checkout; under `npm install` this script lives at
+REM     node_modules\@edgehero\pi-dispatch\deploy\, whose parent is the package -- no `.env` there.
+REM   - The arguments ARE the command, e.g.:  C:\path\to\node.exe C:\...\src\cli.mjs worker
+REM     `pi-dispatch service install` passes them via nssm AppParameters. This wrapper no longer
+REM     decides WHAT to run -- only the env it runs in and what its exit code means -- so an empty
+REM     argument list is a configuration error, refused below.
 REM
 REM TRAP: inside pi, ANTHROPIC_OAUTH_TOKEN silently takes precedence over ANTHROPIC_API_KEY. Set exactly
 REM one in `.env`.
@@ -20,23 +31,21 @@ REM multiple services. Requires the AOF-enabled Valkey from deploy/docker-compos
 
 setlocal
 
-REM Resolve repo root relative to this script (deploy\ is one level down).
-cd /d "%~dp0.." || exit /b 1
+if "%~1"=="" (
+  echo worker-env-wrapper: no command given -- expected: worker-env-wrapper.cmd node-path script-path [args...]; re-render with: pi-dispatch service render 1>&2
+  exit /b 1
+)
 
 if not exist ".env" (
-  echo worker-env-wrapper: .env not found in "%CD%" 1>&2
+  echo worker-env-wrapper: .env not found in "%CD%" -- this wrapper must be started in the deployment folder, the service's nssm AppDirectory; it no longer guesses a location from its own path 1>&2
   exit /b 1
 )
 
 for /f "usebackq eol=# tokens=1,* delims==" %%A in (".env") do set "%%A=%%B"
 
-REM One wrapper serves both daemons (see the .sh twin): no argument runs the worker; `receiver`
-REM (passed by `pi-dispatch service --receiver`) runs the webhook receiver.
-if "%~1"=="receiver" (
-  node receiver\src\start.mjs
-) else (
-  node worker\src\cli.mjs worker
-)
+REM The argv runs verbatim -- absolute node, absolute script, composed by `pi-dispatch service` (see
+REM the .sh twin for the whole contract).
+%*
 set "RC=%ERRORLEVEL%"
 
 REM Exit 2 is EXIT_POLICY (worker\src\exit-code.mjs): a determinate config/budget refusal. nssm's

--- a/worker/deploy/worker-env-wrapper.sh
+++ b/worker/deploy/worker-env-wrapper.sh
@@ -1,9 +1,20 @@
 #!/bin/sh
 # pi-dispatch launcher for daemon managers that have NO EnvironmentFile mechanism. systemd reads
 # `.env` for you via `EnvironmentFile=` (see deploy/worker.service); launchd (macOS) has no equivalent --
-# a plist's ProgramArguments cannot name a `.env`. This wrapper closes that gap: launchd execs THIS
-# script, which loads the explicit `.env` from the repo root and then runs node. Its exit-code
-# conversion and signal forwarding are exercised under `sh` by worker/test/service.test.mjs.
+# a plist's ProgramArguments cannot name a `.env`. This wrapper closes that gap: it sources `./.env`
+# from the directory it is STARTED IN, then runs the command it was handed. Its exit-code conversion
+# and signal forwarding are exercised under `sh` by worker/test/service.test.mjs.
+#
+# CONTRACT (issue #96 -- nothing here is guessed from this script's own location any more):
+#   - The current directory IS the deployment folder. The daemon manager guarantees it: launchd sets
+#     the plist's WorkingDirectory, nssm sets AppDirectory. The old `cd "$(dirname "$0")/.."` self-guess
+#     was right only in a repo checkout; under `npm install` this script lives at
+#     node_modules/@edgehero/pi-dispatch/deploy/, whose parent is the package -- no `.env` there, ever.
+#   - "$@" IS the command, e.g.:  /path/to/node /abs/path/to/src/cli.mjs worker
+#     `pi-dispatch service` composes it with absolute paths (the same node that rendered, the worker
+#     package's own cli.mjs or the receiver package's start.mjs) and puts it in the unit's
+#     ProgramArguments / AppParameters. This wrapper no longer decides WHAT to run -- only the env it
+#     runs in and what its exit code means -- so an empty argv is a configuration error, refused below.
 #
 # It sources ONLY the declared `.env` (see `.env.example`), never the host login shell: the
 # container-boundary rules require an explicit, auditable variable set, not whatever the operator's
@@ -17,19 +28,15 @@
 # One worker per host (DES-CONCURRENCY-3): parallelism is PI_CONCURRENCY inside the single process, not
 # multiple daemons. Requires the AOF-enabled Valkey from deploy/docker-compose.yml.
 
-# Resolve repo root relative to this script (deploy/ is one level down).
-cd "$(dirname "$0")/.." || exit 1
-if [ ! -f .env ]; then echo "worker-env-wrapper: .env not found in $(pwd)" >&2; exit 1; fi
-set -a; . ./.env; set +a
-
-# One wrapper serves both daemons, because the gap it closes (no EnvironmentFile under launchd/nssm)
-# is identical for both: no argument runs the worker; `receiver` (passed by the derived receiver
-# units `pi-dispatch service` renders) runs the webhook receiver.
-if [ "$1" = "receiver" ]; then
-	set -- node receiver/src/start.mjs
-else
-	set -- node worker/src/cli.mjs worker
+if [ "$#" -eq 0 ]; then
+	echo "worker-env-wrapper: no command given -- expected: worker-env-wrapper.sh /path/to/node /path/to/script [args...]; the unit's ProgramArguments/AppParameters carry these (re-render with: pi-dispatch service render)" >&2
+	exit 1
 fi
+if [ ! -f ./.env ]; then
+	echo "worker-env-wrapper: .env not found in $PWD -- this wrapper must be started in the deployment folder (the unit's WorkingDirectory / nssm AppDirectory); it no longer guesses a location from its own path" >&2
+	exit 1
+fi
+set -a; . ./.env; set +a
 
 # `exec` is deliberately GONE here (it used to hand this shell's pid straight to node): intercepting
 # the exit code needs a parent still alive after node exits. launchd's KeepAlive/SuccessfulExit=false

--- a/worker/src/service.mjs
+++ b/worker/src/service.mjs
@@ -3,11 +3,26 @@
  *
  * Durable running used to mean hand-editing the per-OS examples in deploy/. This module reads those
  * SAME files from the package and substitutes a documented table of their known literals —
- * `/usr/bin/node` → `process.execPath`, `/opt/pi-dispatch` → the real repo root — rather than
+ * `/usr/bin/node` → `process.execPath`, `/opt/pi-dispatch` → the deployment folder — rather than
  * introducing a `{{placeholder}}` dialect. That keeps the deploy/ files byte-usable examples (and
  * deploy-lint keeps parsing exactly what ships); TEMPLATE_PINS below is the table's enforcement — the
  * test suite asserts every literal is still present in every template, so template drift breaks the
  * build loudly instead of breaking the render silently.
+ *
+ * Path doctrine (issue #96): this module used to derive a REPO_ROOT from its own location ("../..").
+ * Right in a checkout; WRONG under `npm install`, where src/ lives at
+ * node_modules/@edgehero/pi-dispatch/src and "../.." is the @edgehero SCOPE directory — every rendered
+ * unit pointed at files that do not exist. Three anchors replace it, each correct in BOTH layouts:
+ *   - deployDir     the deployment folder = the cwd `service` is invoked from. Owns everything
+ *                   host-side: WorkingDirectory, EnvironmentFile (<deployDir>/.env) and the daemon
+ *                   logs (<deployDir>/logs/, created at install time) — never the package dir, which
+ *                   npm may replace wholesale on update.
+ *   - cliPath       join(moduleDir, "cli.mjs"): cli.mjs sits beside this module in src/ in both
+ *                   layouts, so the worker ExecStart needs no repo root at all.
+ *   - receiverStart import.meta.resolve("@edgehero/pi-dispatch-receiver/start"): the receiver
+ *                   package's own exported entry, wherever npm (or the workspace symlink) put it.
+ *                   null when the package is not installed — receiver renders refuse loudly instead
+ *                   of writing a unit that would crash-loop at boot.
  *
  * Scope doctrine:
  *   - User-level by default, everywhere. macOS REFUSES root outright (a LaunchAgent is per-user, and a
@@ -32,12 +47,26 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
-// Deploy templates resolved relative to this module (the init.mjs pattern): worker/deploy is SHIPPED
-// in the npm tarball and kept byte-identical to the repo-root deploy/ (the documented source) by
-// worker/test/publish.test.mjs — so `service` renders the same templates from a checkout and from an
-// npm install, no matter where the CLI is invoked from.
-const DEPLOY_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..", "deploy");
-const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+// src/ is where this module lives in BOTH layouts (worker/src in a checkout,
+// node_modules/@edgehero/pi-dispatch/src under npm). Deploy templates resolve one level up from it
+// (the init.mjs pattern): worker/deploy is SHIPPED in the npm tarball and kept byte-identical to the
+// repo-root deploy/ (the documented source) by worker/test/publish.test.mjs — so `service` renders
+// the same templates from a checkout and from an npm install, no matter where the CLI is invoked from.
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The receiver's entry point comes from the receiver PACKAGE (its ./start export), wherever module
+ * resolution finds it from here — the workspace symlink in a checkout, the sibling install under the
+ * deployment folder's node_modules in production. Never a path guessed off this module: that guess is
+ * exactly what issue #96 is about. null = not installed, and the receiver renders refuse on it.
+ */
+function resolveReceiverStart() {
+	try {
+		return fileURLToPath(import.meta.resolve("@edgehero/pi-dispatch-receiver/start"));
+	} catch {
+		return null;
+	}
+}
 
 /**
  * The whole substitution surface, template by template. The render replaces ONLY these literals (plus
@@ -47,9 +76,9 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
  */
 export const TEMPLATE_PINS = {
 	"worker.service": [
-		"ExecStart=/usr/bin/node worker/src/cli.mjs worker", // /usr/bin/node → process.execPath
-		"WorkingDirectory=/opt/pi-dispatch", // /opt/pi-dispatch → the real repo root
-		"EnvironmentFile=/opt/pi-dispatch/.env",
+		"ExecStart=/usr/bin/node worker/src/cli.mjs worker", // the WHOLE line → `<execPath> <cliPath> worker` (cli.mjs sits beside this module in src/ in both layouts)
+		"WorkingDirectory=/opt/pi-dispatch", // /opt/pi-dispatch → the deployment folder (the cwd `service` runs from)
+		"EnvironmentFile=/opt/pi-dispatch/.env", // → <deployDir>/.env — the operator's .env lives beside the units, never inside the package
 		"\nUser=pi\n", // the DIRECTIVE line (the header comment also says User=pi mid-line, hence the \n anchors): stripped for --user scope; rewritten to the invoking user for --system
 		"WantedBy=multi-user.target", // → default.target in user scope (multi-user.target never runs there)
 		// Byte-for-byte survivors — semantics the render must not lose:
@@ -60,7 +89,7 @@ export const TEMPLATE_PINS = {
 		"TimeoutStopSec=30",
 	],
 	"receiver.service": [
-		"ExecStart=/usr/bin/node receiver/src/start.mjs",
+		"ExecStart=/usr/bin/node receiver/src/start.mjs", // the WHOLE line → `<execPath> <receiverStart>` (the receiver package's resolved ./start export)
 		"WorkingDirectory=/opt/pi-dispatch",
 		"EnvironmentFile=/opt/pi-dispatch/.env",
 		"\nUser=pi\n",
@@ -70,9 +99,9 @@ export const TEMPLATE_PINS = {
 	],
 	"com.pi-dispatch.worker.plist": [
 		"<string>com.pi-dispatch.worker</string>", // → com.pi-dispatch.receiver for --receiver
-		"<string>/opt/pi-dispatch/deploy/worker-env-wrapper.sh</string>", // gains a `receiver` argument for --receiver
-		"<key>WorkingDirectory</key>\n\t<string>/opt/pi-dispatch</string>", // anchor for the PATH injection below
-		"<string>/opt/pi-dispatch/logs/worker.out.log</string>",
+		"<string>/opt/pi-dispatch/deploy/worker-env-wrapper.sh</string>", // → the PACKAGE's wrapper copy, followed by the exec argv (<node> <script> …) the wrapper now runs verbatim
+		"<key>WorkingDirectory</key>\n\t<string>/opt/pi-dispatch</string>", // → the deployment folder (load-bearing: the wrapper sources ./.env there); also the anchor for the PATH injection below
+		"<string>/opt/pi-dispatch/logs/worker.out.log</string>", // → <deployDir>/logs/… (install creates the dir; launchd will not)
 		"<string>/opt/pi-dispatch/logs/worker.err.log</string>",
 		"<key>SuccessfulExit</key>", // the KeepAlive shape the wrapper's exit-2 conversion pairs with
 		"<integer>30</integer>", // ExitTimeOut — room for the SIGTERM drain
@@ -82,8 +111,8 @@ export const TEMPLATE_PINS = {
 	// the two cannot drift apart — especially the AppExit pair, which is the EXIT_POLICY never-retry.
 	"nssm-install.cmd": [
 		"pi-dispatch-worker",
-		"C:\\pi-dispatch", // the REPO placeholder → the real repo root
-		"deploy\\worker-env-wrapper.cmd",
+		"C:\\pi-dispatch", // the REPO placeholder → the deployment folder (cwd)
+		"deploy\\worker-env-wrapper.cmd", // the sequence points at the PACKAGE's wrapper copy and passes the exec argv behind it
 		"AppStopMethodConsole 15000",
 		"AppThrottle 5000",
 		"AppExit Default Restart",
@@ -116,7 +145,11 @@ export async function runService(argv = [], deps = {}) {
 		platform = process.platform,
 		euid = typeof process.geteuid === "function" ? process.geteuid() : null,
 		execPath = process.execPath,
-		repoRoot = REPO_ROOT,
+		// The deployment folder: where the operator ran `service`, where .env lives, where logs/ goes.
+		cwd = process.cwd(),
+		// Injectable so tests can render as if from an npm install without installing anything.
+		moduleDir = MODULE_DIR,
+		resolveReceiver = resolveReceiverStart,
 		home = homedir(),
 		user = env.USER || userInfo().username,
 		tmp = tmpdir(),
@@ -162,12 +195,22 @@ export async function runService(argv = [], deps = {}) {
 	}
 	if (!["darwin", "linux", "win32"].includes(platform)) return fail(err, `unsupported platform: ${platform}`);
 
+	// The templates dir is module-relative like moduleDir itself: worker/deploy in a checkout,
+	// <pkg>/deploy under npm — the SHIPPED copies, correct in both layouts (unlike the old repo root).
+	const templatesDir = resolve(moduleDir, "..", "deploy");
 	const ctx = {
 		env,
 		platform,
 		euid,
 		execPath,
-		repoRoot,
+		deployDir: cwd,
+		cliPath: join(moduleDir, "cli.mjs"),
+		templatesDir,
+		wrapperSh: join(templatesDir, "worker-env-wrapper.sh"),
+		wrapperCmd: join(templatesDir, "worker-env-wrapper.cmd"),
+		// Resolved only when asked for: worker-only invocations must not care whether the receiver
+		// package exists here at all.
+		receiverStart: values.receiver ? resolveReceiver() : null,
 		home,
 		user,
 		tmp,
@@ -240,7 +283,20 @@ function unitPaths(ctx) {
 }
 
 function readTemplate(ctx, name) {
-	return ctx.fs.readFileSync(join(DEPLOY_DIR, name), "utf8");
+	return ctx.fs.readFileSync(join(ctx.templatesDir, name), "utf8");
+}
+
+/**
+ * The receiver refusal, shared by render and install: a null receiverStart means the receiver package
+ * is not resolvable from this worker install. Refusing beats rendering — a unit pointing at a
+ * nonexistent start.mjs would install cleanly and then crash-loop at boot, which is exactly the failure
+ * mode issue #96 shipped for every path.
+ */
+function refuseMissingReceiver(ctx) {
+	return fail(
+		ctx.err,
+		"the receiver package is not installed here — run: npm install @edgehero/pi-dispatch-receiver (from the deployment folder)",
+	);
 }
 
 /**
@@ -250,12 +306,23 @@ function readTemplate(ctx, name) {
  */
 function renderLinuxUnit(ctx) {
 	const template = ctx.which === "receiver" ? "receiver.service" : "worker.service";
+	// The ExecStart line is replaced WHOLE, not path-by-path: the template's script path is relative
+	// to a repo-root WorkingDirectory that only a checkout has. The rendered unit points at absolute
+	// entries that exist in both layouts — cliPath beside this module; the receiver package's ./start
+	// export — so ExecStart works no matter what WorkingDirectory is.
+	const execStart =
+		ctx.which === "receiver"
+			? ["ExecStart=/usr/bin/node receiver/src/start.mjs", `ExecStart=${ctx.execPath} ${ctx.receiverStart}`]
+			: ["ExecStart=/usr/bin/node worker/src/cli.mjs worker", `ExecStart=${ctx.execPath} ${ctx.cliPath} worker`];
 	// The banner outranks the template's own "TEMPLATE/UNTESTED EXAMPLE — set the PLACEHOLDERs" header,
 	// which renders through below (the no-markers design keeps templates byte-usable, so their prose
 	// survives): a reader of the rendered unit should know the placeholders are already substituted.
 	let unit = `# rendered by \`pi-dispatch service\` — paths computed for this host from deploy/${template};\n# the template's PLACEHOLDER prose below is already substituted.\n` +
 		readTemplate(ctx, template)
-		.replaceAll("/opt/pi-dispatch", ctx.repoRoot)
+		.replace(execStart[0], execStart[1])
+		// /opt/pi-dispatch → the deployment folder (the cwd this render ran from): WorkingDirectory and
+		// EnvironmentFile stay operator territory, never the package dir npm may wipe on update.
+		.replaceAll("/opt/pi-dispatch", ctx.deployDir)
 		.replaceAll("/usr/bin/node", ctx.execPath);
 	if (ctx.scope === "user") {
 		// A systemd --user unit always runs as the invoking user, and systemd REJECTS a User= line in
@@ -279,48 +346,67 @@ function renderLinuxUnit(ctx) {
 
 /**
  * Render the launchd plist for this host. For --receiver the worker plist is DERIVED, not a second
- * template: same KeepAlive/ExitTimeOut shape, label and log names swapped, and the shared wrapper told
- * (via its one argument) to run the receiver. The wrapper's exit-2 conversion is a no-op for the
+ * template: same KeepAlive/ExitTimeOut shape, label and log names swapped, and the shared wrapper given
+ * the receiver's exec argv instead of the worker's. The wrapper's exit-2 conversion is a no-op for the
  * receiver — it has no EXIT_POLICY — and harmless.
  */
 function renderPlist(ctx) {
 	let plist = readTemplate(ctx, "com.pi-dispatch.worker.plist");
+	// One wrapper, two daemons: the exec argv IS the difference now. The wrapper sources ./.env in the
+	// unit's WorkingDirectory and runs exactly these arguments — no `receiver` selector flag, no paths
+	// guessed inside the wrapper (issue #96: the wrapper's self-relative guess broke under npm install).
+	const execArgv = ctx.which === "receiver" ? [ctx.execPath, ctx.receiverStart] : [ctx.execPath, ctx.cliPath, "worker"];
 	if (ctx.which === "receiver") {
 		plist = plist
 			.replace("<string>com.pi-dispatch.worker</string>", "<string>com.pi-dispatch.receiver</string>")
-			.replace(
-				"<string>/opt/pi-dispatch/deploy/worker-env-wrapper.sh</string>",
-				"<string>/opt/pi-dispatch/deploy/worker-env-wrapper.sh</string>\n\t\t<!-- the argument that makes the shared .env wrapper run the receiver instead of the worker -->\n\t\t<string>receiver</string>",
-			)
 			.replaceAll("worker.out.log", "receiver.out.log")
 			.replaceAll("worker.err.log", "receiver.err.log");
 	}
-	// launchd's default PATH is /usr/bin:/bin — an nvm or Homebrew node is invisible to it, and the
-	// wrapper invokes bare `node`. Prepend the directory of the node that ran this render so the
-	// service runs the SAME binary, no guessing. PATH is configuration, not a secret: the template's
-	// deliberate no-EnvironmentVariables stance is about credentials, which still live only in .env.
+	// The template's two-element ProgramArguments (sh + wrapper) becomes sh + the PACKAGE's wrapper +
+	// the command: absolute node, absolute script. The wrapper path is module-relative (templatesDir),
+	// so it exists in a checkout AND under node_modules — unlike the old repo-root guess.
+	plist = plist.replace(
+		"<string>/opt/pi-dispatch/deploy/worker-env-wrapper.sh</string>",
+		[
+			`<string>${ctx.wrapperSh}</string>`,
+			"<!-- the command the wrapper execs after sourcing ./.env in WorkingDirectory - absolute paths, nothing guessed -->",
+			...execArgv.map((a) => `<string>${a}</string>`),
+		].join("\n\t\t"),
+	);
+	// launchd's default PATH is /usr/bin:/bin — an nvm or Homebrew node is invisible to it. The exec
+	// argv above pins THIS node absolutely, but the worker's own children (npx-style hooks, tooling
+	// that spawns bare `node`) still resolve via PATH; prepending the render node's directory keeps
+	// them on the SAME binary. PATH is configuration, not a secret: the template's deliberate
+	// no-EnvironmentVariables stance is about credentials, which still live only in .env.
 	plist = plist.replace(
 		"<key>WorkingDirectory</key>\n\t<string>/opt/pi-dispatch</string>",
-		"<key>WorkingDirectory</key>\n\t<string>/opt/pi-dispatch</string>\n\n\t<!-- Injected by `pi-dispatch service`: launchd's default PATH cannot see an nvm/Homebrew node,\n\t     and the wrapper calls bare `node`. Not a secrets dict - credentials still live only in .env\n\t     (see the header comment). -->\n\t<key>EnvironmentVariables</key>\n\t<dict>\n\t\t<key>PATH</key>\n\t\t<string>" +
+		"<key>WorkingDirectory</key>\n\t<string>/opt/pi-dispatch</string>\n\n\t<!-- Injected by `pi-dispatch service`: launchd's default PATH cannot see an nvm/Homebrew node,\n\t     and child processes may call bare `node`. Not a secrets dict - credentials still live only\n\t     in .env (see the header comment). -->\n\t<key>EnvironmentVariables</key>\n\t<dict>\n\t\t<key>PATH</key>\n\t\t<string>" +
 			`${dirname(ctx.execPath)}:/usr/bin:/bin:/usr/sbin:/sbin</string>\n\t</dict>`,
 	);
-	return plist.replaceAll("/opt/pi-dispatch", ctx.repoRoot);
+	// Everything left standing on /opt/pi-dispatch — WorkingDirectory, the log paths, comment prose —
+	// belongs to the deployment folder.
+	return plist.replaceAll("/opt/pi-dispatch", ctx.deployDir);
 }
 
 /**
- * The nssm command sequence — deploy/nssm-install.cmd's exact steps with computed paths. Values that
- * carry semantics (AppStopMethodConsole 15000, AppThrottle 5000, AppExit Default Restart, AppExit 2
- * Exit) mirror the template byte-for-byte and are pinned. Backslashes on purpose: this argv reaches
- * nssm on a real Windows host, where repoRoot is already a Windows path.
+ * The nssm command sequence — deploy/nssm-install.cmd's exact steps with computed paths: the service
+ * Application is the PACKAGE's .cmd wrapper, its AppParameters are the exec argv (<node> <script> …)
+ * the wrapper now runs verbatim, and AppDirectory is the deployment folder so the wrapper finds ./.env
+ * there (the same WorkingDirectory contract as launchd). Values that carry semantics
+ * (AppStopMethodConsole 15000, AppThrottle 5000, AppExit Default Restart, AppExit 2 Exit) mirror the
+ * template byte-for-byte and are pinned. Backslashes on purpose where paths are BUILT here: this argv
+ * reaches nssm on a real Windows host, where deployDir is already a Windows path (wrapperCmd and
+ * cliPath come from win32 path.join and need no help).
  */
 function nssmSequence(ctx) {
 	const service = `pi-dispatch-${ctx.which}`;
-	const logDir = `${ctx.repoRoot}\\logs`;
+	const logDir = `${ctx.deployDir}\\logs`;
+	const execArgv = ctx.which === "receiver" ? [ctx.execPath, ctx.receiverStart] : [ctx.execPath, ctx.cliPath, "worker"];
 	return {
 		service,
 		commands: [
-			["install", service, `${ctx.repoRoot}\\deploy\\worker-env-wrapper.cmd`, ...(ctx.which === "receiver" ? ["receiver"] : [])],
-			["set", service, "AppDirectory", ctx.repoRoot],
+			["install", service, ctx.wrapperCmd, ...execArgv],
+			["set", service, "AppDirectory", ctx.deployDir],
 			["set", service, "AppStdout", `${logDir}\\${ctx.which}.out.log`],
 			["set", service, "AppStderr", `${logDir}\\${ctx.which}.err.log`],
 			["set", service, "AppStopMethodConsole", "15000"],
@@ -332,12 +418,13 @@ function nssmSequence(ctx) {
 }
 
 function doRender(ctx) {
+	if (ctx.which === "receiver" && !ctx.receiverStart) return refuseMissingReceiver(ctx);
 	const paths = unitPaths(ctx);
 	if (ctx.platform === "darwin") {
 		ctx.out(`# → ${paths.installPath}\n`);
 		ctx.out(renderPlist(ctx));
 		ctx.out(
-			"\n# note: ProgramArguments runs deploy/worker-env-wrapper.sh — launchd has no EnvironmentFile,\n# so the wrapper loads .env at runtime. The wrapper also converts a policy refusal (exit 2,\n# EXIT_POLICY) into a clean exit, so KeepAlive never relaunch-loops a refusal into a provider bill.\n",
+			"\n# note: ProgramArguments runs the package's worker-env-wrapper.sh, which sources ./.env in the\n# WorkingDirectory above and then runs the argv that follows it — launchd has no EnvironmentFile.\n# The wrapper also converts a policy refusal (exit 2, EXIT_POLICY) into a clean exit, so KeepAlive\n# never relaunch-loops a refusal into a provider bill.\n",
 		);
 		return 0;
 	}
@@ -354,6 +441,7 @@ function doRender(ctx) {
 }
 
 async function doInstall(ctx) {
+	if (ctx.which === "receiver" && !ctx.receiverStart) return refuseMissingReceiver(ctx);
 	const paths = unitPaths(ctx);
 
 	// THE refusal, worker only: one worker per docker daemon (DES-CONCURRENCY-3). The worker's boot
@@ -396,6 +484,9 @@ async function installDarwin(ctx, paths) {
 		await run(ctx, "launchctl", ["bootout", `gui/${ctx.euid}/${paths.name}`]);
 	}
 	ctx.fs.mkdirSync(dirname(paths.installPath), { recursive: true });
+	// launchd creates the StandardOutPath FILES but not their parent directory: without this the job
+	// spawns and dies with its error unwritable. Done at install, not render — render stays read-only.
+	ctx.fs.mkdirSync(join(ctx.deployDir, "logs"), { recursive: true });
 	ctx.fs.writeFileSync(paths.installPath, renderPlist(ctx));
 	const bootstrap = await run(ctx, "launchctl", ["bootstrap", `gui/${ctx.euid}`, paths.installPath]);
 	if (bootstrap !== 0) {
@@ -459,6 +550,10 @@ async function installWindows(ctx) {
 		const removed = await run(ctx, "nssm", ["remove", service, "confirm"]);
 		if (removed !== 0) return fail(ctx.err, `nssm remove ${service} confirm failed (exit ${removed})`);
 	}
+	// nssm, like launchd, does not create the AppStdout/AppStderr directory. join(), not the
+	// sequence's literal backslashes: this branch runs on the actual Windows host, where join is
+	// win32-flavoured anyway.
+	ctx.fs.mkdirSync(join(ctx.deployDir, "logs"), { recursive: true });
 	for (const args of commands) {
 		const code = await run(ctx, "nssm", args);
 		if (code !== 0) return fail(ctx.err, `nssm ${args.join(" ")} failed (exit ${code})`);

--- a/worker/test/publish.test.mjs
+++ b/worker/test/publish.test.mjs
@@ -22,10 +22,13 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const WORKER_DIR = join(REPO_ROOT, "worker");
 const RECEIVER_DIR = join(REPO_ROOT, "receiver");
 
-// The deploy templates `pi-dispatch service` renders (see TEMPLATE_PINS in src/service.mjs) plus the
-// wrapper scripts the rendered units invoke — the full set worker/deploy must mirror and ship.
+// The deploy templates `pi-dispatch service` renders (see TEMPLATE_PINS in src/service.mjs), the
+// wrapper scripts the rendered units invoke, and the compose file the docs point every deployment at
+// (an npm install has no repo checkout to read deploy/docker-compose.yml from) — the full set
+// worker/deploy must mirror and ship.
 const MIRRORED_DEPLOY = [
 	"com.pi-dispatch.worker.plist",
+	"docker-compose.yml",
 	"nssm-install.cmd",
 	"receiver.service",
 	"worker-env-wrapper.cmd",
@@ -52,7 +55,7 @@ test("sync: every worker/deploy template is byte-identical to its root deploy/ t
 	assert.deepEqual(
 		readdirSync(join(WORKER_DIR, "deploy")).sort(),
 		MIRRORED_DEPLOY,
-		"worker/deploy must hold exactly the templates the service renderer reads — nothing missing, no strays",
+		"worker/deploy must hold exactly the templates the service renderer reads plus the shipped compose file — nothing missing, no strays",
 	);
 	for (const name of MIRRORED_DEPLOY) {
 		assert.equal(

--- a/worker/test/service.test.mjs
+++ b/worker/test/service.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -11,6 +11,17 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 // The deploy/ copy the render actually reads: worker/deploy, shipped in the npm tarball and kept
 // byte-identical to the repo-root deploy/ by the sync test in publish.test.mjs.
 const DEPLOY_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..", "deploy");
+
+// The checkout-layout anchors (issue #96): moduleDir is worker/src, so cliPath and the wrapper paths
+// land on REAL files here — the npm-layout tests below build the other shape under a tmpdir.
+const WORKER_SRC = join(REPO_ROOT, "worker", "src");
+const CLI_PATH = join(WORKER_SRC, "cli.mjs");
+const RECEIVER_START = join(REPO_ROOT, "receiver", "src", "start.mjs");
+const WRAPPER_SH = join(DEPLOY_DIR, "worker-env-wrapper.sh");
+const WRAPPER_CMD = join(DEPLOY_DIR, "worker-env-wrapper.cmd");
+// The injected deployment folder (cwd): deliberately NOT the repo root, so any assertion that still
+// expected repo-root-derived paths would fail loudly instead of passing by coincidence.
+const DEPLOY_AT = "/srv/pi-deploy";
 
 // ---------------------------------------------------------------------------------------------------
 // The pin test: render is a targeted substitution of the templates' KNOWN literals, so a template
@@ -32,7 +43,9 @@ test("pin: every literal the render substitutes or preserves is present in its r
 
 // ---------------------------------------------------------------------------------------------------
 // Harness: everything injected, everything recorded. The fake fs serves writes from a Map but lets
-// reads FALL THROUGH to the real filesystem, so renders exercise the actual deploy/ templates.
+// reads FALL THROUGH to the real filesystem, so renders exercise the actual deploy/ templates. The
+// three path seams (cwd = the deployment folder, moduleDir = where service.mjs lives, resolveReceiver)
+// replace the old injected repoRoot: they are what makes checkout AND npm layouts testable.
 // ---------------------------------------------------------------------------------------------------
 
 // The up.test.mjs fake spawn: plan keys are command-line prefixes mapped to an exit code, a
@@ -75,10 +88,22 @@ function fakeSpawn(plan, calls, events) {
 	};
 }
 
-function harness({ platform = "linux", argv = [], files = {}, euid = 501, plan = {}, queue = null, events = null } = {}) {
+function harness({
+	platform = "linux",
+	argv = [],
+	files = {},
+	euid = 501,
+	plan = {},
+	queue = null,
+	events = null,
+	cwd = DEPLOY_AT,
+	moduleDir = WORKER_SRC,
+	resolveReceiver = () => RECEIVER_START,
+} = {}) {
 	const calls = [];
 	const buf = [];
 	const errBuf = [];
+	const mkdirs = [];
 	const store = new Map(Object.entries(files));
 	let clock = 0;
 	const deps = {
@@ -86,7 +111,9 @@ function harness({ platform = "linux", argv = [], files = {}, euid = 501, plan =
 		platform,
 		euid,
 		execPath: "/fake/node/bin/node",
-		repoRoot: REPO_ROOT,
+		cwd,
+		moduleDir,
+		resolveReceiver,
 		home: "/home/tester",
 		user: "tester",
 		tmp: "/faketmp",
@@ -104,27 +131,35 @@ function harness({ platform = "linux", argv = [], files = {}, euid = 501, plan =
 			existsSync: (p) => store.has(p),
 			readFileSync: (p, encoding) => (store.has(p) ? store.get(p) : readFileSync(p, encoding)),
 			writeFileSync: (p, data) => store.set(p, data),
-			mkdirSync: () => {},
+			mkdirSync: (p) => mkdirs.push(p),
 			unlinkSync: (p) => store.delete(p),
 		},
 	};
-	return { run: () => runService(argv, deps), calls, store, text: () => buf.join(""), errText: () => errBuf.join("") };
+	return { run: () => runService(argv, deps), calls, store, mkdirs, text: () => buf.join(""), errText: () => errBuf.join("") };
 }
 
 const USER_UNIT = "/home/tester/.config/systemd/user/pi-dispatch-worker.service";
 const AGENT_PLIST = "/home/tester/Library/LaunchAgents/com.pi-dispatch.worker.plist";
 
+/** The <string> values of the rendered plist's ProgramArguments ARRAY — not the comment prose. */
+function programArguments(plist) {
+	const block = plist.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/);
+	assert.ok(block, "the plist has a ProgramArguments array");
+	return [...block[1].matchAll(/<string>([\s\S]*?)<\/string>/g)].map((m) => m[1]);
+}
+
 // ---------------------------------------------------------------------------------------------------
-// render
+// render — checkout layout (moduleDir = worker/src, so every substituted path must EXIST here)
 // ---------------------------------------------------------------------------------------------------
 
-test("render linux --user: execPath and repo root land; the exit-2 and crash-loop semantics survive; User= is stripped", async () => {
+test("render linux --user: ExecStart is the absolute module-relative cli, the deployment folder owns WorkingDirectory and .env; the exit-2 and crash-loop semantics survive; User= is stripped", async () => {
 	const h = harness({ platform: "linux", argv: ["render"] });
 	assert.equal(await h.run(), 0);
 	const text = h.text();
-	assert.match(text, new RegExp(`ExecStart=/fake/node/bin/node worker/src/cli\\.mjs worker`));
-	assert.ok(text.includes(`WorkingDirectory=${REPO_ROOT}`), "repo root landed in WorkingDirectory");
-	assert.ok(text.includes(`EnvironmentFile=${REPO_ROOT}/.env`), "repo root landed in EnvironmentFile");
+	assert.ok(text.includes(`ExecStart=/fake/node/bin/node ${CLI_PATH} worker`), "ExecStart = <node> <cliPath> worker");
+	assert.ok(existsSync(CLI_PATH), "the checkout-layout cliPath must be a real file");
+	assert.ok(text.includes(`WorkingDirectory=${DEPLOY_AT}`), "the deployment folder landed in WorkingDirectory");
+	assert.ok(text.includes(`EnvironmentFile=${DEPLOY_AT}/.env`), ".env is looked up in the deployment folder, never inside the package");
 	assert.match(text, /RestartPreventExitStatus=2/, "the EXIT_POLICY never-restart must survive byte-for-byte");
 	assert.match(text, /StartLimitBurst=5/, "the crash-loop bound must survive byte-for-byte");
 	assert.match(text, /StartLimitIntervalSec=60/);
@@ -142,48 +177,145 @@ test("render linux --system: User= is rewritten to the invoking user, WantedBy s
 	assert.match(h.text(), /WantedBy=multi-user\.target/);
 });
 
-test("render linux --receiver: receiver.service rendered with the same table", async () => {
+test("render linux --receiver: ExecStart is the receiver package's resolved ./start export", async () => {
 	const h = harness({ platform: "linux", argv: ["render", "--receiver"] });
 	assert.equal(await h.run(), 0);
-	assert.ok(h.text().includes("ExecStart=/fake/node/bin/node receiver/src/start.mjs"));
-	assert.ok(h.text().includes(`WorkingDirectory=${REPO_ROOT}`));
+	assert.ok(h.text().includes(`ExecStart=/fake/node/bin/node ${RECEIVER_START}`), "ExecStart = <node> <receiverStart>");
+	assert.ok(existsSync(RECEIVER_START), "the workspace-resolved receiver start must be a real file");
+	assert.ok(h.text().includes(`WorkingDirectory=${DEPLOY_AT}`));
 	assert.doesNotMatch(h.text(), /^User=/m);
 	assert.match(h.text(), /pi-dispatch-receiver\.service/, "the receiver unit gets its own name");
 });
 
-test("render darwin: plist paths computed, node dir injected into PATH, KeepAlive shape intact, wrapper note printed", async () => {
+test("render darwin: ProgramArguments = sh + package wrapper + exec argv in order, logs under the deployment folder, node dir injected into PATH, KeepAlive shape intact, wrapper note printed", async () => {
 	const h = harness({ platform: "darwin", argv: ["render"] });
 	assert.equal(await h.run(), 0);
 	const text = h.text();
 	assert.ok(text.includes("<string>com.pi-dispatch.worker</string>"));
-	assert.ok(text.includes(`<string>${REPO_ROOT}/deploy/worker-env-wrapper.sh</string>`), "the wrapper path follows the repo root");
-	assert.ok(text.includes(`<string>${REPO_ROOT}/logs/worker.out.log</string>`));
+	assert.ok(text.includes(`<string>${WRAPPER_SH}</string>`), "the wrapper is the PACKAGE's copy (worker/deploy), not a repo-root guess");
+	assert.ok(existsSync(WRAPPER_SH), "the checkout-layout wrapper must be a real file");
+	// The exec argv contract: the wrapper runs "$@", so the plist must carry the full command after it.
+	// Scoped to the ProgramArguments ARRAY: the template's own comment block quotes example <string>s
+	// for hand-editors, which a whole-document search would trip over.
+	assert.deepEqual(
+		programArguments(text),
+		["/bin/sh", WRAPPER_SH, "/fake/node/bin/node", CLI_PATH, "worker"],
+		"sh, wrapper, node, cli, worker — in exec order",
+	);
+	assert.ok(text.includes(`<string>${DEPLOY_AT}/logs/worker.out.log</string>`), "daemon logs live under the deployment folder");
 	// launchd's default PATH cannot see an nvm/Homebrew node; the render must pin the installing node's dir.
 	assert.ok(text.includes("<string>/fake/node/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>"), "node's directory is prepended to the service PATH");
 	assert.ok(text.includes("<key>SuccessfulExit</key>"), "the KeepAlive crash-only-restart shape survives");
 	assert.match(text, /converts a policy refusal \(exit 2/, "the wrapper note explains the exit-2 conversion");
 });
 
-test("render darwin --receiver: derived plist swaps label and logs and passes the receiver argument to the shared wrapper", async () => {
+test("render darwin --receiver: derived plist swaps label and logs and carries the receiver's exec argv — the old `receiver` selector argument is gone", async () => {
 	const h = harness({ platform: "darwin", argv: ["render", "--receiver"] });
 	assert.equal(await h.run(), 0);
 	const text = h.text();
 	assert.ok(text.includes("<string>com.pi-dispatch.receiver</string>"));
 	assert.ok(!text.includes("<string>com.pi-dispatch.worker</string>"), "the worker label must not survive the derivation");
-	assert.ok(text.includes("<string>receiver</string>"), "the wrapper argument that selects the receiver");
+	assert.deepEqual(
+		programArguments(text),
+		["/bin/sh", WRAPPER_SH, "/fake/node/bin/node", RECEIVER_START],
+		"the receiver argv is the whole difference — no `receiver` selector argument, no worker cli",
+	);
 	assert.ok(text.includes("receiver.out.log") && text.includes("receiver.err.log"));
 });
 
-test("render win32: the nssm sequence carries computed paths and the AppExit pair byte-for-byte", async () => {
+test("render win32: the nssm sequence carries the package wrapper + exec argv and the AppExit pair byte-for-byte", async () => {
 	const h = harness({ platform: "win32", argv: ["render"] });
 	assert.equal(await h.run(), 0);
 	const text = h.text();
-	assert.ok(text.includes(`nssm install pi-dispatch-worker "${REPO_ROOT}\\deploy\\worker-env-wrapper.cmd"`));
-	assert.ok(text.includes(`"${REPO_ROOT}\\logs\\worker.out.log"`));
+	assert.ok(text.includes(`nssm install pi-dispatch-worker ${WRAPPER_CMD} /fake/node/bin/node ${CLI_PATH} worker`), "Application = the package wrapper; AppParameters = the exec argv");
+	assert.ok(text.includes(`nssm set pi-dispatch-worker AppDirectory ${DEPLOY_AT}`), "AppDirectory = the deployment folder — the wrapper's ./.env contract");
+	assert.ok(text.includes(`"${DEPLOY_AT}\\logs\\worker.out.log"`), "logs live under the deployment folder");
 	assert.match(text, /AppExit Default Restart/);
 	assert.match(text, /AppExit 2 Exit/, "the EXIT_POLICY never-retry must survive");
 	assert.match(text, /AppStopMethodConsole 15000/, "the console-stop grace must survive");
 	assert.match(text, /AppThrottle 5000/, "the crash-loop throttle must survive");
+});
+
+// ---------------------------------------------------------------------------------------------------
+// render — npm layout (issue #96): moduleDir is <deployment>/node_modules/@edgehero/pi-dispatch/src
+// under a real tmpdir, with real files, so "the rendered path EXISTS" is a filesystem fact, not a
+// string-shape opinion. This is exactly the layout where the old repoRoot ("../..") landed on the
+// @edgehero SCOPE directory and every rendered unit pointed at nothing.
+// ---------------------------------------------------------------------------------------------------
+
+function npmLayout() {
+	const dep = mkdtempSync(join(tmpdir(), "pi-dispatch-npmdep-"));
+	const pkg = join(dep, "node_modules", "@edgehero", "pi-dispatch");
+	mkdirSync(join(pkg, "src"), { recursive: true });
+	writeFileSync(join(pkg, "src", "cli.mjs"), "// stands in for the packed cli.mjs\n");
+	mkdirSync(join(pkg, "deploy"), { recursive: true });
+	// The real shipped mirrors, copied byte-for-byte: the render must read ITS package's templates.
+	for (const name of readdirSync(DEPLOY_DIR)) {
+		writeFileSync(join(pkg, "deploy", name), readFileSync(join(DEPLOY_DIR, name)));
+	}
+	const receiverStart = join(dep, "node_modules", "@edgehero", "pi-dispatch-receiver", "src", "start.mjs");
+	mkdirSync(dirname(receiverStart), { recursive: true });
+	writeFileSync(receiverStart, "// stands in for the packed start.mjs\n");
+	return { dep, moduleDir: join(pkg, "src"), receiverStart };
+}
+
+test("npm layout: the rendered linux unit points at files that EXIST under node_modules — never the @edgehero scope dir", async () => {
+	const { dep, moduleDir } = npmLayout();
+	const h = harness({ platform: "linux", argv: ["render"], cwd: dep, moduleDir });
+	assert.equal(await h.run(), 0);
+	const text = h.text();
+	const exec = text.match(/^ExecStart=(\S+) (\S+) worker$/m);
+	assert.ok(exec, "ExecStart parses as <node> <cliPath> worker");
+	assert.equal(exec[1], "/fake/node/bin/node");
+	assert.ok(existsSync(exec[2]), `the rendered ExecStart target must exist: ${exec[2]}`);
+	assert.ok(exec[2].includes(join("node_modules", "@edgehero", "pi-dispatch", "src")), "the cli comes from the PACKAGE");
+	assert.ok(!text.includes(join("@edgehero", "worker")), "the issue #96 scope-dir path shape must never render");
+	assert.ok(text.includes(`EnvironmentFile=${dep}/.env`), ".env is the deployment folder's, beside node_modules");
+	assert.ok(text.includes(`WorkingDirectory=${dep}`));
+});
+
+test("npm layout: the plist's wrapper and exec argv exist in the package and logs land in the deployment folder", async () => {
+	const { dep, moduleDir } = npmLayout();
+	const h = harness({ platform: "darwin", argv: ["render"], cwd: dep, moduleDir });
+	assert.equal(await h.run(), 0);
+	const text = h.text();
+	const cli = join(moduleDir, "cli.mjs");
+	const wrapper = join(dep, "node_modules", "@edgehero", "pi-dispatch", "deploy", "worker-env-wrapper.sh");
+	assert.deepEqual(
+		programArguments(text),
+		["/bin/sh", wrapper, "/fake/node/bin/node", cli, "worker"],
+		"sh, the PACKAGE's shipped wrapper, then the exec argv the wrapper runs",
+	);
+	assert.ok(existsSync(wrapper), `the wrapper path must exist: ${wrapper}`);
+	assert.ok(existsSync(cli), `the cli path must exist: ${cli}`);
+	assert.ok(text.includes(`<string>${dep}/logs/worker.out.log</string>`), "logs belong to the deployment folder, not the package");
+});
+
+test("npm layout: the receiver render uses the resolved receiver package; win32 nssm uses the package wrapper and the deployment folder", async () => {
+	const { dep, moduleDir, receiverStart } = npmLayout();
+	const r = harness({ platform: "linux", argv: ["render", "--receiver"], cwd: dep, moduleDir, resolveReceiver: () => receiverStart });
+	assert.equal(await r.run(), 0);
+	assert.ok(r.text().includes(`ExecStart=/fake/node/bin/node ${receiverStart}`), "ExecStart = the sibling-installed receiver package's start");
+	assert.ok(existsSync(receiverStart));
+	const w = harness({ platform: "win32", argv: ["render"], cwd: dep, moduleDir });
+	assert.equal(await w.run(), 0);
+	const wrapperCmd = join(dep, "node_modules", "@edgehero", "pi-dispatch", "deploy", "worker-env-wrapper.cmd");
+	assert.ok(w.text().includes(`nssm install pi-dispatch-worker ${wrapperCmd} /fake/node/bin/node ${join(moduleDir, "cli.mjs")} worker`));
+	assert.ok(existsSync(wrapperCmd), "the .cmd wrapper ships in the package");
+	assert.ok(w.text().includes(`nssm set pi-dispatch-worker AppDirectory ${dep}`));
+});
+
+test("--receiver with no receiver package installed: render and install both refuse with the npm install hint, writing nothing", async () => {
+	const r = harness({ platform: "linux", argv: ["render", "--receiver"], resolveReceiver: () => null });
+	assert.equal(await r.run(), 1);
+	assert.match(r.errText(), /receiver package is not installed here/);
+	assert.match(r.errText(), /npm install @edgehero\/pi-dispatch-receiver/);
+	assert.match(r.errText(), /from the deployment folder/);
+	const i = harness({ platform: "darwin", argv: ["install", "--receiver"], resolveReceiver: () => null, plan: { launchctl: 0 } });
+	assert.equal(await i.run(), 1);
+	assert.match(i.errText(), /npm install @edgehero\/pi-dispatch-receiver/);
+	assert.equal(i.store.size, 0, "nothing written after the refusal");
+	assert.equal(i.calls.length, 0, "nothing spawned after the refusal");
 });
 
 // ---------------------------------------------------------------------------------------------------
@@ -199,12 +331,14 @@ test("install darwin: refuses euid 0 outright — no writes, no spawns", async (
 	assert.equal(h.calls.length, 0, "nothing spawned");
 });
 
-test("install darwin: writes the LaunchAgent, bootstraps and enables it, and prints the honest login-scope note", async () => {
+test("install darwin: writes the LaunchAgent with the exec argv, creates the logs dir, bootstraps and enables it, and prints the honest login-scope note", async () => {
 	const h = harness({ platform: "darwin", argv: ["install"], plan: { launchctl: 0 } });
 	assert.equal(await h.run(), 0);
 	const plist = h.store.get(AGENT_PLIST);
 	assert.ok(plist, "plist written into ~/Library/LaunchAgents");
-	assert.ok(plist.includes(`<string>${REPO_ROOT}/deploy/worker-env-wrapper.sh</string>`));
+	assert.ok(plist.includes(`<string>${WRAPPER_SH}</string>`), "the installed plist runs the package wrapper");
+	assert.ok(plist.includes(`<string>${CLI_PATH}</string>`) && plist.includes("<string>worker</string>"), "the installed plist carries the exec argv");
+	assert.ok(h.mkdirs.includes(`${DEPLOY_AT}/logs`), "launchd will not create StandardOutPath's directory — install must");
 	const argvs = h.calls.map((c) => [c.cmd, ...c.args].join(" "));
 	assert.deepEqual(argvs, [`launchctl bootstrap gui/501 ${AGENT_PLIST}`, "launchctl enable gui/501/com.pi-dispatch.worker"]);
 	assert.match(h.text(), /LOGIN-scoped/, "no pretending a LaunchAgent is a boot daemon");
@@ -230,6 +364,7 @@ test("install linux --user: unit written without User=, daemon-reload then enabl
 	const unit = h.store.get(USER_UNIT);
 	assert.ok(unit, "unit written into ~/.config/systemd/user");
 	assert.doesNotMatch(unit, /^User=/m);
+	assert.ok(unit.includes(`ExecStart=/fake/node/bin/node ${CLI_PATH} worker`), "the installed unit carries the absolute cli path");
 	assert.match(unit, /RestartPreventExitStatus=2/);
 	assert.match(unit, /WantedBy=default\.target/);
 	const argvs = h.calls.map((c) => c.args);
@@ -248,6 +383,7 @@ test("install linux --system: prints the exact sudo commands, stages the render,
 	assert.ok(staged, "the render is staged for inspection");
 	assert.match(staged, /^User=tester$/m, "system scope keeps a User= line, rewritten to the invoking user");
 	assert.match(staged, /RestartPreventExitStatus=2/);
+	assert.ok(staged.includes(`EnvironmentFile=${DEPLOY_AT}/.env`), "the staged render still points .env at the deployment folder");
 	assert.ok(h.text().includes("sudo install -m 644 /faketmp/pi-dispatch-worker.service /etc/systemd/system/pi-dispatch-worker.service"));
 	assert.ok(h.text().includes("sudo systemctl daemon-reload"));
 	assert.ok(h.text().includes("sudo systemctl enable --now pi-dispatch-worker.service"));
@@ -299,21 +435,22 @@ test("install win32: nssm absent → the download pointer, nothing else", async 
 	assert.match(h.errText(), /Task Scheduler is not a substitute/);
 });
 
-test("install win32: drives the nssm-install.cmd sequence with computed paths, AppExit 2 Exit included", async () => {
+test("install win32: drives the nssm-install.cmd sequence — package wrapper + exec argv, AppDirectory = deployment folder, AppExit 2 Exit included", async () => {
 	const h = harness({ platform: "win32", argv: ["install"], plan: { "nssm status": 3, nssm: 0 } });
 	assert.equal(await h.run(), 0);
 	const argvs = h.calls.map((c) => c.args);
 	assert.deepEqual(argvs[0], ["status", "pi-dispatch-worker"], "the probe that answers both on-PATH and already-exists");
 	assert.deepEqual(argvs.slice(1), [
-		["install", "pi-dispatch-worker", `${REPO_ROOT}\\deploy\\worker-env-wrapper.cmd`],
-		["set", "pi-dispatch-worker", "AppDirectory", REPO_ROOT],
-		["set", "pi-dispatch-worker", "AppStdout", `${REPO_ROOT}\\logs\\worker.out.log`],
-		["set", "pi-dispatch-worker", "AppStderr", `${REPO_ROOT}\\logs\\worker.err.log`],
+		["install", "pi-dispatch-worker", WRAPPER_CMD, "/fake/node/bin/node", CLI_PATH, "worker"],
+		["set", "pi-dispatch-worker", "AppDirectory", DEPLOY_AT],
+		["set", "pi-dispatch-worker", "AppStdout", `${DEPLOY_AT}\\logs\\worker.out.log`],
+		["set", "pi-dispatch-worker", "AppStderr", `${DEPLOY_AT}\\logs\\worker.err.log`],
 		["set", "pi-dispatch-worker", "AppStopMethodConsole", "15000"],
 		["set", "pi-dispatch-worker", "AppThrottle", "5000"],
 		["set", "pi-dispatch-worker", "AppExit", "Default", "Restart"],
 		["set", "pi-dispatch-worker", "AppExit", "2", "Exit"],
 	]);
+	assert.ok(h.mkdirs.includes(join(DEPLOY_AT, "logs")), "nssm will not create the AppStdout directory — install must");
 	assert.match(h.text(), /nssm start pi-dispatch-worker/);
 });
 
@@ -447,28 +584,29 @@ test("--user and --system together refuse; --system refuses on macOS", async () 
 });
 
 // ---------------------------------------------------------------------------------------------------
-// The real wrapper under a real sh: the exit-2 conversion and the SIGTERM forwarding are behaviour of
-// deploy/worker-env-wrapper.sh itself, so these tests execute the shipped file with a stub `node` on
-// PATH. POSIX-only (win32 has no sh).
+// The real wrapper under a real sh: the exit-2 conversion, the SIGTERM forwarding, the ./.env contract
+// and the argv contract are behaviour of deploy/worker-env-wrapper.sh itself, so these tests execute
+// the shipped file exactly the way a rendered unit does: cwd = the deployment folder (the unit's
+// WorkingDirectory) and the command as arguments. POSIX-only (win32 has no sh).
 // ---------------------------------------------------------------------------------------------------
 
 const POSIX = process.platform === "linux" || process.platform === "darwin";
+const REAL_WRAPPER = join(REPO_ROOT, "deploy", "worker-env-wrapper.sh");
 
-function wrapperDir(nodeStub) {
+function wrapperDir(nodeStub, { env = true } = {}) {
 	const dir = mkdtempSync(join(tmpdir(), "pi-dispatch-wrapper-"));
-	mkdirSync(join(dir, "deploy"));
-	writeFileSync(join(dir, "deploy", "worker-env-wrapper.sh"), readFileSync(join(REPO_ROOT, "deploy", "worker-env-wrapper.sh")));
-	writeFileSync(join(dir, ".env"), "PI_WRAPPER_TEST=1\n");
+	if (env) writeFileSync(join(dir, ".env"), "PI_WRAPPER_TEST=1\n");
 	mkdirSync(join(dir, "bin"));
 	writeFileSync(join(dir, "bin", "node"), nodeStub);
 	chmodSync(join(dir, "bin", "node"), 0o755);
 	return dir;
 }
 
-function runWrapper(dir, { onSpawn } = {}) {
+function runWrapper(dir, { args, onSpawn } = {}) {
 	return new Promise((resolvePromise, reject) => {
-		const child = spawn("sh", [join(dir, "deploy", "worker-env-wrapper.sh")], {
-			env: { ...process.env, PATH: `${join(dir, "bin")}:${process.env.PATH}`, MARKER_DIR: dir },
+		const child = spawn("sh", [REAL_WRAPPER, ...(args ?? [join(dir, "bin", "node")])], {
+			cwd: dir,
+			env: { ...process.env, MARKER_DIR: dir },
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 		let stderr = "";
@@ -491,6 +629,30 @@ test("wrapper: every other nonzero exit passes through untouched (7 stays 7, so 
 	const dir = wrapperDir("#!/bin/sh\nexit 7\n");
 	const { code } = await runWrapper(dir);
 	assert.equal(code, 7);
+});
+
+test("wrapper: sources ./.env from its cwd and passes the trailing argv through to the command", { skip: !POSIX }, async () => {
+	// The stub proves both halves of the contract at once: the sourced variable arrived, and so did
+	// the argument after the script path (the `worker` in `<node> <cli> worker`).
+	const dir = wrapperDir('#!/bin/sh\n[ "$PI_WRAPPER_TEST" = "1" ] || exit 9\n[ "$1" = "worker" ] || exit 8\nexit 0\n');
+	const { code } = await runWrapper(dir, { args: [join(dir, "bin", "node"), "worker"] });
+	assert.equal(code, 0, "exit 9 = .env not sourced; exit 8 = argv not forwarded");
+});
+
+test("wrapper: refuses with no argv command — it no longer decides what to run", { skip: !POSIX }, async () => {
+	const dir = wrapperDir("#!/bin/sh\nexit 0\n");
+	const { code, stderr } = await runWrapper(dir, { args: [] });
+	assert.equal(code, 1);
+	assert.match(stderr, /no command given/);
+	assert.match(stderr, /pi-dispatch service render/, "points at the re-render that composes the argv");
+});
+
+test("wrapper: refuses when ./.env is absent from its cwd, naming the directory it looked in", { skip: !POSIX }, async () => {
+	const dir = wrapperDir("#!/bin/sh\nexit 0\n", { env: false });
+	const { code, stderr } = await runWrapper(dir);
+	assert.equal(code, 1);
+	assert.match(stderr, /\.env not found in \//, "the message names $PWD, an absolute directory");
+	assert.match(stderr, /deployment folder/, "the message explains the WorkingDirectory contract instead of guessing");
 });
 
 test("wrapper: SIGTERM to the wrapper reaches node (trap + kill + double wait replaces the old exec)", { skip: !POSIX }, async () => {


### PR DESCRIPTION
Closes #96. Makes `/dispatch` the default way to set up pi-dispatch, and fixes a shipped bug found while verifying it.

## Fixed: `service install` was broken for every npm deployment

`service.mjs` derived a "repo root" two directories above its own module. Right in a checkout; under `npm install` that is `node_modules/@edgehero`, the **scope directory**, so every rendered unit pointed at files that do not exist: the worker ExecStart, the receiver ExecStart, `EnvironmentFile`, the plist wrapper path, the nssm paths. The wizard's service step has been installing those units since it shipped. Tests never caught it because they injected a correct `repoRoot`; no npm-layout fixture existed.

Three anchors replace the guess, each correct in both layouts: **`deployDir`** (the cwd `service` runs from) owns everything host-side (WorkingDirectory, `.env`, and `logs/`, created at install time since launchd and nssm create log files but never their directory), **`cliPath`** is `cli.mjs` beside the service module, and **`receiverStart`** comes from `import.meta.resolve("@edgehero/pi-dispatch-receiver/start")`, with a loud refusal naming the install command when the package is absent instead of writing a unit that crash-loops at boot. The wrapper stops guessing too: cwd *is* the deployment folder, it refuses empty argv and a missing `.env` naming `$PWD`, then runs `"$@"` verbatim. The exit-2 conversion and SIGTERM forwarding are preserved and still asserted against the real shipped wrapper. `worker/deploy` also gains `docker-compose.yml`, so npm deployments can run the receiver profile.

**Existing service installs from 0.1.1 should re-run `pi-dispatch service install --force`** from their deployment folder.

## pi compatibility becomes strategy, not luck

As the advertised front door, a pi release must not break onboarding silently. The extension now reads pi's exported `VERSION` and, when it differs from the tested pin while the capability probe still passes, surfaces **one info line** on the first `/dispatch`. Never a refusal: the all-or-nothing capability probe stays the only hard gate. The peer pin widens to the `"*"` range pi's own packages doc prescribes for host-provided packages (the exact devDep stays the tested marker). And a weekly **canary** installs latest pi into a scratch dir (never the repo root, so the pinned assertions keep asserting the pin) and fails CI if any used API member or type needle disappears. Verified against **pi 0.83.0**, today's latest: the canary passes, so the advisory is what real operators on a newer pi will see.

## The default route

- **Direct entry**: bare `/dispatch` with nothing configured no longer asks a yes/no before showing the wizard's own opening select. That select (Guided setup / Open the panel anyway / Cancel) **is** the consent, and one keypress no longer costs two detections. A configured deployment with a down queue still keeps the unreachable banner and never enters the wizard.
- **Docker pre-check** (new step 3): distinguishes not-on-PATH from daemon-down, then a Re-check / Continue anyway / Stop loop with per-OS vendor pointers and never a command to pipe into a shell. The probe carries a 10 second timeout, because it is a synchronous exec on a dialog path and a wedged docker socket would otherwise freeze pi's render loop.
- **Trigger edge** (new step 10): the receiver as a user-level service (consented pinned install, version assertion, then `service install --receiver`, correct after the fix above), or the compose profile (compose file copied create-only), or the polling command printed, or skip. A receiver version mismatch skips the unit and continues; the receiver is optional, unlike the runtime install, which stops.
- **Skew notice**: when the deployed runtime falls behind the console's pin, one notice per process points at `/dispatch setup`, which is already the upgrade path.

## Docs

README quickstart leads with the extension route; the npx block moves to "Servers and headless" unchanged; the clone note stays for custom images. `admin/README` follows. `docs/launch-kit.md` gains the install line it never had. No dashes in README prose, per the house style.

## Specs

`DES-FIRST-RUN-SETUP-WIZARD` amended (direct entry, both new steps, the skew notice, `RECEIVER_VERSION`, the outage rule restated as load-bearing); `REQ-ADMIN-VIA-PI-EXTENSION` acceptance amended (lands in the select, Cancel spawns and writes nothing; an untested-but-complete pi is an advisory; the skew notice). Revision rows in `design.md` and `requirements.md` record the service-unit fix and the compatibility strategy. `CONST-BUDGET-BEFORE-TOKENS`, `CONST-RETRY-INFRA-ONLY`, `REQ-DEPLOYMENT-BOOTSTRAP` unchanged, checked.

## Tests

Full suite: **1871 tests, 1855 pass, 0 fail, 16 pre-existing skips** (from 1843). Worker service suite 30 → 37 (real npm-layout fixtures asserting rendered targets exist and never take the scope shape, the missing-receiver refusal, live-shell wrapper tests under the new argv contract); admin 341 → 360. Workflow YAML validated; `sh -n`, `xmllint`, and `plutil -lint` pass on the wrapper and a live render; CI greps and control-byte scans clean.
