### PR TITLE
docs: say what this project is, and stop underselling what ships

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,118 @@
+# Working on pi-dispatch
+
+Notes for an AI agent working in this repository. Short on purpose: `specs/` is the authority, and this file
+exists to stop you from having to discover the load-bearing parts by breaking them.
+
+## What this project is
+
+pi-dispatch runs the [pi](https://github.com/earendil-works/pi) coding agent as a service. It **lives in the
+background** and, on a cron schedule or a forge event (an issue, a comment, a pull request), opens a
+container that runs a flow against a repository, does the work, and shuts the container down. A panel shows
+the triggers, the history of every past run and the spend, and can turn the whole thing off.
+
+pi has no queue, no concurrency control, no spend limit and, by its own README, no permission system.
+**This project is exactly that missing operational layer and nothing else.** When a change would make
+pi-dispatch smarter about *what the agent does*, it probably belongs in a skill or a flow, not here.
+
+Two consequences worth internalising before you design anything:
+
+- **The container is the boundary.** Isolation is built by the worker's own `docker run` argv, so nothing an
+  image contains can weaken it.
+- **Money is the other boundary.** Every gate that costs nothing runs before every gate that costs
+  something, and a paid container starts only after all of them pass.
+
+## The shape
+
+| Path | What it is |
+|---|---|
+| `worker/` | the queue consumer, the CLI (`pi-dispatch`), the forge hosts, doctor, service installer |
+| `receiver/` | the always-on trigger edge (`pi-dispatch-receiver`): webhook routes and the poller |
+| `admin/` | the operator console, a pi extension (`/dispatch`), TypeScript, bundled to `dist/` |
+| `image/` | the job image and the in-container runner that implements the exit-code protocol |
+| `deploy/` | service units, wrappers and the compose file; `worker/deploy/` is the published mirror |
+| `specs/` | constitution, requirements, design, interfaces, open questions. The source of truth |
+| `docs/` | operator-facing reference, one file per feature or forge |
+
+## Read these before changing behaviour
+
+1. `specs/constitution.md` — the non-negotiables. A change that violates one must justify **the
+   constraint**, not the code, and amend that file in the same PR.
+2. `specs/design.md` — decisions that could have gone another way, and what was rejected.
+3. `specs/interfaces.md` — the file and container contracts, including the run-record shape.
+4. The revision history at the end of each spec file. It records corrections, not just additions, and
+   several entries exist because a previous claim was refuted.
+
+## Rules that bite
+
+- **Specs change in the same PR as the code**, with a revision-history row. When a spec entry is unaffected,
+  say so explicitly ("UNCHANGED, checked") rather than silently leaving it. Cite spec IDs
+  (`CONST-*`, `REQ-*`, `DES-*`, `INT-*`) in commit bodies; they are permanent addresses.
+- **Verify against the pinned artifact, not against HEAD.** pi is pinned to an exact npm version. A sha is
+  not a version, and this rule is in the constitution because ignoring it once nearly shipped a runner that
+  imported an export the pinned release did not have. Docs are a hint; source at the pin is evidence.
+- **`CONST-MERGE-NEVER-AUTOMATIC`.** Nothing in this project merges anything, ever. CI greps
+  `worker/src`, `receiver/src` and `image/runner` for `pulls.merge`, `gh pr merge`, `autoMerge` and friends,
+  so even a comment mentioning one fails the build.
+- **`CONST-BUDGET-BEFORE-TOKENS`.** Free, determinate refusals go before anything that spends: before the
+  token mint, the clone, the token-cap read and the budget reservation.
+- **`CONST-RETRY-INFRA-ONLY`.** A determinate policy refusal **returns** a result; only infrastructure
+  failure **throws** so the queue retries. Getting this backwards means either paying to retry something
+  that can never succeed, or dropping real work behind a silent success.
+- **Exact pins only** (`CONST-PI-VERSION-PINNED`). No `^`, `~`, `latest` or a floating tag for pi, for
+  staged pi packages, or for image bases. A floating range turns an upstream release into every queued job
+  quietly losing a tool while the queue still reports success.
+- **No secrets or PII in logs.** Log key *names*, never values, and never payload text. The run record is
+  PII-free by construction: it holds no attacker-chosen string.
+- **Fail loudly, or fail open and say which.** A silent no-op is the worst outcome available here. If a
+  feature cannot do what it was asked, it refuses with a reason an operator can act on. Where it fails open,
+  the reason is named in the record.
+
+## Style
+
+- **Tabs** in `worker/`, `receiver/`, `image/`. **Two spaces** in `admin/`. Double quotes, semicolons.
+  There is no linter, so match the file you are in.
+- Node 22.19 or newer.
+- Tests are `node:test` with hand-rolled, dependency-injected fakes. No mocking framework, no network, no
+  Docker in unit tests. Inject a seam rather than reaching for a global.
+- Comments explain **why**, and especially why the obvious alternative is wrong. This codebase is dense with
+  them on purpose; a comment that merely restates the code is noise, one that records a rejected approach is
+  the most valuable line in the file.
+- **Both READMEs avoid dashes as punctuation** (no em dash, no ` - `). Use commas, colons or parentheses.
+  Keep the images: they carry more than the prose does.
+
+## Tests and CI
+
+- `npm test` at the root runs every workspace. Run the whole suite before committing, not just the file you
+  touched: the workspaces share the triggers schema and the queue.
+- CI runs the same suite with `PI_DISPATCH_REQUIRE_{LOADER,WORKER,RECEIVER}_TESTS=1` and a live Valkey, which
+  is where the integration tests that skip locally actually execute.
+- `admin/dist/` is gitignored and built by `node admin/build.mjs`. Never commit it.
+- Two mirrors must stay **byte-identical**, pinned by tests: `worker/.env.example` to the root
+  `.env.example`, and `worker/deploy/*` to `deploy/*`. Edit both.
+- The wizard's `RUNTIME_VERSION` and `RECEIVER_VERSION` are bolted to the workspace versions by anti-drift
+  tests. A release bump moves all of them together.
+
+## Commits and PRs
+
+- Conventional subjects citing the issue number. The body explains *why*, names the spec IDs touched, and
+  states what was checked and left unchanged.
+- DCO sign-off (`git commit -s`). Branch names are `type/short-slug`.
+- One PR per issue where possible; stacked PRs are merged one at a time, parent first, never with
+  `--delete-branch` until the whole chain has landed.
+
+## Things that look like bugs and are not
+
+- **`resolveSession` returning `null` when no store is configured** is a DI-seam backstop; the processor
+  refuses such a job before it spends, so the store's own branch is unreachable in a wired worker.
+- **The overlay's `extensions/` load by default** while staged packages are withheld per trigger. Two
+  different switches, deliberately: see `docs/global-pi-overlay.md`.
+- **A serviced repo's `.pi/extensions` really does load in a job.** `/workspace` is the base repo's
+  default-branch sha, so it is merge-gated content, never a fork's branch.
+- **The staged-package manifest is read once at worker boot**, not per job, because the overlay is
+  deploy-time state under a read-only mount.
+
+## One note on this file
+
+`CLAUDE.md` is read by the agent working on **this repository**. It is not `AGENTS.md`: pi discovers
+`AGENTS.md` natively, so a root `AGENTS.md` here would also be loaded into every job that services this
+repo. Keep instructions meant for maintenance out of the job containers.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 # pi-dispatch
 
-**Run the [pi](https://github.com/earendil-works/pi) coding agent as a service: triggered on demand, on a
-cron schedule, or by a GitHub or GitLab issue, comment or pull request. Every job runs in a container you
-control, behind a durable queue, a spend cap, and a live admin panel.**
+**Run the [pi](https://github.com/earendil-works/pi) coding agent as a service. It lives in the background
+and, on a schedule or on an issue, comment or pull request from GitHub, GitLab, Forgejo or Azure DevOps,
+opens a container, runs your flow against the repo, and shuts the container down. Every job runs behind a
+durable queue, a spend cap, and a live admin panel you can turn the whole thing off from.**
 
 ![The /dispatch dashboard overlay, theme-colored: live queue state, day/week/month spend meters plus a daily token counter, the unified triggers pane (cron, label, comment, pull_request; selectable and editable), scheduled pause windows, and the interactive runs list, in one framed TUI](docs/images/dispatch-dashboard.svg?v=0.5.0)
 
@@ -466,10 +467,18 @@ a frontend, screenshot it, and iterate until it renders right.
 
 ## Status
 
-The local path, the GitHub path, the GitLab path, cron scheduling, the service installer, and the admin
-extension are built and work. The design is specified in [`specs/`](specs/): start with
-[`specs/constitution.md`](specs/constitution.md) for the non-negotiables and
-[`specs/design.md`](specs/design.md) for the decisions and what was rejected.
+Everything this README describes is built and running: four forges (GitHub, GitLab, Forgejo and Gitea,
+Azure DevOps), cron and CLI jobs, the durable queue with spend caps in four windows, resumable sessions,
+replica runs, per trigger job images, quiet hours, cost analytics, resurrectable sandboxes, the service
+installer for all three platforms, and the admin console with guided first run setup.
+
+The design is specified in [`specs/`](specs/), and the specs are the source of truth rather than a summary
+of the code: start with [`specs/constitution.md`](specs/constitution.md) for the non-negotiables,
+[`specs/design.md`](specs/design.md) for the decisions and what was rejected, and
+[`specs/interfaces.md`](specs/interfaces.md) for the file and container contracts. Every spec file ends with
+a revision history that records what changed and why, including the corrections.
+
+Working on this repo with an AI agent? [`CLAUDE.md`](CLAUDE.md) is the short version of what matters here.
 
 ## Contributing
 

--- a/docs/global-pi-overlay.md
+++ b/docs/global-pi-overlay.md
@@ -112,6 +112,23 @@ present but dormant is a deployment missing the setup its flows were written aga
    reports it, the runner refuses the job — because the damaging misreading is now "I thought I had turned
    these off", where before a typo merely left them dormant.
 
+**Three sources of extension code reach a job, and only one of them is this overlay.** Worth stating in one
+place, because two of them are easy to forget and #58 originally called the third a non-goal:
+
+| Source | Where it comes from | How to withhold it |
+|---|---|---|
+| the overlay's `extensions/` | your own host setup, staged here by `import-pi` | `PI_GLOBAL_ALLOW_EXTENSIONS=0` |
+| a staged package's extensions | pinned third-party code under `packages/` | `"packages": false` on the trigger |
+| the serviced repo's `.pi/extensions` | the repo being worked on, discovered natively by pi | nothing here: it is the repo's own tree |
+
+The third one surprises people, and it is deliberate. pi's normal discovery posture is on
+(`noExtensions: false`), and `/workspace` holds the **base repo's default-branch sha**, so what loads is
+merge-gated content and never a fork's branch on a pull-request job — which is why this does not reopen the
+fork-adversarial hole #58 closed. Precedence runs repo mount, then overlay, then staged packages, then
+whatever discovery finds under `/workspace`, first path wins, so a discovered repo extension is last of all
+and shadows nothing you staged. The recursion guard drops any extension named like the admin console or
+registering a `dispatch_*` tool, wherever it came from.
+
 The rule of thumb inverted with the default: what you would not want running in a job container should not
 be in the overlay. Never place the admin extension there (it can enqueue paid jobs — a recursion vector;
 `import-pi` blocks it, but treat it as a rule).


### PR DESCRIPTION
Came out of reading the closed issues to find the project's actual goal, then checking whether the README says it.

## The goal, as the record states it

#8 (`[epic] Realize the vision`) still holds the only plain statement, quoted there from the original `DESIGN.md`:

> pi-dispatch should **live in the background** and, on a **cron / webhook / GitHub trigger**, spin up a **container that opens the repo in pi, runs a prompt, does the work, and shuts the container down** — with a **main panel** to see triggers, read the logs of every past run, manage them, change settings, and **turn pi-dispatch on/off**.

That epic listed five pillars: three missing, one partial, one built. **All five ship now**, and the closed set traces the arc exactly (#3 cron, #4 history, #1 receiver, #2 clone to PR, #6 service, #5 panel, then #42/#43/#61 for breadth, #48/#53/#55/#56/#58 for depth, #80/#81/#82/#92/#96 for setup).

#8 also flagged that the README headline *"undersells the product, it reads as a local dev tool"*. That was fixed, and has since drifted again in two ways.

## What this PR changes

**The headline named two forges out of four.** Forgejo/Gitea (#61) and Azure DevOps (#43) shipped with full setup docs and their own receiver arms. The #99 docs audit fixed this exact staleness in `admin/README.md` and the launch kit and never touched the root README's first sentence. It now names all four, and states the shape (lives in the background, opens a container, shuts it down, panel can turn it off) instead of implying it, because that is what separates this from a CLI tool.

**Status read like a project a third of the way in.** It listed six things as built, omitting two forges, resumable sessions, replica runs, per-trigger images, quiet hours, cost analytics, sandboxes and the entire guided-setup path. It now says what runs, and points at `specs/` as the source of truth rather than as background reading, naming the revision histories since that is where the corrections live.

**New `CLAUDE.md`.** There was nothing at the root telling an agent or a new contributor what matters here: `specs/constitution.md` is the real authority and was cited exactly once, inside a paragraph about project status. The new file is short and defers to the specs rather than restating them. It carries the goal, the layout, what to read first, the constraints that bite with their IDs (`CONST-MERGE-NEVER-AUTOMATIC`, `CONST-BUDGET-BEFORE-TOKENS`, `CONST-RETRY-INFRA-ONLY`, the exact-pin rule, the pinned-artifact evidence rule), the style split, the two byte-identical mirrors, the anti-drift version pins, and a closing list of four things that look like bugs and are not.

It is `CLAUDE.md` and not `AGENTS.md` deliberately: pi discovers `AGENTS.md` natively, so a root `AGENTS.md` in this repo would be loaded into every job that services this repo. Maintenance notes do not belong in a job container.

**One reconciliation, now stated in one place.** `docs/global-pi-overlay.md` gains a table: three sources of extension code reach a job, and only one is the overlay (the overlay's `extensions/`, a staged package's, and the serviced repo's own `.pi/extensions`). #58 treated a repo's `.pi/extensions` as code that must not run, and today it runs, because the pi-normal discovery posture landed afterwards. That is not a reversal of #58's reasoning: `/workspace` holds the base repo's **default-branch sha**, so what loads is merge-gated content and never a fork's branch on a pull-request job. The two read as contradictory unless someone says that out loud, so now the doc does, with the precedence order and the recursion guard that applies wherever an extension came from.

## Verification

1909 tests, 0 failures. Both READMEs stay dash-free per the house style, every relative link in the touched files resolves, and no control bytes. The CI claims in `CLAUDE.md` were checked against `pi-upgrade-check.yml` rather than written from memory.
