### PR TITLE
fix: import-pi staged a symlinked skill by copying its target (issue #60)

### DIFF
--- a/worker/src/copy-tree.mjs
+++ b/worker/src/copy-tree.mjs
@@ -1,0 +1,215 @@
+import { lstatSync, mkdirSync, readdirSync, copyFileSync, writeFileSync, readFileSync } from "node:fs";
+import { isAbsolute, join, relative } from "node:path";
+
+/**
+ * A valid skill/extension entry name: lowercase kebab/underscore, no leading dot (so no ".." and no
+ * dotfiles) and no slashes.
+ *
+ * It MOVED here from import-pi.mjs, which still re-exports it so every existing import path keeps
+ * working -- this codebase does not rename an address that already has readers. The owner is now the
+ * module that actually enforces it, because import-pi.mjs importing the copier while the copier
+ * imported the charset back would be a cycle for one regex.
+ */
+export const ENTRY_NAME_RE = /^[a-z0-9](?:[a-z0-9_.-]{0,62}[a-z0-9])?$/i;
+
+/**
+ * Copy a directory of skills from the HOST filesystem into a destination the job container will read.
+ *
+ * Two callers, deliberately one implementation: `import-pi` staging `~/.pi/agent/skills` into the
+ * operator's global overlay, and the per-trigger `run.skillsDir` injection (issue #60). They differ
+ * only in whether caps apply and what mode the copies get, both of which are parameters.
+ *
+ * THE SYMLINK GUARD IS THE REASON THIS MODULE EXISTS. The code it replaces tested
+ * `fs.statSync(p).isSymbolicLink?.()`, and `statSync` FOLLOWS links, so that expression is
+ * permanently `false`: a symlinked skill directory under `~/.pi/agent/skills` was copied AS ITS
+ * TARGET'S CONTENTS into an overlay that is `:ro`-mounted into every adversarial-input container.
+ * The repo already knew -- `import-pi.mjs` says so where it explains why package staging uses
+ * `renameSync` instead -- but the skills path still had the broken guard. `lstatSync` is the fix, and
+ * it is the habit two other modules already keep for exactly this reason (`outbox.mjs`:
+ * "lstat (NOT stat) so a symlink is rejected on its own inode, not followed"; `sandbox-store.mjs`).
+ *
+ * Every other rule here mirrors `materialize.mjs`, which solves the same problem against a git tree
+ * rather than a filesystem: regular files only, destination paths rebuilt from validated name
+ * segments rather than taken from the source string, containment re-checked, and caps that refuse
+ * rather than truncate.
+ *
+ * NEVER THROWS for a per-entry problem: a symlink, a device node, a badly named entry is SKIPPED and
+ * counted. A cap breach, an unreadable root, or an empty result returns `{ refused: "<reason>" }` and
+ * the caller decides the outcome class. A read error past the caller's own existence check is also a
+ * refusal rather than a throw, and that is deliberate: the reflex is to call an EIO infrastructure and
+ * retry it, but this directory is operator-side layout that a retry cannot change.
+ *
+ * The receipt carries COUNTS ONLY -- no names, no paths. It is built to be logged, and a host path in
+ * a log line is the leak `packages.mjs`'s `dropped` record is shaped to avoid.
+ */
+
+/** The bounds on one trigger's injected skills. `import-pi` passes none: the overlay is not per job. */
+export const INJECT_LIMITS = Object.freeze({
+	// The binding one, and its reason is NOT disk. Every loaded skill contributes a <name> and a
+	// description (spec-capped at 1024 chars) to the SYSTEM PROMPT of every job of that trigger, so
+	// this bounds the cached prefix rather than the filesystem. UNVERIFIED figure, in the sense
+	// ISOLATION_FLAGS' --pids-limit=512 is: a ceiling on absurdity, not a measured budget.
+	maxDirs: 64,
+	maxFiles: 512,
+	maxBytes: 4 << 20,
+	maxDepth: 8,
+});
+
+/**
+ * Copy `<src>/<name>/**` for every valid child directory of `src`.
+ *
+ * @param src   host directory whose CHILDREN are skill directories (the `~/.pi/agent/skills` layout)
+ * @param dest  destination root; `<dest>/<name>/...` is created
+ * @param fs    injected for tests; defaults to the real sync fs
+ * @param limits  caps to enforce, or `null` for none (import-pi's staging path)
+ * @param mode  file mode for each copy, or `null` to preserve the source's
+ * @param onSkip  called with (name, reason) for a skipped TOP-LEVEL entry, so import-pi can print it
+ */
+export function copySkillTree(
+	src,
+	dest,
+	{ fs = defaultFs, limits = INJECT_LIMITS, mode = 0o444, onSkip = () => {} } = {},
+) {
+	const tally = blankTally();
+
+	let names;
+	try {
+		names = fs.readdirSync(src);
+	} catch {
+		return { refused: "skills-dir-unreadable" };
+	}
+
+	for (const name of names) {
+		// The name charset is the traversal choke point, and it is checked BEFORE the name is joined
+		// into any path -- the same ordering flow-gate.mjs uses on `flow`. ENTRY_NAME_RE's leading
+		// character class excludes ".", so "." and ".." cannot match and no separate test is needed.
+		if (!ENTRY_NAME_RE.test(name)) {
+			tally.skipped.badNames++;
+			onSkip(name, "unexpected name");
+			continue;
+		}
+		const childSrc = join(src, name);
+		const st = statOrNull(fs, childSrc);
+		if (!st) {
+			tally.skipped.nonRegular++;
+			continue;
+		}
+		if (st.isSymbolicLink()) {
+			tally.skipped.symlinks++;
+			onSkip(name, "symlink");
+			continue;
+		}
+		if (!st.isDirectory()) {
+			tally.skipped.nonRegular++;
+			continue;
+		}
+		if (limits && tally.dirs >= limits.maxDirs) return { refused: "skills-dir-too-large" };
+		const refusal = copyDirContents(childSrc, join(dest, name), { fs, limits, mode, tally, depth: 1 });
+		if (refusal) return refusal;
+		tally.dirs++;
+	}
+
+	// An operator who pointed at the wrong directory and got a silently unchanged job is the "a silent
+	// no-op is the worst outcome available here" failure this project refuses. The CALLER decides
+	// whether emptiness is fatal (it is, for a trigger that asked for skills; it is not for import-pi,
+	// where an absent skills/ dir just means the operator has none).
+	if (tally.dirs === 0) return { refused: "skills-dir-empty", tally };
+	return tally;
+}
+
+/**
+ * Recursively copy the CONTENTS of one directory. Exported because `import-pi` needs exactly this and
+ * must not carry a second walker: its old one guarded symlinks with `statSync`, which follows them.
+ *
+ * Returns a `{ refused }` object or `null`. `tally` and `depth` are internal and default for an
+ * external caller, who gets an uncapped, mode-preserving copy.
+ */
+export function copyDirContents(src, dest, { fs = defaultFs, limits = null, mode = null, tally = blankTally(), depth = 1 } = {}) {
+	const ctx = { fs, limits, mode, tally, depth };
+	if (ctx.limits && ctx.depth > ctx.limits.maxDepth) return { refused: "skills-dir-too-deep" };
+	try {
+		fs.mkdirSync(dest, { recursive: true });
+	} catch {
+		return { refused: "skills-dir-unreadable" };
+	}
+	let entries;
+	try {
+		entries = fs.readdirSync(src);
+	} catch {
+		return { refused: "skills-dir-unreadable" };
+	}
+	for (const entry of entries) {
+		// Nested names get the same charset as the top level. A dotfile fails it, which matches pi's own
+		// loader (it skips entries starting with "."), so nothing is dropped that pi would have read.
+		if (!ENTRY_NAME_RE.test(entry)) {
+			ctx.tally.skipped.badNames++;
+			continue;
+		}
+		const s = join(src, entry);
+		const st = statOrNull(fs, s);
+		if (!st) {
+			ctx.tally.skipped.nonRegular++;
+			continue;
+		}
+		// lstat, so this is the LINK's own inode. Never followed, for a file or a directory: a directory
+		// symlink pointing at / would otherwise turn a skill copy into a copy of the host filesystem.
+		if (st.isSymbolicLink()) {
+			ctx.tally.skipped.symlinks++;
+			continue;
+		}
+		// The destination is rebuilt from the VALIDATED entry name, never from any source-supplied
+		// string, and containment is re-checked behind that as defence in depth.
+		const d = safeJoin(dest, entry);
+		if (st.isDirectory()) {
+			const refusal = copyDirContents(s, d, { ...ctx, depth: ctx.depth + 1 });
+			if (refusal) return refusal;
+			continue;
+		}
+		if (!st.isFile()) {
+			ctx.tally.skipped.nonRegular++; // fifo, socket, device node
+			continue;
+		}
+		if (ctx.limits) {
+			if (ctx.tally.files >= ctx.limits.maxFiles) return { refused: "skills-dir-too-many-files" };
+			if (ctx.tally.bytes + st.size > ctx.limits.maxBytes) return { refused: "skills-dir-too-large" };
+		}
+		try {
+			if (ctx.mode === null) {
+				fs.copyFileSync(s, d);
+			} else {
+				// Written rather than copied, because copyFileSync onto an existing 0444 file is EACCES and
+				// a re-stage must not fail on its own previous output.
+				fs.writeFileSync(d, fs.readFileSync(s), { mode: ctx.mode });
+			}
+		} catch {
+			return { refused: "skills-dir-unreadable" };
+		}
+		ctx.tally.files++;
+		ctx.tally.bytes += st.size;
+	}
+	return null;
+}
+
+function blankTally() {
+	return { dirs: 0, files: 0, bytes: 0, skipped: { symlinks: 0, badNames: 0, nonRegular: 0 } };
+}
+
+function statOrNull(fs, p) {
+	try {
+		return fs.lstatSync(p);
+	} catch {
+		return null;
+	}
+}
+
+/** Mirrors materialize.mjs's safeJoin: path.relative, not a string prefix, so it is correct on Windows. */
+function safeJoin(root, segment) {
+	const resolved = join(root, segment);
+	const rel = relative(root, resolved);
+	if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+		throw new Error("path escapes destination");
+	}
+	return resolved;
+}
+
+const defaultFs = { lstatSync, mkdirSync, readdirSync, copyFileSync, writeFileSync, readFileSync };

--- a/worker/src/import-pi.mjs
+++ b/worker/src/import-pi.mjs
@@ -23,15 +23,20 @@
  *           learn what pi has installed and what the operator turned off; reading is not copying, and no part
  *           of that file reaches the overlay.
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, statSync, copyFileSync, renameSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, lstatSync, statSync, copyFileSync, renameSync, rmSync } from "node:fs";
 import { execFile } from "node:child_process";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { FROM_HOST, PACKAGES_SUBDIR, RESOURCE_DIRS, STAGE_MANIFEST, mergeHostPackages, parsePackagesFile } from "./packages.mjs";
 import { agentDirFrom, readHostPi } from "./host-pi.mjs";
+import { ENTRY_NAME_RE, copyDirContents, copySkillTree } from "./copy-tree.mjs";
 
-/** A valid skill/extension entry name: lowercase kebab/underscore, no dots (no "..") and no slashes. */
-export const ENTRY_NAME_RE = /^[a-z0-9](?:[a-z0-9_.-]{0,62}[a-z0-9])?$/i;
+/**
+ * A valid skill/extension entry name. Defined in copy-tree.mjs, which is the module that enforces it,
+ * and re-exported from here because this is the address its readers already use (the materialiser's
+ * drift test, this module's own tests). Renaming an import path that has readers is not a tidy-up.
+ */
+export { ENTRY_NAME_RE };
 /** The admin extension — never duplicated into a job overlay (it can enqueue paid jobs: a recursion vector). */
 export const ADMIN_RE = /pi-dispatch|dispatch-admin/i;
 
@@ -91,7 +96,9 @@ export async function runImportPi(argv = [], deps = {}) {
 		env = process.env,
 		cwd = process.cwd(),
 		out = (s) => process.stdout.write(s),
-		fs = { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, statSync, copyFileSync, renameSync, rmSync },
+		// lstatSync rides along for the shared copier, whose symlink guard is the whole point of it: the
+		// walker this dir's copies used to go through guarded with statSync, which FOLLOWS links.
+		fs = { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, lstatSync, statSync, copyFileSync, renameSync, rmSync },
 		exec = defaultExec,
 		// Injected like `fs`/`exec`/`out` so the win32 npm branch below is reachable from a test on any host;
 		// it is the branch that was dead on arrival precisely because nothing could exercise it here.
@@ -264,21 +271,29 @@ export async function runImportPi(argv = [], deps = {}) {
 	return 0;
 }
 
-/** Copy `<src>/<name>/**` for each valid, non-symlink child dir. Returns the count copied. */
+/**
+ * Copy `<src>/<name>/**` for each valid, non-symlink child dir. Returns the count copied.
+ *
+ * Delegates to the shared copier (issue #60), which is where the symlink guard actually works. The
+ * guard here USED to be `fs.statSync(p).isSymbolicLink?.()`, and `statSync` FOLLOWS links, so it was
+ * permanently false: a symlinked skill directory in `~/.pi/agent/skills` was staged as its target's
+ * CONTENTS into an overlay that is :ro-mounted into every job container. `copySkillTree` uses lstat.
+ *
+ * Caps are off and source modes are preserved, so this command behaves exactly as it did apart from
+ * the repair: the overlay is deploy-time operator config, not a per-job input, and a staged file that
+ * changed mode would break a re-import (copyFileSync onto a 0444 file is EACCES).
+ */
 function copyNamedDirs(fs, src, dst, out) {
 	if (!fs.existsSync(src)) return 0;
-	let n = 0;
-	for (const name of fs.readdirSync(src)) {
-		if (!ENTRY_NAME_RE.test(name)) {
-			out(`  skipped "${name}" — unexpected name\n`);
-			continue;
-		}
-		const childSrc = join(src, name);
-		if (fs.statSync(childSrc).isSymbolicLink?.() || !fs.statSync(childSrc).isDirectory()) continue;
-		copyTree(fs, childSrc, join(dst, name));
-		n++;
-	}
-	return n;
+	const result = copySkillTree(src, dst, {
+		fs,
+		limits: null,
+		mode: null,
+		onSkip: (name, reason) => out(`  skipped "${name}" — ${reason === "symlink" ? "symlink" : "unexpected name"}\n`),
+	});
+	// "empty" is a refusal for a TRIGGER that asked for skills; here it just means the operator has
+	// none, which is the ordinary case for a host that never wrote a skill.
+	return result.refused ? 0 : result.dirs;
 }
 
 /**
@@ -308,7 +323,9 @@ function copyExtensions(fs, src, dst, out, hostDisabled = new Set()) {
 			continue;
 		}
 		const childSrc = join(src, name);
-		const st = fs.statSync(childSrc);
+		// lstat, NEVER stat: stat follows the link, so the old `statSync(p).isSymbolicLink?.()` here was
+		// permanently false and a symlinked extension was staged as its target's contents (issue #60).
+		const st = (fs.lstatSync ?? fs.statSync)(childSrc);
 		if (st.isSymbolicLink?.()) continue;
 		if (st.isDirectory()) copyTree(fs, childSrc, join(dst, name));
 		else fs.copyFileSync(childSrc, join(dst, name));
@@ -317,16 +334,13 @@ function copyExtensions(fs, src, dst, out, hostDisabled = new Set()) {
 	return { copied, blocked, disabled };
 }
 
-/** Recursively copy a directory tree, skipping symlinks (a symlink could point outside the source). */
+/**
+ * Recursively copy one directory's contents, skipping symlinks (a symlink could point outside the
+ * source). A thin adapter over the shared walker, so extensions and skills cannot drift apart on the
+ * guard that matters: it is `lstat` there, where it used to be a `statSync` that followed every link.
+ */
 function copyTree(fs, src, dst) {
-	fs.mkdirSync(dst, { recursive: true });
-	for (const entry of fs.readdirSync(src)) {
-		const s = join(src, entry);
-		const st = fs.statSync(s);
-		if (st.isSymbolicLink?.()) continue;
-		if (st.isDirectory()) copyTree(fs, s, join(dst, entry));
-		else fs.copyFileSync(s, join(dst, entry));
-	}
+	copyDirContents(src, dst, { fs, limits: null, mode: null });
 }
 
 /**

--- a/worker/test/copy-tree.test.mjs
+++ b/worker/test/copy-tree.test.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { ENTRY_NAME_RE, INJECT_LIMITS, copySkillTree } from "../src/copy-tree.mjs";
+
+/** A host skills dir: `<root>/<name>/SKILL.md`, the `~/.pi/agent/skills` layout. */
+function skillsDir({ skills = { tidy: { "SKILL.md": "---\nname: tidy\n---\nTidy.\n" } } } = {}) {
+	const root = mkdtempSync(join(tmpdir(), "pi-inject-"));
+	for (const [name, files] of Object.entries(skills)) {
+		for (const [rel, body] of Object.entries(files)) {
+			const p = join(root, name, rel);
+			mkdirSync(join(p, ".."), { recursive: true });
+			writeFileSync(p, body);
+		}
+	}
+	return root;
+}
+
+const destDir = () => mkdtempSync(join(tmpdir(), "pi-inject-dest-"));
+const flat = (d) => JSON.stringify(readdirSync(d, { recursive: true }));
+
+test("a skill directory is copied whole, and the receipt counts what landed", () => {
+	const src = skillsDir({
+		skills: { tidy: { "SKILL.md": "---\nname: tidy\n---\nTidy.\n", "references/api.md": "REF-SENTINEL" } },
+	});
+	const dest = destDir();
+	const result = copySkillTree(src, dest);
+
+	assert.equal(result.refused, undefined);
+	assert.equal(result.dirs, 1);
+	assert.equal(result.files, 2);
+	assert.equal(readFileSync(join(dest, "tidy", "references", "api.md"), "utf8"), "REF-SENTINEL");
+});
+
+test("copied files are 0444, so nothing on the host can rewrite a job's inputs by accident", () => {
+	const dest = destDir();
+	copySkillTree(skillsDir(), dest);
+	assert.equal(statSync(join(dest, "tidy", "SKILL.md")).mode & 0o777, 0o444);
+});
+
+test("mode null preserves the source mode, which is what import-pi needs to re-stage without EACCES", () => {
+	const src = skillsDir();
+	const dest = destDir();
+	copySkillTree(src, dest, { mode: null });
+	// A second stage over the first must not fail: copyFileSync onto a 0444 file is EACCES, which is
+	// exactly the trap that makes the mode a parameter rather than a constant.
+	const again = copySkillTree(src, dest, { mode: null });
+	assert.equal(again.refused, undefined);
+});
+
+// --- the symlink guard: the bug this module exists to fix ---
+
+test("a symlinked SKILL.md is skipped, and no host file content reaches the destination", () => {
+	const src = skillsDir();
+	const secret = join(mkdtempSync(join(tmpdir(), "pi-secret-")), "env");
+	writeFileSync(secret, "HOST-SECRET-SENTINEL");
+	symlinkSync(secret, join(src, "tidy", "stolen.md"));
+
+	const dest = destDir();
+	const result = copySkillTree(src, dest);
+
+	assert.equal(result.skipped.symlinks, 1);
+	assert.ok(!flat(dest).includes("stolen"), "the symlink was materialised");
+	const bodies = readdirSync(dest, { recursive: true })
+		.map((r) => join(dest, r))
+		.filter((p) => statSync(p).isFile())
+		.map((p) => readFileSync(p, "utf8"))
+		.join("\n");
+	assert.ok(!bodies.includes("HOST-SECRET-SENTINEL"), "host file content leaked through a symlink");
+});
+
+test("a symlinked DIRECTORY is skipped -- statSync would have FOLLOWED it, which is the repaired bug", () => {
+	// This is the case the old `statSync(p).isSymbolicLink?.()` guard could never catch: statSync
+	// resolves the link, so the expression was permanently false and the target's CONTENTS were copied.
+	// A directory symlink pointing at / would have walked the host filesystem into a job container.
+	const src = skillsDir();
+	const elsewhere = mkdtempSync(join(tmpdir(), "pi-elsewhere-"));
+	writeFileSync(join(elsewhere, "secret.md"), "HOST-TREE-SENTINEL");
+	symlinkSync(elsewhere, join(src, "tidy", "linked"));
+
+	const dest = destDir();
+	const result = copySkillTree(src, dest);
+
+	assert.equal(result.skipped.symlinks, 1);
+	assert.ok(!flat(dest).includes("linked"), "a symlinked directory was followed");
+	assert.ok(!flat(dest).includes("secret.md"), "a symlinked directory's CONTENTS were copied");
+});
+
+test("a symlinked TOP-LEVEL skill directory is skipped and reported to the caller", () => {
+	const src = skillsDir();
+	const elsewhere = mkdtempSync(join(tmpdir(), "pi-elsewhere-"));
+	writeFileSync(join(elsewhere, "SKILL.md"), "---\nname: sneaky\n---\nx\n");
+	symlinkSync(elsewhere, join(src, "sneaky"));
+
+	const skips = [];
+	const dest = destDir();
+	const result = copySkillTree(src, dest, { onSkip: (n, r) => skips.push([n, r]) });
+
+	assert.equal(result.dirs, 1, "only the real skill was copied");
+	assert.deepEqual(skips, [["sneaky", "symlink"]]);
+	assert.ok(!flat(dest).includes("sneaky"));
+});
+
+// --- names, and the destination template ---
+
+test("a badly named entry is skipped and reported, never joined into a path", () => {
+	// The charset is checked BEFORE the name reaches join(), which is the traversal choke point --
+	// ENTRY_NAME_RE's leading class excludes ".", so "." and ".." cannot match.
+	const src = skillsDir();
+	mkdirSync(join(src, "not a skill"), { recursive: true });
+	writeFileSync(join(src, "not a skill", "SKILL.md"), "x");
+
+	const skips = [];
+	const result = copySkillTree(src, destDir(), { onSkip: (n, r) => skips.push([n, r]) });
+	assert.equal(result.dirs, 1);
+	assert.deepEqual(skips, [["not a skill", "unexpected name"]]);
+});
+
+test("a dotfile is skipped, the same rule pi's own loader applies", () => {
+	const src = skillsDir();
+	writeFileSync(join(src, "tidy", ".DS_Store"), "junk");
+	const dest = destDir();
+	const result = copySkillTree(src, dest);
+	assert.equal(result.files, 1, "only SKILL.md should land");
+	assert.ok(!flat(dest).includes("DS_Store"));
+});
+
+// --- the caps ---
+
+test("the directory cap refuses, and the reason names the breach", () => {
+	const skills = {};
+	for (let i = 0; i <= INJECT_LIMITS.maxDirs; i++) skills[`s${i}`] = { "SKILL.md": "x" };
+	assert.equal(copySkillTree(skillsDir({ skills }), destDir()).refused, "skills-dir-too-large");
+});
+
+test("the byte cap refuses mid-walk rather than copying most of a skill", () => {
+	const big = "x".repeat(1 << 20);
+	const files = { "SKILL.md": "x" };
+	for (let i = 0; i < 5; i++) files[`f${i}.md`] = big;
+	assert.equal(copySkillTree(skillsDir({ skills: { tidy: files } }), destDir()).refused, "skills-dir-too-large");
+});
+
+test("the file-count cap refuses", () => {
+	const files = {};
+	for (let i = 0; i <= INJECT_LIMITS.maxFiles; i++) files[`f${i}.md`] = "x";
+	assert.equal(copySkillTree(skillsDir({ skills: { tidy: files } }), destDir()).refused, "skills-dir-too-many-files");
+});
+
+test("the depth cap refuses a tree nested past it", () => {
+	const deep = `${Array.from({ length: INJECT_LIMITS.maxDepth + 1 }, (_, i) => `d${i}`).join("/")}/x.md`;
+	assert.equal(copySkillTree(skillsDir({ skills: { tidy: { "SKILL.md": "x", [deep]: "x" } } }), destDir()).refused, "skills-dir-too-deep");
+});
+
+test("the caps are the LITERAL numbers reviewed here, not whatever the constant says", () => {
+	// Same role as materialize.mjs's PI_LIMITS pin: every other test derives its vector from the
+	// constant and so is blind to a change IN it. Widening a bound must be a deliberate edit.
+	assert.deepEqual({ ...INJECT_LIMITS }, { maxDirs: 64, maxFiles: 512, maxBytes: 4194304, maxDepth: 8 });
+	assert.ok(Object.isFrozen(INJECT_LIMITS));
+});
+
+test("limits null lifts every cap, which is how import-pi stages an overlay", () => {
+	const skills = {};
+	for (let i = 0; i <= INJECT_LIMITS.maxDirs; i++) skills[`s${i}`] = { "SKILL.md": "x" };
+	const result = copySkillTree(skillsDir({ skills }), destDir(), { limits: null, mode: null });
+	assert.equal(result.refused, undefined);
+	assert.equal(result.dirs, INJECT_LIMITS.maxDirs + 1);
+});
+
+// --- refusals that are not caps ---
+
+test("an empty or absent source refuses rather than silently copying nothing", () => {
+	// A trigger that named a skills dir and got a job with no skills is the silent no-op this project
+	// treats as the worst outcome available.
+	assert.equal(copySkillTree(mkdtempSync(join(tmpdir(), "pi-empty-")), destDir()).refused, "skills-dir-empty");
+	assert.equal(copySkillTree(join(tmpdir(), "pi-absent-xyz-123"), destDir()).refused, "skills-dir-unreadable");
+});
+
+test("the receipt carries COUNTS only -- no name and no path a caller could log", () => {
+	const src = skillsDir();
+	symlinkSync(join(src, "tidy"), join(src, "alias"));
+	const result = copySkillTree(src, destDir());
+	const serialised = JSON.stringify(result);
+	assert.ok(!serialised.includes(src), "the receipt carries the host path");
+	assert.ok(!serialised.includes("tidy"), "the receipt carries a skill name");
+	assert.deepEqual(Object.keys(result).sort(), ["bytes", "dirs", "files", "skipped"]);
+});
+
+test("ENTRY_NAME_RE lives here now, and import-pi re-exports the same object", async () => {
+	const { ENTRY_NAME_RE: reExported } = await import("../src/import-pi.mjs");
+	assert.equal(reExported, ENTRY_NAME_RE, "the re-export must be the same regex, not a copy");
+});

--- a/worker/test/import-pi.test.mjs
+++ b/worker/test/import-pi.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, readdirSync, statSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runImportPi, findLiteralSecret } from "../src/import-pi.mjs";
@@ -55,6 +55,29 @@ test("import-pi copies models/skills/persona and NEVER auth.json", async () => {
 	assert.ok(existsSync(join(to, "skills", "tidy", "SKILL.md")), "skill copied");
 	assert.ok(existsSync(join(to, "APPEND_SYSTEM.md")), "persona copied");
 	assert.equal(existsSync(join(to, "auth.json")), false, "auth.json must NEVER be copied — the credential stays in env");
+});
+
+test("a symlinked skill directory is NOT staged (it was, BY CONTENT, before the shared copier)", async () => {
+	// The guard here used to be `statSync(p).isSymbolicLink?.()`, and statSync FOLLOWS links, so it was
+	// permanently false: the link's TARGET was walked and its contents copied into an overlay that is
+	// :ro-mounted into every adversarial-input container. This is the regression test for that.
+	const from = hostAgent();
+	const secretDir = mkdtempSync(join(tmpdir(), "pi-host-secret-"));
+	writeFileSync(join(secretDir, "SKILL.md"), "HOST-TREE-SENTINEL");
+	symlinkSync(secretDir, join(from, "skills", "aliased"));
+	const to = overlayDir();
+	const { out, text } = capture();
+
+	const code = await run(from, to, [], out);
+
+	assert.equal(code, 0);
+	assert.ok(existsSync(join(to, "skills", "tidy", "SKILL.md")), "the real skill must still stage");
+	assert.ok(!existsSync(join(to, "skills", "aliased")), "a symlinked skill dir was staged");
+	assert.ok(!readdirSync(to, { recursive: true }).some((r) => {
+		const p = join(to, r);
+		return statSync(p).isFile() && readFileSync(p, "utf8").includes("HOST-TREE-SENTINEL");
+	}), "the symlink target's CONTENTS were staged");
+	assert.ok(text().includes("symlink"), "the operator must be told what was skipped");
 });
 
 test("import-pi refuses a models.json with a literal key and writes nothing", async () => {


### PR DESCRIPTION
A latent bug found while building the `run.skillsDir` injection from #60. It stands alone, so it ships alone.

## The bug

`copyNamedDirs` and `copyTree` guarded symlinks with:

```js
if (fs.statSync(childSrc).isSymbolicLink?.() || !fs.statSync(childSrc).isDirectory()) continue;
```

`statSync` **follows** links, so `isSymbolicLink()` on its result is permanently `false`. The guard never fired. A symlinked skill or extension directory under `~/.pi/agent` was staged **as its target's contents** into the global overlay, which is `:ro`-mounted into every job container, beside adversarial issue text.

**The repo already knew half of this.** `stagePackages` says so where it explains why it uses `renameSync`:

> `renameSync`, never `copyTree`: copyTree's symlink guard uses statSync, which FOLLOWS links, so it would copy the target of every `node_modules/.bin` symlink instead of skipping it.

The packages path was fixed at the time. The skills and extensions paths kept the broken guard.

## The fix

`lstatSync`, in one shared walker rather than in each copy of the loop. `outbox.mjs` and `sandbox-store.mjs` already keep that habit for exactly this reason (*"lstat (NOT stat) so a symlink is rejected on its own inode, not followed"*), so this is the third module to learn it, not a new idea.

`worker/src/copy-tree.mjs` is that walker. Its rules mirror `materialize.mjs`, which solves the same problem against a git tree instead of a filesystem: regular files only, destination paths rebuilt from validated name segments rather than taken from the source string, containment re-checked behind that, and per-entry problems **skipped and counted** rather than thrown.

It also carries caps and a `0444` write mode, both **off by default and unused here**. They are what will let the same walker be pointed at a per-trigger operator directory in the next PR of this chain, which is why the walker is shared rather than inlined into `import-pi`. Flagging that explicitly rather than letting a reviewer find unused parameters.

`ENTRY_NAME_RE` moves to the new module, because `import-pi` importing the copier while the copier imported the charset back would be a cycle for one regex. `import-pi` re-exports it, so every existing import path keeps working: the materialiser's drift test and `import-pi`'s own tests both reach for it there, and an address with readers is not renamed for tidiness.

## What does not change

`import-pi` behaves identically apart from the repair. Caps are off, because the overlay is deploy-time operator config rather than a per-job input. Source modes are preserved, because a staged file that changed mode would break the next re-import (`copyFileSync` onto a `0444` file is `EACCES`), and there is a test for that specific trap.

The one visible change is a new skip line: a symlinked entry is now reported to the operator **by name**, since staging is the moment they can still see what is about to run in every container.

## Specs

- `CONST-TOKEN-SCOPED-PER-JOB` **UNCHANGED, checked**, and strengthened in passing: the leak this closes is precisely a host file reaching a credential-adjacent container.
- `REQ-GLOBAL-PI-OVERLAY` **UNCHANGED, checked**: what the overlay may carry is the same list. This is about the copy that puts it there.
- `CONST-ISOLATION-CONTAINER-PER-JOB`, `INT-CONTAINER-RUNTIME-CONTRACT` **UNCHANGED, checked**: no mount, no flag, no env var.

## Tests

17 new in `copy-tree.test.mjs`, on real temp trees with real `symlinkSync` fixtures, including the case the old guard could never catch: a symlinked **directory**, whose contents were previously walked and copied.

**Mutation check.** Restoring the follow-the-link behaviour turns the new hostile-fixture test in `import-pi.test.mjs` red:

```
✖ a symlinked skill directory is NOT staged (it was, BY CONTENT, before the shared copier)
```

Full suite: 2034 tests, 0 failures.

## Chain

First of the remaining #60 work. `run.skillsDir` (Gap 2), the flow-gate statement (Gap 5) and `run.instructions` (Gap 3) follow; #160 (Gap 1, whole-directory materialisation) is already merged.
