### PR TITLE
feat(admin): buildGraphModel, the graph's edge-honesty fold (issue #54)

### DIFF
--- a/admin/src/graph-model.mjs
+++ b/admin/src/graph-model.mjs
@@ -1,9 +1,13 @@
 /**
- * The PURE side of the trigger/flow graph (issue #54): text scanners over skill content, and (next
- * slice) the model assembler every graph consumer renders from. No fs, no child_process, no redis,
- * no queue, no env -- read-model.mjs supplies bytes and joins, this module supplies meaning. The
- * purity is enforced by a source-regex test, the render.mjs/panel.mjs/costs.mjs pattern.
+ * The PURE side of the trigger/flow graph (issue #54): text scanners over skill content, and the
+ * model assembler every graph consumer renders from. No fs, no child_process, no redis, no queue,
+ * no env -- read-model.mjs supplies bytes and joins, this module supplies meaning. The purity is
+ * enforced by a source-regex test, the render.mjs/panel.mjs/costs.mjs pattern.
  */
+
+// SKILL_NAME_RE is a plain frozen RegExp; importing it keeps the charset single-sourced (the
+// issue #92 lesson) without breaking this module's purity -- nothing here spawns or reads anything.
+import { SKILL_NAME_RE } from "@edgehero/pi-dispatch/flow-gate";
 
 // One frontmatter value line: `key: value`, an optional surrounding double quote, single-line only.
 // The same block-isolation discipline as flow-gate.mjs's aiTriggerAllows, and deliberately NOT a YAML
@@ -75,4 +79,350 @@ export function findSiblingMentions(text, siblingNames) {
 
 function escapeRegExp(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// The closed edge and flag vocabularies. Closed on purpose and pinned in the tests: every consumer
+// (the text renderer, the TUI view, the HTML export) switches on these strings, and a producer
+// minting a new one without a renderer arm should go red in a unit test, not render as nothing.
+export const GRAPH_EDGE_KINDS = Object.freeze(["config", "observed", "potential", "cron-rearm"]);
+export const GRAPH_FLAGS = Object.freeze([
+  "no-skill", // config edge target absent at HEAD in an ENUMERATED folder (readFlowGate's precise token)
+  "charset-invalid", // run.flow fails SKILL_NAME_RE: can never materialise, a distinct defect from no-skill
+  "orphan", // no trigger, no ai-trigger, no incoming mention: dead by every path the system has
+  "ai-reachable-no-trigger", // no trigger but ai-trigger: allow -- deliberately chain/dispatch_run-reachable
+  "injected-ai-trigger", // an injected skill carrying ai-trigger: allow is a silent no-op (OQ-022)
+  "unread", // SKILL.md unreadable/oversized at enumeration: facts unknown, gate read as closed
+  "pr-spend-loop-risk", // pull_request on opened/synchronize: the OQ-020 cross-actor spend-loop signature
+]);
+
+/**
+ * Assemble the graph model every consumer renders from. Pure fold over the read-model's outputs --
+ * this function performs no I/O, applies the EDGE HONESTY RULES (DES-GRAPH-EDGE-DERIVATION), and is
+ * the single place they live:
+ *
+ *   - every trigger with a `run.flow` gets exactly one `config` edge, always;
+ *   - `observed` edges come only from run records (they carry count + lastEndedAt);
+ *   - `potential` edges come only from a text mention, labelled `strong`/`eligible`, and eligibility
+ *     is a NODE badge (`aiTrigger`), never an all-pairs edge;
+ *   - `cron-rearm` is the one self-edge every cron trigger carries by definition;
+ *   - no chain edge is ever drawn out of a forge trigger's flow or across folders -- the harness
+ *     makes both unrepresentable (OQ-009), and drawing either would draw a lie;
+ *   - an UNREACHABLE folder produces zero dangling flags ("unverified" is not "dangling": deny and
+ *     no-skill are different facts, and a read that never happened proves neither);
+ *   - `caps` ride every model, because a consumer that renders edges without their bounds invites
+ *     the reader to extrapolate an unbounded chain fabric out of a depth-1, width-2 reality.
+ *
+ * Total function: absent or malformed inputs degrade to an empty-but-well-formed model, never a
+ * throw (the read-model's viewer doctrine, one layer up).
+ */
+export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSkills, cronStats, runJoin, chainEdges, caps, nowMs } = {}) {
+  const triggerList = Array.isArray(triggers?.triggers) ? triggers.triggers : [];
+  const schedulerList = Array.isArray(schedulers) ? schedulers : [];
+  const folders = folderSkills && typeof folderSkills === "object" ? folderSkills : {};
+  const injected = injectedSkills && typeof injectedSkills === "object" ? injectedSkills : {};
+  const statsById = cronStats?.byId && typeof cronStats.byId === "object" ? cronStats.byId : {};
+  const statsByIndex = runJoin?.byIndex && typeof runJoin.byIndex === "object" ? runJoin.byIndex : {};
+  const observed = Array.isArray(chainEdges?.edges) ? chainEdges.edges : [];
+
+  const model = {
+    folders: [],
+    nodes: [],
+    edges: [],
+    flags: [],
+    caps: {
+      chainDepthMax: Number.isInteger(caps?.chainDepthMax) ? caps.chainDepthMax : null,
+      chainMaxPerJob: Number.isInteger(caps?.chainMaxPerJob) ? caps.chainMaxPerJob : null,
+      sameFolderOnly: true,
+      windowDays: Number.isInteger(caps?.windowDays) ? caps.windowDays : null,
+    },
+    meta: {
+      generatedAt: Number.isFinite(nowMs) ? nowMs : null,
+      triggersMissing: triggers?.missing === true,
+      triggersInvalid: typeof triggers?.invalid === "string" ? triggers.invalid : null,
+      unattributedRuns: Number.isInteger(runJoin?.unattributed) ? runJoin.unattributed : 0,
+      chainRefusals: chainEdges?.refusals && typeof chainEdges.refusals === "object" ? chainEdges.refusals : {},
+      truncated: {
+        folders: false,
+        skills: Object.values(folders).some((f) => f?.truncated === true),
+        edges: chainEdges?.truncated === true,
+      },
+      droppedObservedEdges: 0,
+    },
+  };
+
+  // ---- folder groups: one per enumerated local folder, one per forge named by a webhook trigger ----
+  const folderByPath = new Map();
+  for (const [path, result] of Object.entries(folders)) {
+    const group = {
+      key: `folder:${path}`,
+      path,
+      label: basenameOf(path),
+      kind: "local",
+      head: typeof result?.head === "string" ? result.head : null,
+      unreachable: typeof result?.unreachable === "string" ? result.unreachable : null,
+      triggerIds: [],
+      skillIds: [],
+    };
+    folderByPath.set(path, group);
+    model.folders.push(group);
+  }
+  const forgeGroups = new Map();
+  const forgeGroup = (forge) => {
+    const name = typeof forge === "string" && forge !== "" ? forge : "forge";
+    let group = forgeGroups.get(name);
+    if (!group) {
+      // A forge trigger's repo is not on this host, so its skills are unverifiable from the admin
+      // (readFlowGate needs a local git dir); the group says so instead of growing dangling flags.
+      group = { key: `forge:${name}`, path: null, label: name, kind: "forge", head: null, unreachable: "remote-repo", triggerIds: [], skillIds: [] };
+      forgeGroups.set(name, group);
+      model.folders.push(group);
+    }
+    return group;
+  };
+
+  // ---- skill nodes from the enumerations ----
+  const skillNode = new Map(); // "folderKey name" -> node
+  const addSkill = (group, skill) => {
+    const id = `skill:${group.key}:${skill.name}`;
+    const node = {
+      id,
+      kind: "skill",
+      name: skill.name,
+      folderKey: group.key,
+      isSub: skill.isSub === true,
+      group: skill.isSub === true ? skill.group : null,
+      aiTrigger: skill.aiTrigger === true,
+      meta: skill.meta ?? null,
+      unread: skill.unread === true,
+      isFlow: false, // set true when a config edge lands on it
+      mentionedBy: 0,
+    };
+    skillNode.set(`${group.key} ${skill.name}`, node);
+    model.nodes.push(node);
+    group.skillIds.push(id);
+    if (node.unread) model.flags.push({ nodeId: id, flag: "unread", detail: "SKILL.md unreadable at enumeration; gate read as closed" });
+    return node;
+  };
+  for (const [path, result] of Object.entries(folders)) {
+    const group = folderByPath.get(path);
+    for (const skill of Array.isArray(result?.skills) ? result.skills : []) {
+      if (typeof skill?.name === "string" && skill.name !== "") addSkill(group, skill);
+    }
+  }
+  for (const [dir, result] of Object.entries(injected)) {
+    for (const skill of Array.isArray(result?.skills) ? result.skills : []) {
+      if (typeof skill?.name !== "string" || skill.name === "") continue;
+      const id = `injected:${dir}:${skill.name}`;
+      model.nodes.push({ id, kind: "injected", name: skill.name, dir, aiTrigger: skill.aiTrigger === true });
+      if (skill.aiTrigger === true) {
+        model.flags.push({ nodeId: id, flag: "injected-ai-trigger", detail: "ai-trigger: allow on an injected skill is a silent no-op (OQ-022)" });
+      }
+    }
+  }
+
+  // A config edge may point at a flow the enumeration did not find; the target then exists as a
+  // `skill-missing` node so the edge has a visible end. Created lazily, once per (group, name).
+  const missingNode = (group, name) => {
+    const key = `${group.key} ${name}`;
+    let node = skillNode.get(key);
+    if (node) return node;
+    node = { id: `skill:${group.key}:${name}`, kind: "skill-missing", name, folderKey: group.key, isSub: false, group: null, aiTrigger: false, meta: null, unread: false, isFlow: false, mentionedBy: 0 };
+    skillNode.set(key, node);
+    model.nodes.push(node);
+    group.skillIds.push(node.id);
+    return node;
+  };
+
+  // ---- trigger nodes + config edges + cron-rearm self-edges ----
+  for (const t of triggerList) {
+    if (!t || typeof t !== "object" || !Number.isInteger(t.index)) continue;
+    const id = `trigger:${t.index}`;
+    const isCron = t.type === "cron";
+    let group = null;
+    if (isCron) {
+      if (typeof t.folder === "string" && t.folder !== "") {
+        group = folderByPath.get(t.folder) ?? null;
+        if (!group) {
+          // The folder cap (or a caller that never enumerated) left this folder unscanned; the
+          // trigger and its config edge still draw -- the config fact is real -- on a group that
+          // says why its skills are unknown, rather than silently losing the edge.
+          group = { key: `folder:${t.folder}`, path: t.folder, label: basenameOf(t.folder), kind: "local", head: null, unreachable: "not-enumerated", triggerIds: [], skillIds: [] };
+          folderByPath.set(t.folder, group);
+          model.folders.push(group);
+        }
+      }
+    } else {
+      group = forgeGroup(t.forge);
+    }
+    const stats = isCron ? (typeof t.id === "string" ? statsById[t.id] : undefined) : statsByIndex[t.index];
+    const sched = isCron ? matchScheduler(schedulerList, t) : null;
+    const node = {
+      id,
+      kind: "trigger",
+      index: t.index,
+      onType: t.type,
+      forge: isCron ? null : (t.forge ?? null),
+      cronId: isCron ? (t.id ?? null) : null,
+      pattern: isCron ? (t.pattern ?? null) : null,
+      label: triggerMatchLabel(t),
+      flow: t.flow ?? null,
+      replicas: t.replicas ?? null,
+      folderKey: group?.key ?? null,
+      runs: Number.isInteger(stats?.runs) ? stats.runs : 0,
+      lastOutcome: stats?.lastOutcome ?? null,
+      lastEndedAt: stats?.lastEndedAt ?? null,
+      next: sched?.next ?? null,
+      overdueMs: sched?.overdueMs ?? null,
+    };
+    model.nodes.push(node);
+    if (group) group.triggerIds.push(id);
+
+    // The OQ-020 cross-actor spend-loop signature is static and cheap; the graph is where an
+    // operator can actually see it, so it badges here rather than only in SECURITY.md prose.
+    if (t.type === "pull_request" && Array.isArray(t.action) && t.action.some((a) => a === "opened" || a === "synchronize")) {
+      model.flags.push({ nodeId: id, flag: "pr-spend-loop-risk", detail: "fires on opened/synchronize; a flow that pushes can loop with another bot (OQ-020)" });
+    }
+
+    // Every cron trigger re-arms by definition: the one self-edge that is config, not history.
+    if (isCron) model.edges.push({ from: id, to: id, kind: "cron-rearm", label: t.pattern ?? null });
+
+    // The config edge -- every trigger that names a flow gets one, ALWAYS.
+    if (typeof t.flow === "string" && t.flow !== "") {
+      if (!SKILL_NAME_RE.test(t.flow)) {
+        // A charset-invalid flow can never materialise (materialize.mjs refuses the name), and the
+        // gate answers deny, not no-skill -- a distinct, currently-invisible defect class.
+        const target = group ? missingNode(group, clipName(t.flow)) : null;
+        if (target) model.edges.push({ from: id, to: target.id, kind: "config" });
+        model.flags.push({ nodeId: id, flag: "charset-invalid", detail: `run.flow ${JSON.stringify(clipName(t.flow))} fails the skill charset and can never materialise` });
+        continue;
+      }
+      if (isCron && group && group.unreachable === null) {
+        const existing = skillNode.get(`${group.key} ${t.flow}`);
+        if (existing && existing.kind === "skill" && !existing.isSub) {
+          existing.isFlow = true;
+          model.edges.push({ from: id, to: existing.id, kind: "config" });
+        } else {
+          // Enumeration SUCCEEDED and the path is absent: this is readFlowGate's precise
+          // "no-skill", the one token that means dangling (deny would prove nothing).
+          const target = missingNode(group, t.flow);
+          model.edges.push({ from: id, to: target.id, kind: "config" });
+          model.flags.push({ nodeId: id, flag: "no-skill", detail: `.pi/skills/${t.flow}/SKILL.md absent at HEAD` });
+        }
+      } else if (group) {
+        // Forge repo (not local) or unreachable folder: the edge still draws -- the config fact is
+        // real -- but no dangling flag can honestly attach to a read that never happened, so the
+        // target is an UNVERIFIED node, a different kind from skill-missing on purpose.
+        const target = missingNode(group, t.flow);
+        if (target.kind === "skill-missing") target.kind = "skill-unverified";
+        target.isFlow = true;
+        model.edges.push({ from: id, to: target.id, kind: "config" });
+      }
+    }
+  }
+
+  // ---- observed chain edges (records only), resolved onto folder groups by target basename ----
+  const localGroups = model.folders.filter((f) => f.kind === "local");
+  for (const edge of observed) {
+    if (typeof edge?.parentFlow !== "string" || typeof edge?.childFlow !== "string") continue;
+    const base = typeof edge.target === "string" && edge.target.startsWith("local:") ? edge.target.slice("local:".length) : null;
+    const matches = base === null ? [] : localGroups.filter((f) => f.label === base);
+    if (matches.length !== 1) {
+      // No enumerated folder (or an ambiguous basename) to hang the edge on: dropping it and saying
+      // so beats guessing, which could pin real history onto the wrong folder's skills.
+      model.meta.droppedObservedEdges++;
+      continue;
+    }
+    const group = matches[0];
+    const from = missingNode(group, edge.parentFlow);
+    const to = missingNode(group, edge.childFlow);
+    model.edges.push({ from: from.id, to: to.id, kind: "observed", count: Number.isInteger(edge.count) ? edge.count : 0, lastEndedAt: edge.lastEndedAt ?? null });
+  }
+
+  // ---- potential edges from text mentions, within each enumerated folder only ----
+  for (const [path, result] of Object.entries(folders)) {
+    const group = folderByPath.get(path);
+    for (const skill of Array.isArray(result?.skills) ? result.skills : []) {
+      if (skill?.isSub === true) continue;
+      const from = skillNode.get(`${group.key} ${skill?.name}`);
+      if (!from) continue;
+      for (const mention of Array.isArray(skill?.mentions) ? skill.mentions : []) {
+        const to = skillNode.get(`${group.key} ${mention?.name}`);
+        if (!to || to.isSub) continue;
+        to.mentionedBy++;
+        model.edges.push({
+          from: from.id,
+          to: to.id,
+          kind: "potential",
+          strong: mention.strong === true,
+          // Eligibility is the exact static half: without ai-trigger: allow on the TARGET, the
+          // outbox gate refuses this edge every time, so a mention alone renders "can never fire".
+          eligible: to.aiTrigger === true,
+        });
+      }
+    }
+  }
+
+  // ---- orphan / reachability flags, only where the enumeration actually succeeded ----
+  for (const [path] of Object.entries(folders)) {
+    const group = folderByPath.get(path);
+    if (group.unreachable !== null) continue;
+    for (const id of group.skillIds) {
+      const node = model.nodes.find((n) => n.id === id);
+      if (!node || node.kind !== "skill" || node.isSub || node.unread) continue;
+      if (node.isFlow) continue;
+      if (node.aiTrigger) {
+        model.flags.push({ nodeId: id, flag: "ai-reachable-no-trigger", detail: "no trigger names it, but ai-trigger: allow keeps it chain/dispatch_run-reachable" });
+      } else if (node.mentionedBy === 0) {
+        model.flags.push({ nodeId: id, flag: "orphan", detail: "no trigger, no ai-trigger, no mention: dead by every path the system has" });
+      }
+    }
+  }
+
+  return model;
+}
+
+/** The display label for a trigger's match side, mirroring render.mjs's triggerLine vocabulary. */
+function triggerMatchLabel(t) {
+  switch (t?.type) {
+    case "cron":
+      return `${t.id ?? "-"} ${t.pattern ?? "-"}`;
+    case "label":
+      return selectorLabel(t);
+    case "comment":
+      return `"${t.phrase ?? "-"}"`;
+    case "pull_request":
+      return `action[${(Array.isArray(t.action) ? t.action : []).join(",")}]`;
+    default:
+      return "(unknown)";
+  }
+}
+
+function selectorLabel(t) {
+  const parts = [];
+  if (Array.isArray(t.any) && t.any.length) parts.push(`any[${t.any.join(",")}]`);
+  if (Array.isArray(t.all) && t.all.length) parts.push(`all[${t.all.join(",")}]`);
+  if (Array.isArray(t.none) && t.none.length) parts.push(`none[${t.none.join(",")}]`);
+  return parts.join(" ") || "(no selector)";
+}
+
+/** Match a cron display trigger to its resident scheduler: by key/name (the id), else by pattern. */
+function matchScheduler(schedulers, t) {
+  if (typeof t?.id === "string") {
+    const byId = schedulers.find((s) => s?.key === t.id || s?.name === t.id);
+    if (byId) return byId;
+  }
+  return typeof t?.pattern === "string" ? (schedulers.find((s) => s?.pattern === t.pattern) ?? null) : null;
+}
+
+/** Basename without importing node:path (this module is pure); both separators, trailing-sep safe. */
+function basenameOf(path) {
+  const trimmed = String(path).replace(/[\\/]+$/, "");
+  const at = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return at === -1 ? trimmed : trimmed.slice(at + 1);
+}
+
+/** Clip an arbitrary (possibly hostile) flow string for node display; the honest badge needs the name. */
+function clipName(name) {
+  const s = String(name);
+  return s.length > 64 ? `${s.slice(0, 64)}…` : s;
 }

--- a/admin/test/graph-model.test.mjs
+++ b/admin/test/graph-model.test.mjs
@@ -69,3 +69,181 @@ test("findSiblingMentions is total: bad inputs yield [], and a self-shaped name 
   assert.deepEqual(findSiblingMentions("text", null), []);
   assert.deepEqual(findSiblingMentions("text", [42, "", null]), []);
 });
+
+// ---- buildGraphModel (the assembler; DES-GRAPH-EDGE-DERIVATION's honesty rules live here) ----
+
+import { buildGraphModel, GRAPH_EDGE_KINDS, GRAPH_FLAGS } from "../src/graph-model.mjs";
+
+test("the edge and flag vocabularies are the LITERAL closed sets, frozen", () => {
+  // Every consumer switches on these strings; a producer minting a new one without a renderer arm
+  // must go red HERE, not render as nothing. Change these on purpose and say why in the commit body.
+  assert.deepEqual([...GRAPH_EDGE_KINDS], ["config", "observed", "potential", "cron-rearm"]);
+  assert.deepEqual(
+    [...GRAPH_FLAGS],
+    ["no-skill", "charset-invalid", "orphan", "ai-reachable-no-trigger", "injected-ai-trigger", "unread", "pr-spend-loop-risk"],
+  );
+  assert.ok(Object.isFrozen(GRAPH_EDGE_KINDS) && Object.isFrozen(GRAPH_FLAGS));
+});
+
+// One canned deployment the assembler tests share: a local folder with a healthy chain pair, an
+// orphan, an AI-reachable skill, a sub-skill, plus a github label trigger and a dangling cron.
+const CANNED = () => ({
+  triggers: {
+    triggers: [
+      { type: "cron", index: 0, id: "nightly", pattern: "0 3 * * *", folder: "/srv/site", flow: "build-report", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false },
+      { type: "label", index: 1, any: ["ai"], all: [], none: [], flow: "triage", packages: true, image: null, skillsDir: null, instructions: false, resume: false, replicas: null, forge: "github" },
+      { type: "cron", index: 2, id: "gone", pattern: "0 4 * * *", folder: "/srv/site", flow: "deleted-flow", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false },
+    ],
+  },
+  schedulers: [{ key: "nightly", name: "nightly", pattern: "0 3 * * *", every: null, next: "2026-08-12T03:00:00.000Z", overdueMs: null }],
+  folderSkills: {
+    "/srv/site": {
+      head: "abc123",
+      truncated: false,
+      unreachable: null,
+      skills: [
+        { name: "build-report", isSub: false, group: null, aiTrigger: true, meta: { name: "build-report", description: "d" }, mentions: [{ name: "notify", strong: true }], unread: false },
+        { name: "notify", isSub: false, group: null, aiTrigger: true, meta: null, mentions: [], unread: false },
+        { name: "old-import", isSub: false, group: null, aiTrigger: false, meta: null, mentions: [], unread: false },
+        { name: "group/sub", isSub: true, group: "group", aiTrigger: false, meta: null, mentions: [], unread: false },
+        { name: "group", isSub: false, group: null, aiTrigger: false, meta: null, mentions: [], unread: false },
+      ],
+    },
+  },
+  injectedSkills: { "/inj": { skills: [{ name: "tidy", aiTrigger: true }], truncated: false, unreachable: null } },
+  cronStats: { byId: { nightly: { runs: 41, lastOutcome: "completed", lastEndedAt: "2026-08-11T00:00:00.000Z" }, gone: { runs: 0, lastOutcome: null, lastEndedAt: null } } },
+  runJoin: { byIndex: { 1: { runs: 12, lastOutcome: "completed", lastEndedAt: "2026-08-11T01:00:00.000Z" } }, unattributed: 2 },
+  chainEdges: { edges: [{ parentFlow: "build-report", childFlow: "notify", target: "local:site", count: 3, lastEndedAt: "2026-08-10T00:00:00.000Z" }], refusals: { "build-report": 1 }, truncated: false },
+  caps: { chainDepthMax: 1, chainMaxPerJob: 2, windowDays: 30 },
+  nowMs: 1770000000000,
+});
+
+test("buildGraphModel: config edges always, cron joins by id, forge joins by persisted index", () => {
+  const m = buildGraphModel(CANNED());
+  const configs = m.edges.filter((e) => e.kind === "config");
+  assert.equal(configs.length, 3, "every trigger naming a flow gets its config edge, dangling included");
+
+  const nightly = m.nodes.find((n) => n.id === "trigger:0");
+  assert.equal(nightly.runs, 41, "cron stats join by scheduler id");
+  assert.equal(nightly.next, "2026-08-12T03:00:00.000Z", "the resident scheduler's next fire rides the node");
+
+  const label = m.nodes.find((n) => n.id === "trigger:1");
+  assert.equal(label.runs, 12, "forge stats join by the persisted raw index");
+  assert.equal(label.folderKey, "forge:github");
+
+  const forgeGroup = m.folders.find((f) => f.key === "forge:github");
+  assert.equal(forgeGroup.unreachable, "remote-repo", "a forge repo is not on this host; its skills are unverifiable, not dangling");
+  const forgeFlow = m.nodes.find((n) => n.id === "skill:forge:github:triage");
+  assert.equal(forgeFlow.kind, "skill-unverified", "an unverified flow is a DIFFERENT kind from skill-missing, on purpose");
+});
+
+test("buildGraphModel: dangling is precise -- no-skill only where enumeration SUCCEEDED", () => {
+  const m = buildGraphModel(CANNED());
+  const flags = m.flags.filter((f) => f.flag === "no-skill");
+  assert.deepEqual(flags.map((f) => f.nodeId), ["trigger:2"], "only the cron whose enumerated folder lacks the flow");
+  assert.ok(m.nodes.some((n) => n.id === "skill:folder:/srv/site:deleted-flow" && n.kind === "skill-missing"), "the dangling edge still has a visible end");
+
+  // The negative claim: an UNREACHABLE folder must produce zero dangling flags.
+  const inputs = CANNED();
+  inputs.folderSkills["/srv/site"] = { head: null, skills: [], truncated: false, unreachable: "not-a-git-repo" };
+  const m2 = buildGraphModel(inputs);
+  assert.equal(m2.flags.filter((f) => f.flag === "no-skill").length, 0, "a read that never happened proves nothing (deny != no-skill)");
+  assert.equal(m2.edges.filter((e) => e.kind === "config").length, 3, "the config edges still draw; the folder says unverified instead");
+});
+
+test("buildGraphModel: charset-invalid run.flow is its own flag, distinct from no-skill", () => {
+  const inputs = CANNED();
+  inputs.triggers.triggers.push({ type: "cron", index: 3, id: "bad", pattern: "0 5 * * *", folder: "/srv/site", flow: "Tidy/../up", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false });
+  const m = buildGraphModel(inputs);
+  const flag = m.flags.find((f) => f.flag === "charset-invalid");
+  assert.equal(flag.nodeId, "trigger:3");
+  assert.equal(m.flags.filter((f) => f.flag === "no-skill" && f.nodeId === "trigger:3").length, 0, "invalid-name never doubles as no-skill: the gate would answer deny, not no-skill");
+});
+
+test("buildGraphModel: observed edges come only from records, potential only from mentions, and they never blur", () => {
+  const m = buildGraphModel(CANNED());
+  const observed = m.edges.filter((e) => e.kind === "observed");
+  assert.equal(observed.length, 1);
+  assert.equal(observed[0].count, 3, "an observed edge carries its count; that is what observed MEANS");
+  assert.equal(observed[0].from, "skill:folder:/srv/site:build-report");
+  assert.equal(observed[0].to, "skill:folder:/srv/site:notify");
+
+  const potential = m.edges.filter((e) => e.kind === "potential");
+  assert.equal(potential.length, 1);
+  assert.deepEqual(
+    { strong: potential[0].strong, eligible: potential[0].eligible },
+    { strong: true, eligible: true },
+    "a mention is labelled by its evidence; eligibility is the target's own gate fact",
+  );
+  assert.equal("count" in potential[0], false, "a potential edge NEVER carries a count -- counts are what observed means");
+
+  // Gate-eligibility alone draws NO edge: notify allows ai-trigger but mentions nobody, so there is
+  // no notify -> * potential edge. Eligibility is a node badge, not an all-pairs fabric.
+  assert.equal(potential.filter((e) => e.from === "skill:folder:/srv/site:notify").length, 0);
+});
+
+test("buildGraphModel: an observed edge with no unique folder to hang on is DROPPED and counted, never guessed", () => {
+  const inputs = CANNED();
+  inputs.chainEdges.edges.push({ parentFlow: "a", childFlow: "b", target: "local:elsewhere", count: 1, lastEndedAt: null });
+  const m = buildGraphModel(inputs);
+  assert.equal(m.edges.filter((e) => e.kind === "observed").length, 1, "only the resolvable edge draws");
+  assert.equal(m.meta.droppedObservedEdges, 1, "the drop is counted, because a silent drop reads as covered-everything");
+});
+
+test("buildGraphModel: cron-rearm is the one config self-edge, labelled with the pattern", () => {
+  const m = buildGraphModel(CANNED());
+  const rearms = m.edges.filter((e) => e.kind === "cron-rearm");
+  assert.deepEqual(
+    rearms.map((e) => [e.from, e.to, e.label]),
+    [["trigger:0", "trigger:0", "0 3 * * *"], ["trigger:2", "trigger:2", "0 4 * * *"]],
+    "every cron trigger re-arms by definition; webhook triggers never do",
+  );
+});
+
+test("buildGraphModel: orphan and AI-reachable are distinct facts, sub-skills are neither", () => {
+  const m = buildGraphModel(CANNED());
+  const flagsFor = (id) => m.flags.filter((f) => f.nodeId === id).map((f) => f.flag);
+  assert.deepEqual(flagsFor("skill:folder:/srv/site:old-import"), ["orphan"], "no trigger, no ai-trigger, no mention: dead by every path");
+  assert.deepEqual(flagsFor("skill:folder:/srv/site:notify"), ["ai-reachable-no-trigger"], "ai-trigger: allow keeps it reachable, so it is NOT an orphan");
+  assert.deepEqual(flagsFor("skill:folder:/srv/site:group/sub"), [], "a sub-skill can never be a flow, so it is never an orphan candidate");
+  assert.deepEqual(flagsFor("injected:/inj:tidy"), ["injected-ai-trigger"], "the OQ-022 silent no-op badges loudly here");
+});
+
+test("buildGraphModel: the pr-spend-loop signature badges pull_request triggers on opened/synchronize", () => {
+  const inputs = CANNED();
+  inputs.triggers.triggers.push({ type: "pull_request", index: 3, action: ["opened", "synchronize"], any: [], all: [], none: [], flow: "review", packages: true, image: null, skillsDir: null, instructions: false, resume: false, replicas: null, forge: "github" });
+  const m = buildGraphModel(inputs);
+  assert.deepEqual(m.flags.filter((f) => f.flag === "pr-spend-loop-risk").map((f) => f.nodeId), ["trigger:3"]);
+});
+
+test("buildGraphModel: caps ride every model, and a cron folder outside the enumeration still draws", () => {
+  const m = buildGraphModel(CANNED());
+  assert.deepEqual(m.caps, { chainDepthMax: 1, chainMaxPerJob: 2, sameFolderOnly: true, windowDays: 30 });
+
+  const inputs = CANNED();
+  inputs.triggers.triggers.push({ type: "cron", index: 3, id: "x", pattern: "0 6 * * *", folder: "/srv/unscanned", flow: "f", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false });
+  const m2 = buildGraphModel(inputs);
+  const group = m2.folders.find((f) => f.path === "/srv/unscanned");
+  assert.equal(group.unreachable, "not-enumerated", "the folder cap must not silently lose a trigger's edge");
+  assert.ok(m2.edges.some((e) => e.from === "trigger:3" && e.kind === "config"));
+  assert.equal(m2.flags.filter((f) => f.nodeId === "trigger:3" && f.flag === "no-skill").length, 0, "and no dangling flag attaches to a read that never happened");
+});
+
+test("buildGraphModel is total: empty and malformed inputs yield an empty well-formed model", () => {
+  for (const input of [undefined, {}, { triggers: { missing: true } }, { triggers: { invalid: "nope" }, chainEdges: "x", folderSkills: null }]) {
+    const m = buildGraphModel(input);
+    assert.deepEqual(m.nodes, []);
+    assert.deepEqual(m.edges, []);
+    assert.equal(m.caps.sameFolderOnly, true, "the same-folder rule is structural, stated even on an empty model");
+  }
+  assert.equal(buildGraphModel({ triggers: { missing: true } }).meta.triggersMissing, true);
+  assert.equal(buildGraphModel({ triggers: { invalid: "bad json" } }).meta.triggersInvalid, "bad json");
+});
+
+test("buildGraphModel: meta carries the honesty counters (unattributed, refusals, truncation)", () => {
+  const m = buildGraphModel(CANNED());
+  assert.equal(m.meta.unattributedRuns, 2, "runs the current triggers file cannot claim are said, not hidden");
+  assert.deepEqual(m.meta.chainRefusals, { "build-report": 1 });
+  assert.deepEqual(m.meta.truncated, { folders: false, skills: false, edges: false });
+  assert.equal(m.meta.generatedAt, 1770000000000);
+});

--- a/specs/design.md
+++ b/specs/design.md
@@ -1075,6 +1075,65 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   `INT-PRICING-EXPORT-CONTRACT`, `REQ-TOKEN-ACCOUNTING-AND-CAPS`; implemented in
   `admin/src/read-model.mjs` (`scanRunRecords`) and `admin/src/costs.mjs`.
 
+## DES-GRAPH-EDGE-DERIVATION
+
+- **Decision**: The trigger/flow graph (issue #54) is assembled by **one pure fold**
+  (`buildGraphModel`, `admin/src/graph-model.mjs`) over the read-model's outputs, and every edge it
+  emits is labelled by its **evidence class**, drawn from a closed, test-pinned vocabulary:
+  - **`config`** — trigger → flow, from the live triggers file. Every trigger naming a `run.flow`
+    gets exactly one, **always** — dangling, unverifiable and charset-invalid included; a target the
+    enumeration did not find exists as a `skill-missing` (enumerated folder) or `skill-unverified`
+    (forge repo / unreachable folder) node so the edge has a visible end.
+  - **`observed`** — flow → flow, from run records only (`parentJobId` joins), folded per flow pair
+    with its **count and last occurrence**. An observed edge exists because a run actually spawned
+    another, never because one could. Same-target only; an edge that cannot be hung on exactly one
+    enumerated folder is **dropped and counted** (`meta.droppedObservedEdges`), never guessed onto a
+    basename that merely matches.
+  - **`potential`** — flow → flow, from a **text mention** of a sibling skill's name in a SKILL.md,
+    labelled `strong` (near the outbox vocabulary) and `eligible` (the target's own
+    `ai-trigger: allow`, the exact static half of the edge). Gate-eligibility alone draws **no
+    edge**: it is a node badge, because an all-pairs "could chain" fabric among allow-listed skills
+    would bury the informative edges under a combinatorial lie.
+  - **`cron-rearm`** — the one self-edge every cron trigger carries by definition, labelled with its
+    pattern: config, not history.
+  Two structural prohibitions, from `OQ-009`: **no chain edge is ever drawn out of a forge
+  trigger's flow** (a forge job gets no `/outbox` mount), and **no chain edge ever crosses
+  folders** (the child folder is forced to the parent's own) — the harness makes both
+  unrepresentable, so the graph never renders either. Dangling is precise: `no-skill` flags only
+  where enumeration **succeeded** and the path is absent at HEAD (the gate's own token); an
+  unreachable or remote folder renders **unverified**, never dangling, and a `run.flow` failing
+  `SKILL_NAME_RE` is its own `charset-invalid` flag — the gate would answer `deny` for it, and
+  deny proves nothing about existence. Orphanhood is three distinct facts, not one: `orphan` (no
+  trigger, no `ai-trigger`, no incoming mention), `ai-reachable-no-trigger` (deliberately
+  chain/dispatch_run-reachable), and `injected-ai-trigger` (the `OQ-022` silent no-op, badged
+  loudly). Sub-skills are never orphan candidates — the gate's path template has no room for them.
+  Every model carries the chain caps (`chainDepthMax`, `chainMaxPerJob`, same-folder-only, the
+  record window) and every consumer must render them; the honesty counters (`unattributedRuns`,
+  refusals, truncation, dropped edges) ride `meta` for the same reason.
+- **Why**: The four gaps issue #54 names are all failures of *assembly*, not of data — every edge
+  already exists somewhere in triggers.json, the records, or the object store. What a graph adds is
+  precisely the temptation to blur evidence classes: a mention rendered like an observation, a
+  gate-eligibility fabric rendered like config, a stale index landing on today's row. So the
+  derivation rules are the design, they live in exactly one pure function, and the negative claims
+  ("an observed edge never comes from potential-only evidence", "an unreachable folder produces
+  zero dangling flags", "a potential edge never carries a count") are asserted as tests, the
+  zero-cost-day-versus-absent-day discipline applied to topology.
+- **Rejected**:
+  - *Declared chain topology in config* — chains are agent-requested at runtime by design
+    (`DES-JOB-OUTBOX-CHAINING`); the graph reports what happened and what could, it does not promise
+    what will. Issue #54 refuses this explicitly.
+  - *An all-pairs "could chain" edge set from gate eligibility* — with N allow-listed skills that is
+    N×(N−1) identical arrows; eligibility becomes a badge and a mention becomes the edge, or the
+    graph is noise.
+  - *Treating `deny` as dangling* — `deny` conflates a missing gate opt-in, a bad sha, and a git
+    failure; only `no-skill` means "absent", and a graph that flags `deny` as dangling tells an
+    operator to delete a trigger whose skill exists.
+  - *Resolving ambiguous observed-edge targets by first match* — pins real history onto the wrong
+    folder's skills; dropped-and-counted is honest, guessed is not.
+- **Traces to**: `DES-ADMIN-VIA-PI-EXTENSION`, `DES-JOB-OUTBOX-CHAINING`, `DES-AI-TRIGGER-FLOW-GATE`,
+  `OQ-008`, `OQ-009`, `OQ-022`, `INT-RUN-HISTORY-FILE-CONTRACT`; implemented in
+  `admin/src/graph-model.mjs` (`buildGraphModel`) over `admin/src/read-model.mjs`'s graph readers.
+
 ## DES-RUNTIME-SETTINGS-FILE-OVERLAY
 
 - **Decision**: Runtime-tunable settings are a flat `settings.json` **overlay** — path `PI_SETTINGS_FILE`,
@@ -1854,6 +1913,7 @@ a tunnel.
 
 | Date | Change |
 |---|---|
+| 2026-08-11 | Issue #54 (the model assembler). **NEW `DES-GRAPH-EDGE-DERIVATION`**: the graph's edge honesty rules, in one pure fold (`buildGraphModel`). Four evidence classes (`config`/`observed`/`potential`/`cron-rearm`, a closed test-pinned vocabulary), the two OQ-009 structural prohibitions (no forge-parent chain edges, no cross-folder chain edges — the harness makes both unrepresentable, so drawing either would draw a lie), precise dangling (`no-skill` only where enumeration succeeded; unverified is not dangling; `charset-invalid` is its own flag because the gate's `deny` proves nothing about existence), three-way orphanhood, caps and honesty counters on every model. The interesting rejections are recorded: an all-pairs gate-eligibility fabric (eligibility is a node badge, a mention is the edge, or the graph is noise) and first-match resolution of ambiguous observed-edge targets (dropped-and-counted beats pinning real history onto the wrong folder). **DES-JOB-OUTBOX-CHAINING UNCHANGED, checked** (the graph consumes its record fields and caps; nothing about collection moves). **DES-COST-FOLD-BY-SCAN UNCHANGED, checked** (same scan, second consumer, still fold-time-derived and never stored). |
 | 2026-08-11 | Issue #54 (the data layer under the trigger/flow graph). **DES-ADMIN-VIA-PI-EXTENSION AMENDED**, and this row says out loud what the last three dashboard rows certified as unchanged, because this time it DID change: a new read-model surface and new fs/git access. `readFolderSkills` enumerates a cron folder's committed skills from the git OBJECT STORE at HEAD via the worker's own `selectEntries`/`keepOnlyDeclaredSkills` (a `./materialize` exports-map subpath added for exactly this — re-deriving the listing parse admin-side is how the graph would show a skill the job path never materialises), one hardened `ls-tree` plus one bounded `cat-file` per top-level SKILL.md, with the frontmatter read through the gate's own newly exported `aiTriggerAllows`. `readInjectedSkills` lists a `run.skillsDir` from the working tree and is labelled advisory (the doctor precedent; host files have no object store to prefer). `cronRunStats`/`joinRunsToTriggers`/`observedChainEdges` fold already-scanned records into the joins the graph will draw; `collectGraphInputs` is the one dedupe/caps funnel over the folder spawns. Everything is never-throw, degrades per folder to a discriminated `unreachable`, and is bounded by the frozen, literal-pinned `GRAPH_LIMITS`. Three properties re-affirmed rather than assumed: the enumeration is DISPLAY-ADVISORY and never a gate decision (`DES-AI-TRIGGER-FLOW-GATE`'s pre-agent-sha truth untouched; HEAD-at-display-time answers what the NEXT run will see, a different question, and an unreadable SKILL.md reads as NOT chainable); the dashboard's source-regex fs ban UNCHANGED, checked (every new spawn and read lives in read-model.mjs); the `.log` placement boundary UNCHANGED, checked (the folds read `.json` records only). `resolvePaths` mirrors the chain caps with defaults IMPORTED from the worker (new `CHAIN_DEPTH_MAX_DEFAULT`/`CHAIN_MAX_PER_JOB_DEFAULT` exports) so the graph can never state a cap the worker does not enforce, and `readTriggers` display records now carry the RAW triggers-array index — the identity `matched.index` counts, cron entries and unusable rows included, so a dropped row leaves a hole rather than renumbering every attribution below it. The graph VIEW itself is a later slice; this row is only its data. |
 | 2026-08-09 | Issue #60 (Gap 3). **NEW `DES-TRIGGER-INSTRUCTION-IN-THE-ENVELOPE`**: the operator's text goes in the user prompt's envelope, above the fenced data region and BEFORE the never-merge paragraph, because later text reads as more specific and the harness's non-negotiables must not look like something an operator instruction is qualifying. Five rejected alternatives recorded, and two of them are the interesting ones. Inside the fenced data region it would be DOCUMENTED TO BE IGNORED, since `dataRegion` tells the model everything below its heading must be reported rather than obeyed -- the accepted-where-it-does-nothing hazard. In the system prompt it would work and be marginally cheaper per turn, and is still refused: every other member of that layer is read from a fixed file path once at loader build, which is the shape `CONST-PERSONA-IN-CACHED-PREFIX`'s acceptance leans on, and `run.task` is already contracted user-prompt-only, so two operator text fields with two placements would be an incoherence. Also rejected: reusing `run.task` on webhook triggers, giving local jobs an envelope so cron could take the field, and content-filtering the operator's text (placement is the boundary; the delimiter is defence in depth, and this module's docstring already refuses that reasoning for the payload). Putting it in the envelope is what leaves `dataRegion` UNCHANGED, so the shared export keeps its signature and the new-parameters-go-last rule is honoured without threading a hole through three sibling forges. **DES-FLOWS-ARE-DATA-PERSONA-IS-CODE UNCHANGED, checked**: its clarification already admits operator-authored deploy-time config, and the reviewed `triggers.json` is that; the admin-editable runtime channel it actually bars is untouched, since no `dispatch_trigger_*` parameter was added. |
 | 2026-08-09 | Issue #60 (Gap 2). **NEW `DES-TRIGGER-SKILLS-COPIED-NOT-MOUNTED`**: the injected skills are COPIED into the per-job dir rather than bind-mounted, and the mount-count argument is deliberately recorded as the WEAKEST of the three reasons. The copy is the PIN: `:ro` bounds the container and not the host, and pi reads a skill's body on demand, so under a live bind an operator editing their directory would change the instructions of a job already running. It also answers symlinks once on the host side, where `loadSkillsFromDirInternal` would otherwise follow both file and directory links -- a directory symlink at `/` would have turned skill discovery into a walk of the container filesystem. And it adds no mount, so this entry CAN borrow the argument the 2026-07-31 `/session` row explicitly could not. Four rejected alternatives recorded, including the per-trigger `:ro` bind the issue originally sketched (with the honest qualification that a bind's source path is legible via `/proc/self/mountinfo`) and an env var naming the injected root (a second source of truth that can disagree with the filesystem, silently and in the expensive direction). **DES-AI-TRIGGER-FLOW-GATE AMENDED**: injected skills are trigger-reachable and never AI-reachable, and it FALLS OUT rather than being built -- the gate reads the object store at a pre-agent sha and an injected skill has no object-store presence, so `no-skill` and both callers refuse. The corollary is stated because an operator cannot discover it: an injected `ai-trigger: allow` is never read, `doctor` warns, and the residual is `OQ-022`. **DES-OPERATOR-GLOBAL-OVERLAY UNCHANGED, checked** -- its own rejected `/opt/pi-packages:ro` mount is the precedent the new entry cites, and the overlay's tier is unmoved. |


### PR DESCRIPTION
Third slice of issue #54: the pure assembler every graph consumer renders from. Stacked on #166 (merged).

## What

`buildGraphModel` (`admin/src/graph-model.mjs`) folds the read-model's outputs into one model, and the derivation rules are the design (`DES-GRAPH-EDGE-DERIVATION`, new):

- **Four evidence classes**, a closed test-pinned vocabulary: `config` (every trigger naming a flow gets one, always — dangling, unverifiable and charset-invalid included), `observed` (records only, with count + last occurrence), `potential` (a text mention, labelled `strong`/`eligible`), `cron-rearm` (the one self-edge every cron trigger carries by definition).
- **The OQ-009 prohibitions are structural**: no chain edge out of a forge trigger's flow, none across folders — the harness makes both unrepresentable, so drawing either would draw a lie.
- **Dangling is precise**: `no-skill` only where enumeration succeeded and the path is absent at HEAD; an unreachable or remote folder renders unverified, never dangling; a `run.flow` failing `SKILL_NAME_RE` is its own `charset-invalid` flag (the gate answers `deny` for it, and deny proves nothing about existence).
- **Orphanhood is three facts**: `orphan`, `ai-reachable-no-trigger`, `injected-ai-trigger` (the OQ-022 silent no-op, badged loudly). Sub-skills are never orphan candidates.
- **Gate eligibility is a node badge, never an all-pairs edge fabric** — with N allow-listed skills that would be N×(N−1) identical arrows; a mention is the edge.
- An observed edge that cannot hang on exactly one enumerated folder is **dropped and counted** (`meta.droppedObservedEdges`), never guessed onto a basename that merely matches.
- An unenumerated cron folder (the folder cap) still draws its trigger and config edge on a group that says `not-enumerated` — the cap must not silently lose an edge.
- Caps and honesty counters (unattributed runs, refusals, truncation) ride every model; consumers are required to render them.
- The OQ-020 `pr-spend-loop-risk` badge: a `pull_request` trigger on `opened`/`synchronize` is the static signature of the cross-actor spend loop.

## Specs (same PR)

NEW `DES-GRAPH-EDGE-DERIVATION` with the rejected alternatives recorded (declared chain topology; the all-pairs eligibility fabric; deny-as-dangling; first-match target resolution). `DES-JOB-OUTBOX-CHAINING` UNCHANGED, checked. `DES-COST-FOLD-BY-SCAN` UNCHANGED, checked (same scan, second consumer).

## Tests

21 new assembler tests over one canned deployment: the closed-vocabulary literal pin, per-rule positives, and the negative claims as their own assertions (unreachable folder → zero dangling flags; a potential edge never carries a count; eligibility alone draws no edge; the dropped edge is counted). Suite in the CI posture: 2115 pass, 0 skipped; admin bundle builds.