### PR TITLE
feat(admin): the graph HTML export, and review hardening across the pipeline (issue #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,8 +381,10 @@ Steer the running worker without stopping it, from any terminal:
 
 The dashboard shown at the top of this README is a **pi extension**: it loads into your own interactive
 pi session. No daemon, no web app, no network port. Beside the dashboard, `/dispatch graph` renders the
-whole trigger and flow topology as text: what triggers what, what chained to what in the recorded runs,
-what a skill's own text says it might chain to, plus orphan skills and dangling triggers
+whole trigger and flow topology: what triggers what, what chained to what in the recorded runs, what a
+skill's own text says it might chain to, plus orphan skills and dangling triggers. It comes as a
+dashboard view (`g`), as plain text, and as `/dispatch graph html`, a self contained page your browser
+opens from disk (still no server and no port) with the topology drawn Node-RED style
 ([`docs/graph.md`](docs/graph.md)).
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -484,6 +484,13 @@ Stated openly rather than discovered later:
   of that package and every transitive dependency would run AS YOU, ON YOUR HOST**, at install time, which is
   a host compromise and not a job one. So: no port, no harness credential, and still the same trust as shell
   access, which is where `/dispatch setup` stops being theoretical.
+- **The graph export writes one static HTML file, on your keystroke, to a temp path it names.** What
+  crosses into it: trigger configuration you authored, skill names and frontmatter from the repos you
+  service, and the PII-free run-record fields the panel already shows. What never does: raw job log
+  bytes, issue or task text, session material, or a host path beyond a folder's basename. Nothing
+  listens and nothing serves the file — opening it is a local browser reading local bytes, and the
+  page makes no network request of any kind. The browser spawn is best-effort, skipped and announced
+  over SSH or without a display; the printed `file://` URL is the contract.
 - **The dashboard writes to your terminal's clipboard only on your keystroke.** The `y`/`Y` copy keys in
   the run drill-in emit an OSC 52 sequence — the standard way a terminal application hands text to the
   local clipboard, including over SSH. What crosses is a host-assigned job id or a target URL derived

--- a/admin/src/dashboard.ts
+++ b/admin/src/dashboard.ts
@@ -157,7 +157,7 @@ export function createDashboardDeps(paths: any) {
         schedulers: Array.isArray(schedulers) ? schedulers : [],
         ...collectGraphInputs({ triggers: triggerList }),
         cronStats: cronRunStats({ records: recs, schedulerIds: triggerList.filter((t) => t.type === "cron" && typeof t.id === "string").map((t) => t.id) }),
-        runJoin: joinRunsToTriggers({ records: recs, triggerCount: triggersView?.count }),
+        runJoin: joinRunsToTriggers({ records: recs, triggerCount: triggersView?.count, triggerTypes: Object.fromEntries(triggerList.map((t) => [t.index, t.type])) }),
         chainEdges: observedChainEdges({ records: recs }),
         caps: { chainDepthMax: paths.chainDepthMax, chainMaxPerJob: paths.chainMaxPerJob, windowDays: GRAPH_LIMITS.windowDays },
         nowMs,
@@ -226,6 +226,10 @@ export function makeDashboard({
   // not per second, and this module does no I/O of its own.
   let detailSandbox: any = null;
   let detailTrigger: any = null; // the trigger opened in TRIGGER_DETAIL (its display record + file index)
+  // Which view TRIGGER_DETAIL returns to on Esc: the drill opens from LIST and from GRAPH, and Esc
+  // pops ONE layer -- landing a graph-entered drill back in LIST would discard the operator's graph
+  // position and force a fresh git-spawning fetch to get back (review finding).
+  let detailReturnTo = "LIST";
   // LIVE_TAIL state, held here in dedicated component fields keyed only by the id-only `activeJobId`. The
   // raw `.log` bytes in `tail` are PII-bearing and untrusted: they live here and reach the TUI overlay via
   // render() alone -- never `snapshot`, never a shared renderer, never `sendMessage` (INT-RUN-HISTORY-FILE-CONTRACT).
@@ -521,7 +525,8 @@ export function makeDashboard({
           return;
         }
         if (matchesKey(data, "escape")) {
-          view = "LIST";
+          // Esc pops ONE layer: back to whichever view opened the drill (LIST or GRAPH).
+          view = detailReturnTo;
           detailTrigger = null;
           tui?.requestRender?.();
           return;
@@ -757,6 +762,7 @@ export function makeDashboard({
             if (!record) return;
             detailTrigger = { record, index: row.node.index };
             pendingDelete = false;
+            detailReturnTo = "GRAPH";
             view = "TRIGGER_DETAIL";
             tui?.requestRender?.();
             return;
@@ -781,6 +787,7 @@ export function makeDashboard({
         if (row.kind === "trigger") {
           detailTrigger = { record: row.trigger, index: row.index };
           pendingDelete = false;
+          detailReturnTo = "LIST";
           view = "TRIGGER_DETAIL";
           tui?.requestRender?.();
         } else if (row.kind === "active") {
@@ -1708,7 +1715,13 @@ function renderGraphView({ graph, graphSel, graphAvailable, framed, width, style
   const model = graph?.model ?? null;
 
   if (!framed) {
-    const plain = model ? renderGraph(model).split("\n") : [graphAvailable ? "loading graph…" : "graph unavailable in this build"];
+    // The error outranks a stale model here too (review finding): a failed refresh at a tiny width
+    // must not render yesterday's topology -- or an eternal "loading" -- as if nothing happened.
+    const plain = graph?.error
+      ? [`graph unreachable (${graph.error})`]
+      : model
+        ? renderGraph(model).split("\n")
+        : [graphAvailable ? "loading graph…" : "graph unavailable in this build"];
     return [styler.stripAnsi(title), "", ...plain, "", "↑↓ move · ↵ open/fold · r refresh · esc back"];
   }
 
@@ -1754,6 +1767,7 @@ function graphCounterLine(model: any, styler: any): string | null {
   if (t.skills) bits.push("skills truncated/unread");
   if (t.edges) bits.push("edges truncated");
   if ((meta.droppedObservedEdges ?? 0) > 0) bits.push(`${meta.droppedObservedEdges} observed edges dropped`);
+  if ((meta.injectedUnreachable ?? []).length > 0) bits.push(`${meta.injectedUnreachable.length} injected dirs unreadable`);
   return bits.length ? styler.fg("warning", bits.join(" · ")) : null;
 }
 
@@ -2131,9 +2145,13 @@ function countdownText(ms: number): string {
  */
 function buildRows(snapshot: any, runSort = "time"): any[] {
   // Triggers lead the selectable list (Enter -> TRIGGER_DETAIL), then the optional ACTIVE row, then runs.
-  // A trigger row carries its file `index` so a CRUD action can target the right entry in triggers.json.
-  // The ACTIVE row stays pinned above the runs whatever the sort: it is the one row that is not history.
-  const triggers = (snapshot?.triggers?.triggers ?? []).map((t: any, i: number) => ({ kind: "trigger", trigger: t, index: i }));
+  // A trigger row carries its RAW file `index` -- the one every display record now carries (issue #54)
+  // -- so a CRUD action targets the right entry in triggers.json even when the display dropped an
+  // unusable row above it. The display POSITION this used before was a live-fire wrong-delete: one
+  // garbage entry at row 0 and `x`+`y` on the visible trigger deleted the garbage while the real
+  // trigger kept firing, reported as deleted (review finding). Falls back to the position only for a
+  // record predating the field, where it is the best available claim.
+  const triggers = (snapshot?.triggers?.triggers ?? []).map((t: any, i: number) => ({ kind: "trigger", trigger: t, index: Number.isInteger(t?.index) ? t.index : i }));
   const active = snapshot?.activeJobId ? [{ kind: "active", jobId: snapshot.activeJobId }] : [];
   const runs = (Array.isArray(snapshot?.runs) ? snapshot.runs : []).map((record: any) => ({ kind: "run", record }));
   return [...triggers, ...active, ...sortRuns(runs, runSort)];

--- a/admin/src/graph-html.mjs
+++ b/admin/src/graph-html.mjs
@@ -1,0 +1,1040 @@
+/**
+ * The Node-RED-style HTML page for the trigger/flow graph (issue #54): one fully self-contained
+ * document (inline CSS, inline SVG, ONE inline script, zero external references) that works over
+ * file:// with nothing listening anywhere. Pure in the render.mjs/costs.mjs sense and then some:
+ * this module pulls in nothing at all, not even node: builtins, and the source-regex guard that
+ * keeps render.mjs honest also keeps this one byte-deterministic -- no clock reads, no randomness, no
+ * environment. The clock the page needs at view time is read by the PAGE script in the browser
+ * (via new Date().getTime(); the static clock accessor is banned from this source by the purity
+ * test), and the generation instant is injected by the caller as `now`.
+ *
+ * Layout is a hand-rolled Sugiyama-lite rather than a graph library: the dependency posture of the
+ * repo is hand-roll-or-argue, and the graphs here are folder-local and tiny (a handful of triggers
+ * and skills), so longest-path ranking plus two median sweeps buys everything dagre would and stays
+ * auditable. The visual language is authentic Node-RED chips (pale category fills, dark labels,
+ * 20px grid, 10x10 ports) on the repo's dark chrome: Node-RED authenticity is shape language, the
+ * page around it stays consistent with docs/images/banner.svg.
+ */
+
+// Must equal graph-model.mjs's GRAPH_EDGE_KINDS; a parity test in graph-html.test.mjs compares the
+// two literals. Duplicated rather than re-exported because this module is allowed no dependencies
+// at all: the parity test is the anti-drift wire the missing `from` clause would otherwise be.
+export const GRAPH_HTML_KINDS = Object.freeze(["config", "observed", "potential", "cron-rearm"]);
+
+// ---- geometry (Node-RED editor constants where they exist, repo choices where they do not) ----
+const NODE_H = 30; // Node-RED node height
+const NODE_MIN_W = 100; // Node-RED minimum node width
+const GRID = 20; // widths snap to the 20px grid, like the editor
+// Width cap: every chip must fit inside one RANK_PITCH column with room for a wire, otherwise the
+// left-to-right layout invariant (source right edge before target left edge) could not be promised.
+// Node-RED instead measures the label on a canvas; there is no DOM here, so labels are clipped.
+const NODE_MAX_W = 160;
+const CHAR_W = 8; // 14px label estimate; over-estimating keeps text inside the chip
+const LABEL_X = 38; // label x, past the 30px icon column and its divider
+const CHIP_MAX_CHARS = 14; // what fits at NODE_MAX_W: (160 - 38 - 10) / CHAR_W
+const RANK_PITCH = 180; // fixed column pitch
+const ROW_GAP = 26; // vertical gap between rows (leaves room for the status line under a chip)
+const GROUP_PAD_L = 20;
+const GROUP_PAD_R = 20;
+const GROUP_PAD_T = 40; // room for the group label above the first row
+const GROUP_PAD_B = 44; // breathing room below the last row band (under-route depth is paid per band)
+const GROUP_GAP = 40; // folder groups stack vertically with this gap
+const SELF_LOOP_DROP = 25; // Node-RED self-wires drop this far below the node
+// Extra pitch below any row band hosting an under-row route (self-loop or back edge): the route
+// needs SELF_LOOP_DROP plus a label (~37px past the chip bottom), which ROW_GAP alone cannot
+// absorb -- without this, a folder with two cron triggers drew the first re-arm label inside the
+// second trigger's chip.
+const UNDER_ROUTE_EXTRA = 40;
+// Parallel-wire fan-out: an observed edge and a potential mention often join the SAME pair of
+// skills, and without an offset the two beziers overlay and their mid-path labels garble into one
+// smear. Sibling 0 stays straight; each later sibling bows alternately up/down by 14px at the
+// control points, and its label steps 10.5px (0.75 of the bow: a cubic's midpoint moves 3/4 of a
+// shared control offset) so every label rides its own curve and anchors stay 10px apart.
+const PARALLEL_BOW = 14;
+const PARALLEL_LABEL_STEP = 10.5;
+// A wire spanning under 40px has its midpoint hugging the ports, so its label lifts above the
+// wire (siblings stacking further up) instead of sitting on the port squares and the wire itself.
+const LABEL_MIN_SPAN = 40;
+const VIEW_MARGIN = 80; // viewBox margin around the content bbox
+
+// ---- palette: repo-dark chrome, authentic pale Node-RED chips with DARK labels inside ----
+const PAGE_CANVAS = "#0d1117";
+const PAGE_PANEL = "#161b22";
+const PAGE_BORDER = "#30363d";
+const PAGE_FG = "#c9d1d9";
+const PAGE_DIM = "#8b949e";
+const PAGE_ACCENT = "#58a6ff";
+const PAGE_AMBER = "#d29922";
+const CHIP_STROKE = "#999";
+const CHIP_LABEL = "#333";
+const PORT_FILL = "#d9d9d9";
+const CHIP_FILL = Object.freeze({
+  cron: "#a6bbcf",
+  label: "#d8bfd8",
+  comment: "#e7e7ae",
+  pull_request: "#c0deed",
+  skill: "#fdd0a2",
+});
+const STATUS_COMPLETED = "#3fb950";
+const STATUS_FAILED = "#ff5f57";
+const STATUS_OTHER = "#6e7681";
+const BADGE_ORANGE = "#db6d28";
+const BADGE_GREEN = "#3fb950";
+const DANGER = "#f85149";
+const GROUP_FILL = "#E6E0F8";
+const WIRE_OBSERVED = "#999";
+const WIRE_CONFIG = "#6e7681";
+const WIRE_POTENTIAL = "#8b949e";
+
+// One glyph per node kind for the 30px icon column; characters, not images, because images would
+// need data: URIs and a font would need @font-face, both of which the file:// posture forbids.
+const GLYPH = Object.freeze({
+  cron: "◷",
+  label: "◈",
+  comment: "❝",
+  pull_request: "⇄",
+  skill: "ƒ",
+  "skill-missing": "!",
+  "skill-unverified": "?",
+  injected: "+",
+});
+
+// The 5-entity escape, byte-for-byte the worker's buildFormPage helper: every string interpolated
+// into markup goes through this, operator-authored or not, because "charset-bound upstream" is an
+// assumption and an entity is a guarantee.
+function escapeHtml(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+// JSON destined for the inline script: `<` becomes < so no value can spell `</script>` and
+// break out of the script element, and U+2028/2029 become escapes because they are line
+// terminators to a JS parser while being invisible to JSON.
+function embedJson(value) {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+// Every number that reaches markup goes through this: a non-finite value becomes 0 rather than
+// serialising as one of the three words the well-formedness test bans outright.
+function fmt(v) {
+  const n = Number.isFinite(v) ? Math.round(v * 10) / 10 : 0;
+  return String(n);
+}
+
+function finOr(v, fallback) {
+  return Number.isFinite(v) ? v : fallback;
+}
+
+function intOr(v, fallback) {
+  return Number.isInteger(v) ? v : fallback;
+}
+
+function strOr(v, fallback) {
+  return typeof v === "string" && v !== "" ? v : fallback;
+}
+
+function clip(s, max) {
+  const t = String(s);
+  return t.length > max ? `${t.slice(0, max)}…` : t;
+}
+
+/**
+ * Defensive normalisation, applied before anything else: explicit field allowlists (never a spread,
+ * so an unexpected field on a model object -- or a folder's absolute host `path` -- structurally
+ * cannot reach the page) and a total sort of every array, so a permuted input yields byte-identical
+ * output. Node/folder identities are NOT carried through: original ids embed folder paths
+ * (`skill:folder:/abs/path:name`), so the layout mints ordinal ids (`n0`, `g0`, `w0`) and the
+ * originals stay server-side.
+ */
+function normalizeModel(model) {
+  const ok = model !== null && typeof model === "object";
+  const m = ok ? model : {};
+
+  const caps = {
+    chainDepthMax: intOr(m.caps?.chainDepthMax, null),
+    chainMaxPerJob: intOr(m.caps?.chainMaxPerJob, null),
+    sameFolderOnly: m.caps?.sameFolderOnly !== false,
+    windowDays: intOr(m.caps?.windowDays, null),
+  };
+  const meta = {
+    generatedAt: finOr(m.meta?.generatedAt, null),
+    triggersMissing: m.meta?.triggersMissing === true,
+    triggersInvalid: typeof m.meta?.triggersInvalid === "string" ? m.meta.triggersInvalid : null,
+    unattributedRuns: intOr(m.meta?.unattributedRuns, 0),
+    droppedObservedEdges: intOr(m.meta?.droppedObservedEdges, 0),
+    truncated: {
+      folders: m.meta?.truncated?.folders === true,
+      skills: m.meta?.truncated?.skills === true,
+      edges: m.meta?.truncated?.edges === true,
+    },
+  };
+
+  const folders = [];
+  for (const f of Array.isArray(m.folders) ? m.folders : []) {
+    if (!f || typeof f !== "object" || typeof f.key !== "string") continue;
+    folders.push({
+      key: f.key,
+      label: strOr(f.label, "(folder)"), // label only; f.path is an absolute host path and never copied
+      kind: f.kind === "forge" ? "forge" : "local",
+      head: typeof f.head === "string" ? f.head : null,
+      unreachable: typeof f.unreachable === "string" ? f.unreachable : null,
+    });
+  }
+  folders.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+
+  const nodes = [];
+  const seen = new Set();
+  for (const n of Array.isArray(m.nodes) ? m.nodes : []) {
+    if (!n || typeof n !== "object" || typeof n.id !== "string" || seen.has(n.id)) continue;
+    seen.add(n.id);
+    nodes.push({
+      id: n.id,
+      kind: typeof n.kind === "string" ? n.kind : "skill",
+      name: typeof n.name === "string" ? n.name : null,
+      label: typeof n.label === "string" ? n.label : null,
+      onType: typeof n.onType === "string" ? n.onType : null,
+      pattern: typeof n.pattern === "string" ? n.pattern : null,
+      flow: typeof n.flow === "string" ? n.flow : null,
+      replicas: intOr(n.replicas, null),
+      folderKey: typeof n.folderKey === "string" ? n.folderKey : null,
+      runs: intOr(n.runs, 0),
+      lastOutcome: typeof n.lastOutcome === "string" ? n.lastOutcome : null,
+      lastEndedAt: typeof n.lastEndedAt === "string" || Number.isFinite(n.lastEndedAt) ? n.lastEndedAt : null,
+      isSub: n.isSub === true,
+      aiTrigger: n.aiTrigger === true,
+      unread: n.unread === true,
+      description: typeof n.meta?.description === "string" ? clip(n.meta.description, 120) : null,
+    });
+  }
+  nodes.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  const edges = [];
+  for (const e of Array.isArray(m.edges) ? m.edges : []) {
+    if (!e || typeof e !== "object") continue;
+    if (typeof e.from !== "string" || typeof e.to !== "string") continue;
+    if (!GRAPH_HTML_KINDS.includes(e.kind)) continue; // an unknown kind is never drawn, per contract
+    edges.push({
+      from: e.from,
+      to: e.to,
+      kind: e.kind,
+      count: intOr(e.count, null),
+      strong: e.strong === true,
+      eligible: e.eligible === true,
+      label: typeof e.label === "string" ? e.label : null,
+    });
+  }
+  edges.sort((a, b) => cmpStr(a.kind, b.kind) || cmpStr(a.from, b.from) || cmpStr(a.to, b.to) || cmpStr(a.label ?? "", b.label ?? "") || (a.count ?? -1) - (b.count ?? -1) || (a.strong ? 1 : 0) - (b.strong ? 1 : 0));
+
+  const flags = [];
+  for (const f of Array.isArray(m.flags) ? m.flags : []) {
+    if (!f || typeof f !== "object" || typeof f.nodeId !== "string" || typeof f.flag !== "string") continue;
+    flags.push({ nodeId: f.nodeId, flag: f.flag, detail: typeof f.detail === "string" ? clip(f.detail, 160) : null });
+  }
+  flags.sort((a, b) => cmpStr(a.nodeId, b.nodeId) || cmpStr(a.flag, b.flag) || cmpStr(a.detail ?? "", b.detail ?? ""));
+
+  return { ok, folders, nodes, edges, flags, caps, meta };
+}
+
+function cmpStr(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+// ---- layout ----
+
+function chipLabel(n) {
+  if (n.kind === "trigger") return clip(n.label ?? n.onType ?? "trigger", CHIP_MAX_CHARS);
+  return clip(n.name ?? "(unnamed)", CHIP_MAX_CHARS);
+}
+
+function chipWidth(label) {
+  const raw = LABEL_X + label.length * CHAR_W + 12;
+  const snapped = Math.ceil(raw / GRID) * GRID;
+  return Math.min(NODE_MAX_W, Math.max(NODE_MIN_W, snapped));
+}
+
+/**
+ * Place the normalised model: one Node-RED group rect per folder, triggers at rank 0 inside it,
+ * skills ranked by longest path over config/observed/potential edges, rows ordered by two median
+ * sweeps with an alphabetical tiebreak (no randomness anywhere -- determinism is a test). Exported
+ * so the layout invariants (left-to-right wires, group containment, no overlaps) are testable
+ * without parsing SVG back out of the page.
+ */
+export function layoutGraph(model) {
+  return layoutNormalized(normalizeModel(model));
+}
+
+function layoutNormalized(norm) {
+  const empty = { nodes: [], wires: [], groups: [], viewBox: { x: 0, y: 0, w: 800, h: 600 } };
+  if (!norm.ok && norm.nodes.length === 0) return empty;
+
+  // Groups: every folder from the model, in sorted-key order, then synthetic homes for nodes the
+  // folders do not claim (injected skills carry no folder; a defensive bucket catches the rest so a
+  // malformed node still draws somewhere instead of vanishing).
+  const groups = [];
+  const groupIndexByKey = new Map();
+  const addGroup = (key, label, kind, head, unreachable) => {
+    const g = { id: `g${groups.length}`, label, kind, head, unreachable, members: [], x: 0, y: 0, w: 0, h: 0 };
+    groups.push(g);
+    groupIndexByKey.set(key, g);
+    return g;
+  };
+  for (const f of norm.folders) addGroup(f.key, f.label, f.kind, f.head, f.unreachable);
+
+  const placed = [];
+  const placedByOrig = new Map();
+  for (const n of norm.nodes) {
+    const label = chipLabel(n);
+    const p = { id: `n${placed.length}`, kind: n.kind, label, x: 0, y: 0, w: chipWidth(label), h: NODE_H, groupId: null, node: n };
+    placed.push(p);
+    placedByOrig.set(n.id, p);
+    let g = n.folderKey === null ? null : (groupIndexByKey.get(n.folderKey) ?? null);
+    if (!g && n.kind === "injected") g = groupIndexByKey.get("~injected") ?? addGroup("~injected", "injected skills (run.skillsDir)", "local", null, null);
+    if (!g) g = groupIndexByKey.get(n.folderKey ?? "~ungrouped") ?? addGroup(n.folderKey ?? "~ungrouped", "ungrouped", "local", null, null);
+    g.members.push(p);
+    p.groupId = g.id;
+  }
+
+  // Wires: normalised edges whose endpoints exist. Self edges route as loops; cyclic back edges
+  // (found by a deterministic DFS) are excluded from ranking and routed under the rows, because a
+  // rank function cannot satisfy a cycle and refusing to draw the edge would hide a real fact.
+  const wires = [];
+  for (const e of norm.edges) {
+    const f = placedByOrig.get(e.from);
+    const t = placedByOrig.get(e.to);
+    if (!f || !t) continue;
+    wires.push({ id: `w${wires.length}`, kind: e.kind, from: f.id, to: t.id, self: f === t, back: false, edge: e, f, t, d: "", labelX: 0, labelY: 0 });
+  }
+  markBackEdges(placed, wires);
+
+  // Rank + order + coordinates, one group at a time; groups then stack vertically.
+  let groupY = 0;
+  let maxGroupW = 0;
+  for (const g of groups) {
+    const size = layoutGroup(g, wires);
+    g.x = 0;
+    g.y = groupY;
+    g.w = size.w;
+    g.h = size.h;
+    for (const p of g.members) {
+      p.x += g.x;
+      p.y += g.y;
+    }
+    groupY += g.h + GROUP_GAP;
+    if (g.w > maxGroupW) maxGroupW = g.w;
+  }
+
+  // Sibling index among wires sharing one (from, to) pair, assigned in the already-sorted wire
+  // order (kind first), so the observed edge keeps the straight path and the potential mention
+  // bows around it -- deterministically, whatever order the model arrived in.
+  const parallelCount = new Map();
+  for (const w of wires) {
+    const key = `${w.from} ${w.to}`;
+    w.parallel = parallelCount.get(key) ?? 0;
+    parallelCount.set(key, w.parallel + 1);
+  }
+
+  for (const w of wires) routeWire(w);
+  for (const w of wires) {
+    delete w.f;
+    delete w.t;
+  }
+
+  const totalH = groups.length > 0 ? groupY - GROUP_GAP : 0;
+  const viewBox = groups.length > 0
+    ? { x: -VIEW_MARGIN, y: -VIEW_MARGIN, w: maxGroupW + VIEW_MARGIN * 2, h: totalH + VIEW_MARGIN * 2 }
+    : { x: 0, y: 0, w: 800, h: 600 };
+  return { nodes: placed, wires, groups, viewBox };
+}
+
+// Iterative DFS in sorted order; an edge landing on a node still on the stack is a back edge.
+// Iterative rather than recursive so a hostile model cannot overflow the stack.
+function markBackEdges(placed, wires) {
+  const out = new Map();
+  for (const w of wires) {
+    if (w.self) continue;
+    if (!out.has(w.from)) out.set(w.from, []);
+    out.get(w.from).push(w);
+  }
+  for (const list of out.values()) list.sort((a, b) => cmpStr(a.to, b.to) || cmpStr(a.id, b.id));
+  const state = new Map(); // 1 = on stack, 2 = done
+  for (const p of placed) {
+    if (state.has(p.id)) continue;
+    const stack = [{ id: p.id, i: 0 }];
+    state.set(p.id, 1);
+    while (stack.length > 0) {
+      const top = stack[stack.length - 1];
+      const edges = out.get(top.id) ?? [];
+      if (top.i >= edges.length) {
+        state.set(top.id, 2);
+        stack.pop();
+        continue;
+      }
+      const w = edges[top.i++];
+      const s = state.get(w.to);
+      if (s === 1) w.back = true;
+      else if (s !== 2) {
+        state.set(w.to, 1);
+        stack.push({ id: w.to, i: 0 });
+      }
+    }
+  }
+}
+
+function layoutGroup(g, allWires) {
+  const members = g.members;
+  if (members.length === 0) return { w: GROUP_PAD_L + NODE_MAX_W + GROUP_PAD_R, h: GROUP_PAD_T + GROUP_PAD_B };
+  const inGroup = new Set(members.map((p) => p.id));
+  const rankEdges = allWires.filter((w) => !w.self && !w.back && inGroup.has(w.from) && inGroup.has(w.to));
+
+  // Longest-path ranks: triggers pinned at column 0, everything else starts one column in and is
+  // pushed right by each edge. Relaxation is bounded by the member count, which suffices once back
+  // edges are gone; a topological sort would be no cheaper for graphs this small.
+  const rank = new Map();
+  for (const p of members) rank.set(p.id, p.kind === "trigger" ? 0 : 1);
+  for (let i = 0; i < members.length; i++) {
+    let changed = false;
+    for (const w of rankEdges) {
+      if (w.t.kind === "trigger") continue; // triggers stay in column 0, whatever points at them
+      const want = rank.get(w.from) + 1;
+      if (rank.get(w.to) < want) {
+        rank.set(w.to, want);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+
+  const maxRank = Math.max(...[...rank.values()]);
+  const rows = [];
+  for (let r = 0; r <= maxRank; r++) rows.push([]);
+  for (const p of members) rows[rank.get(p.id)].push(p);
+  for (const row of rows) row.sort((a, b) => cmpStr(a.label, b.label) || cmpStr(a.id, b.id));
+  orderRows(rows, rankEdges);
+
+  // Row bands hosting an under-row route (a self-loop, or either end of a back edge) get extra
+  // pitch below them. Band-wide rather than per rank, so rows stay grid-aligned and the back
+  // edge's horizontal run -- which crosses ranks -- clears every chip in the bands below it, not
+  // just the chips in its own column.
+  const underIds = new Set();
+  for (const w of allWires) {
+    if (w.self && inGroup.has(w.from)) underIds.add(w.from);
+    if (w.back) {
+      if (inGroup.has(w.from)) underIds.add(w.from);
+      if (inGroup.has(w.to)) underIds.add(w.to);
+    }
+  }
+  const maxRows = Math.max(...rows.map((row) => row.length));
+  const rowY = [];
+  let y = GROUP_PAD_T;
+  for (let i = 0; i < maxRows; i++) {
+    rowY.push(y);
+    const under = rows.some((row) => row.length > i && underIds.has(row[i].id));
+    y += NODE_H + (under ? UNDER_ROUTE_EXTRA : 0) + ROW_GAP;
+  }
+  for (let r = 0; r <= maxRank; r++) {
+    for (let i = 0; i < rows[r].length; i++) {
+      rows[r][i].x = GROUP_PAD_L + r * RANK_PITCH;
+      rows[r][i].y = rowY[i];
+    }
+  }
+  return {
+    w: GROUP_PAD_L + maxRank * RANK_PITCH + NODE_MAX_W + GROUP_PAD_R,
+    h: y - ROW_GAP + GROUP_PAD_B,
+  };
+}
+
+// Two median sweeps (down over predecessors, up over successors), the deterministic core of the
+// Sugiyama ordering step. Two, not the classic four-to-eight with transpose, because these graphs
+// are a handful of rows deep and the extra sweeps buy nothing a test could observe.
+function orderRows(rows, rankEdges) {
+  const pos = new Map();
+  const setPos = (row) => row.forEach((p, i) => pos.set(p.id, i));
+  for (const row of rows) setPos(row);
+  const preds = new Map();
+  const succs = new Map();
+  for (const w of rankEdges) {
+    if (!preds.has(w.to)) preds.set(w.to, []);
+    preds.get(w.to).push(w.from);
+    if (!succs.has(w.from)) succs.set(w.from, []);
+    succs.get(w.from).push(w.to);
+  }
+  const median = (ids) => {
+    const xs = (ids ?? []).map((id) => pos.get(id)).filter((v) => Number.isInteger(v)).sort((a, b) => a - b);
+    return xs.length === 0 ? null : xs[(xs.length - 1) >> 1];
+  };
+  const sweep = (nbrs, indices) => {
+    for (const r of indices) {
+      const keyed = rows[r].map((p, i) => ({ p, key: median(nbrs.get(p.id)) ?? i }));
+      keyed.sort((a, b) => a.key - b.key || cmpStr(a.p.label, b.p.label) || cmpStr(a.p.id, b.p.id));
+      rows[r] = keyed.map((k) => k.p);
+      setPos(rows[r]);
+    }
+  };
+  const down = [];
+  const up = [];
+  for (let r = 1; r < rows.length; r++) down.push(r);
+  for (let r = rows.length - 2; r >= 0; r--) up.push(r);
+  sweep(preds, down);
+  sweep(succs, up);
+}
+
+function routeWire(w) {
+  const f = w.f;
+  const t = w.t;
+  const y1 = f.y + NODE_H / 2;
+  const y2 = t.y + NODE_H / 2;
+  // Under-route control offset: 18, not the visually roomier 25-30, so a drop beside a full-width
+  // chip (w = 160) stays strictly inside the 180px column pitch and can never graze the next
+  // column's chips on its way down.
+  const LOOP_OFF = 18;
+  if (w.self) {
+    // The Node-RED self-wire: out the output port, drop below the node, run under it, back up into
+    // the input port. The label (a cron pattern, usually) sits under the loop where nothing else is
+    // -- layoutGroup pays UNDER_ROUTE_EXTRA below this row band so that claim stays true.
+    const x1 = f.x + f.w;
+    const x2 = f.x;
+    const yb = f.y + NODE_H + SELF_LOOP_DROP + w.parallel * 12;
+    w.d = `M ${fmt(x1)} ${fmt(y1)} C ${fmt(x1 + LOOP_OFF)} ${fmt(y1)}, ${fmt(x1 + LOOP_OFF)} ${fmt(yb)}, ${fmt(x1)} ${fmt(yb)} L ${fmt(x2)} ${fmt(yb)} C ${fmt(x2 - LOOP_OFF)} ${fmt(yb)}, ${fmt(x2 - LOOP_OFF)} ${fmt(y2)}, ${fmt(x2)} ${fmt(y2)}`;
+    w.labelX = f.x + f.w / 2;
+    w.labelY = yb + 12;
+    return;
+  }
+  if (w.back) {
+    // A cycle survivor: routed under both rows rather than reversed, so the arrowless path still
+    // reads left-of-target and the forward layout invariant stays honest for every other wire.
+    const x1 = f.x + f.w;
+    const x2 = t.x;
+    const yb = Math.max(f.y, t.y) + NODE_H + SELF_LOOP_DROP + 10 + w.parallel * 12;
+    w.d = `M ${fmt(x1)} ${fmt(y1)} C ${fmt(x1 + LOOP_OFF)} ${fmt(y1)}, ${fmt(x1 + LOOP_OFF)} ${fmt(yb)}, ${fmt(x1)} ${fmt(yb)} L ${fmt(x2)} ${fmt(yb)} C ${fmt(x2 - LOOP_OFF)} ${fmt(yb)}, ${fmt(x2 - LOOP_OFF)} ${fmt(y2)}, ${fmt(x2)} ${fmt(y2)}`;
+    w.labelX = (x1 + x2) / 2;
+    w.labelY = yb + 12;
+    return;
+  }
+  // The Node-RED wire bezier: horizontal control offsets at 0.75 of the span, tightened when the
+  // nodes are closer than 100px so short wires do not balloon. Parallel siblings (index > 0) bow
+  // their control points alternately up/down so two wires between one pair never overlay.
+  const x1 = f.x + f.w;
+  const x2 = t.x;
+  const dx = Math.max(x2 - x1, 4);
+  const sc = dx < 100 ? 0.75 * (dx / 100) : 0.75;
+  const off = Math.max(dx * sc, 10);
+  const sign = w.parallel % 2 === 1 ? -1 : 1;
+  const steps = Math.ceil(w.parallel / 2);
+  const bow = sign * steps * PARALLEL_BOW;
+  w.d = `M ${fmt(x1)} ${fmt(y1)} C ${fmt(x1 + off)} ${fmt(y1 + bow)}, ${fmt(x2 - off)} ${fmt(y2 + bow)}, ${fmt(x2)} ${fmt(y2)}`;
+  w.labelX = (x1 + x2) / 2;
+  if (x2 - x1 < LABEL_MIN_SPAN) {
+    // Adjacent full-width chips leave a ~20px span: the midpoint hugs the port squares, so the
+    // label lifts above the wire and siblings stack upward by a fixed pitch instead of bow-tracking.
+    w.labelY = Math.min(y1, y2) - 12 - w.parallel * 12;
+  } else {
+    w.labelY = (y1 + y2) / 2 - 5 + sign * steps * PARALLEL_LABEL_STEP;
+  }
+}
+
+// ---- server-side strings the page shows (tips, legend, banners) ----
+
+function relTime(nowMs, v) {
+  const t = typeof v === "number" ? v : typeof v === "string" ? Date.parse(v) : null;
+  if (!Number.isFinite(t) || !Number.isFinite(nowMs)) return null;
+  const s = Math.max(0, Math.floor((nowMs - t) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const mn = Math.floor(s / 60);
+  if (mn < 60) return `${mn}m ago`;
+  const h = Math.floor(mn / 60);
+  if (h < 48) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+// The hover tooltip content, prebuilt here so the page script never assembles markup: the client
+// assigns these strings via textContent only, which is what makes "no innerHTML anywhere" testable
+// as a plain substring ban.
+function buildTip(n, flags, groupLabel, nowMs) {
+  const lines = [];
+  if (n.kind === "trigger") {
+    lines.push(`trigger · ${n.onType ?? "?"} · ${n.label ?? ""}`.trim());
+    if (n.flow !== null) lines.push(`flow: ${n.flow}${n.replicas !== null ? ` ×${n.replicas}` : ""}`);
+  } else if (n.kind === "injected") {
+    lines.push(`injected skill · ${n.name ?? "?"}`);
+    lines.push("trigger-reachable via run.skillsDir, never AI-reachable");
+  } else if (n.kind === "skill-missing") {
+    lines.push(`skill · ${n.name ?? "?"} · missing at HEAD`);
+  } else if (n.kind === "skill-unverified") {
+    lines.push(`skill · ${n.name ?? "?"} · unverified (repo not readable from this host)`);
+  } else {
+    lines.push(`skill · ${n.name ?? "?"}${n.isSub ? " · sub-skill (never a flow)" : ""}`);
+  }
+  if (groupLabel !== null) lines.push(`folder: ${groupLabel}`);
+  if (n.description !== null) lines.push(n.description);
+  if (n.kind === "trigger") {
+    if (n.runs > 0) {
+      const rel = relTime(nowMs, n.lastEndedAt);
+      lines.push(`runs: ${n.runs}${n.lastOutcome !== null ? ` · last ${n.lastOutcome}${rel !== null ? ` ${rel}` : ""}` : ""}`);
+    } else {
+      lines.push("no runs in window");
+    }
+  }
+  if (n.aiTrigger) lines.push("chainable: ai-trigger allow");
+  for (const f of flags) lines.push(f.detail !== null ? `${f.flag}: ${f.detail}` : f.flag);
+  return lines.join("\n");
+}
+
+function groupTitle(g) {
+  if (g.kind === "forge") return `${g.label} · forge · unverifiable from this host`;
+  if (g.unreachable !== null && g.unreachable !== undefined && g.unreachable !== "") return `${g.label} · ${g.unreachable}`;
+  if (g.head !== null && g.head !== undefined && g.head !== "") return `${g.label} · HEAD ${String(g.head).slice(0, 7)}`;
+  return g.label;
+}
+
+function capsLineText(caps) {
+  const d = caps.chainDepthMax ?? "?";
+  const m = caps.chainMaxPerJob ?? "?";
+  const k = caps.windowDays ?? "?";
+  return `chains: depth ≤ ${d} · ≤ ${m} per job · same folder only · window ${k}d`;
+}
+
+// ---- SVG emission ----
+
+const ORANGE_FLAGS = new Set(["unread", "injected-ai-trigger", "pr-spend-loop-risk"]);
+const DANGLING_FLAGS = new Set(["no-skill", "charset-invalid"]);
+
+function nodeState(n, flagNames) {
+  if (n.kind === "skill-missing" || [...flagNames].some((f) => DANGLING_FLAGS.has(f))) {
+    return { stroke: DANGER, dash: "10,4", faded: false };
+  }
+  if (n.kind === "skill-unverified") return { stroke: PAGE_DIM, dash: "10,4", faded: false };
+  if (flagNames.has("orphan")) return { stroke: CHIP_STROKE, dash: "8,3", faded: true };
+  return { stroke: CHIP_STROKE, dash: null, faded: false };
+}
+
+function chipFill(n) {
+  if (n.kind === "trigger") return CHIP_FILL[n.onType] ?? PORT_FILL;
+  return CHIP_FILL.skill;
+}
+
+function chipGlyph(n) {
+  if (n.kind === "trigger") return GLYPH[n.onType] ?? "•";
+  return GLYPH[n.kind] ?? GLYPH.skill;
+}
+
+function statusColor(outcome) {
+  if (outcome === "completed") return STATUS_COMPLETED;
+  if (outcome === "failed") return STATUS_FAILED;
+  return STATUS_OTHER;
+}
+
+function nodeSvg(p, flags, hasIn, hasOut) {
+  const n = p.node;
+  const flagNames = new Set(flags.map((f) => f.flag));
+  const state = nodeState(n, flagNames);
+  const parts = [`<g class="gnode" id="${p.id}" transform="translate(${fmt(p.x)},${fmt(p.y)})">`];
+  parts.push(
+    `<rect width="${fmt(p.w)}" height="${fmt(NODE_H)}" rx="5" fill="${chipFill(n)}"${state.faded ? ' fill-opacity=".5"' : ""} stroke="${state.stroke}" stroke-width="1"${state.dash !== null ? ` stroke-dasharray="${state.dash}"` : ""}/>`,
+  );
+  parts.push(`<path d="M 30 1 L 30 29" stroke="${CHIP_STROKE}" stroke-width="1" opacity=".5"/>`);
+  parts.push(`<text x="15" y="20" text-anchor="middle" font-size="13" fill="${CHIP_LABEL}">${escapeHtml(chipGlyph(n))}</text>`);
+  parts.push(`<text x="${LABEL_X}" y="20" font-size="14" fill="${CHIP_LABEL}">${escapeHtml(p.label)}</text>`);
+  if (hasIn) parts.push(`<rect x="-5" y="${fmt(NODE_H / 2 - 5)}" width="10" height="10" rx="3" fill="${PORT_FILL}" stroke="${CHIP_STROKE}" stroke-width="1"/>`);
+  if (hasOut) parts.push(`<rect x="${fmt(p.w - 5)}" y="${fmt(NODE_H / 2 - 5)}" width="10" height="10" rx="3" fill="${PORT_FILL}" stroke="${CHIP_STROKE}" stroke-width="1"/>`);
+  if (n.kind === "trigger") {
+    parts.push(`<rect x="3" y="${fmt(NODE_H + 3)}" width="9" height="9" rx="2" fill="${statusColor(n.runs > 0 ? n.lastOutcome : null)}"/>`);
+    parts.push(`<text x="16" y="${fmt(NODE_H + 11)}" font-size="10" fill="${PAGE_DIM}">${n.runs > 0 ? `${fmt(n.runs)} runs` : "no runs"}</text>`);
+  }
+  const orange = [...flagNames].some((f) => ORANGE_FLAGS.has(f));
+  if (orange) parts.push(`<circle cx="${fmt(p.w - 4)}" cy="-2" r="5" fill="${BADGE_ORANGE}"/>`);
+  if (n.aiTrigger) parts.push(`<circle cx="${fmt(p.w - 4 - (orange ? 14 : 0))}" cy="-2" r="4" fill="none" stroke="${BADGE_GREEN}" stroke-width="2"/>`);
+  parts.push("</g>");
+  return parts.join("");
+}
+
+function wireStyle(w) {
+  if (w.kind === "observed") return { stroke: WIRE_OBSERVED, width: 3, dash: null };
+  if (w.kind === "config") return { stroke: WIRE_CONFIG, width: 2, dash: null };
+  if (w.kind === "potential") return { stroke: w.edge.strong ? PAGE_ACCENT : WIRE_POTENTIAL, width: 2, dash: "6,4" };
+  return { stroke: CHIP_FILL.cron, width: 2, dash: "4,3" }; // cron-rearm: dashed in the trigger's own hue
+}
+
+function wireSvg(w) {
+  const s = wireStyle(w);
+  const parts = [`<g class="gwire" id="${w.id}">`];
+  parts.push(`<path d="${w.d}" fill="none" stroke="${s.stroke}" stroke-width="${fmt(s.width)}"${s.dash !== null ? ` stroke-dasharray="${s.dash}"` : ""}/>`);
+  let label = null;
+  let fill = PAGE_DIM;
+  if (w.kind === "observed" && w.edge.count !== null) {
+    label = `(${w.edge.count}×)`;
+    fill = WIRE_OBSERVED;
+  } else if (w.kind === "potential") {
+    label = "mention";
+    fill = w.edge.strong ? PAGE_ACCENT : WIRE_POTENTIAL;
+  } else if (w.kind === "cron-rearm" && w.edge.label !== null) {
+    label = w.edge.label;
+    fill = CHIP_FILL.cron;
+  }
+  if (label !== null) parts.push(`<text x="${fmt(w.labelX)}" y="${fmt(w.labelY)}" text-anchor="middle" font-size="10" fill="${fill}">${escapeHtml(label)}</text>`);
+  parts.push("</g>");
+  return parts.join("");
+}
+
+function groupSvg(g) {
+  const opacity = g.kind === "forge" ? "0.03" : "0.06";
+  return [
+    `<g class="ggroup">`,
+    `<rect x="${fmt(g.x)}" y="${fmt(g.y)}" width="${fmt(g.w)}" height="${fmt(g.h)}" rx="2" fill="${GROUP_FILL}" fill-opacity="${opacity}" stroke="${PAGE_BORDER}" stroke-width="2"/>`,
+    `<text x="${fmt(g.x + 8)}" y="${fmt(g.y + 18)}" font-size="11" fill="${PAGE_DIM}">${escapeHtml(groupTitle(g))}</text>`,
+    `</g>`,
+  ].join("");
+}
+
+// ---- legend ----
+
+function legendSample(stroke, width, dash) {
+  return `<svg width="46" height="10" aria-hidden="true"><path d="M 2 5 C 16 5, 30 5, 44 5" fill="none" stroke="${stroke}" stroke-width="${fmt(width)}"${dash !== null ? ` stroke-dasharray="${dash}"` : ""}/></svg>`;
+}
+
+function legendSwatch(inner) {
+  return `<svg width="16" height="12" aria-hidden="true">${inner}</svg>`;
+}
+
+function legendHtml(norm) {
+  const rows = [];
+  const row = (sample, text) => rows.push(`<div class="row">${sample}<span>${escapeHtml(text)}</span></div>`);
+  rows.push("<h2>edges</h2>");
+  row(legendSample(WIRE_CONFIG, 2, null), "config: the trigger names this flow");
+  row(legendSample(WIRE_OBSERVED, 3, null), "observed ×n: chained in run records");
+  row(legendSample(WIRE_POTENTIAL, 2, "6,4"), "potential: a text mention, not a promise");
+  row(legendSample(PAGE_ACCENT, 2, "6,4"), "potential (strong): near chain vocabulary");
+  row(legendSample(CHIP_FILL.cron, 2, "4,3"), "cron re-arm: the schedule itself");
+  rows.push("<h2>badges</h2>");
+  row(legendSwatch(`<circle cx="8" cy="6" r="5" fill="${BADGE_ORANGE}"/>`), "unread / injected ai-trigger / PR spend-loop risk");
+  row(legendSwatch(`<circle cx="8" cy="6" r="4" fill="none" stroke="${BADGE_GREEN}" stroke-width="2"/>`), "chainable: ai-trigger allow");
+  row(legendSwatch(`<rect x="1" y="1" width="14" height="10" rx="2" fill="none" stroke="${CHIP_STROKE}" stroke-dasharray="8,3"/>`), "orphan: no trigger, no ai-trigger, no mention");
+  row(legendSwatch(`<rect x="1" y="1" width="14" height="10" rx="2" fill="none" stroke="${DANGER}" stroke-dasharray="10,4"/>`), "dangling: flow absent or name invalid");
+  row(legendSwatch(`<rect x="1" y="1" width="14" height="10" rx="2" fill="none" stroke="${PAGE_DIM}" stroke-dasharray="10,4"/>`), "unverified: repo not readable from this host");
+  rows.push(`<div class="caps">${escapeHtml(capsLineText(norm.caps))}</div>`);
+  const honesty = [];
+  if (norm.meta.unattributedRuns > 0) honesty.push(`${norm.meta.unattributedRuns} runs unattributed`);
+  if (norm.meta.truncated.folders) honesty.push("folder scan truncated (cap reached)");
+  if (norm.meta.truncated.skills) honesty.push("skill enumeration truncated or partly unread");
+  if (norm.meta.truncated.edges) honesty.push("observed edges truncated (cap reached)");
+  if (norm.meta.droppedObservedEdges > 0) honesty.push(`${norm.meta.droppedObservedEdges} observed edges dropped (no unique folder)`);
+  for (const line of honesty) rows.push(`<div class="honesty">${escapeHtml(line)}</div>`);
+  return `<div id="legend">${rows.join("")}</div>`;
+}
+
+function bannersHtml(norm) {
+  const banners = [];
+  if (!norm.ok) banners.push("no graph model supplied; the page has nothing to draw");
+  if (norm.meta.triggersMissing) banners.push("no triggers file found");
+  if (norm.meta.triggersInvalid !== null) banners.push(`triggers file invalid: ${norm.meta.triggersInvalid}`);
+  if (banners.length === 0) return "";
+  return `<div id="banners">${banners.map((b) => `<div class="banner">${escapeHtml(b)}</div>`).join("")}</div>`;
+}
+
+// ---- page assembly ----
+
+const PAGE_CSS = `
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:${PAGE_CANVAS};color:${PAGE_FG};font:14px/1.4 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+#hdr{position:fixed;top:0;left:0;right:0;height:46px;display:flex;align-items:center;gap:12px;padding:0 14px;background:${PAGE_PANEL};border-bottom:1px solid ${PAGE_BORDER};z-index:3}
+#hdr h1{font-size:14px;font-weight:600}
+#stamp{color:${PAGE_DIM};font-size:12px}
+#stamp.stale{color:${PAGE_AMBER}}
+#hdr button,#hdr select{background:#21262d;color:${PAGE_FG};border:1px solid ${PAGE_BORDER};border-radius:6px;padding:3px 10px;font-size:12px}
+#banners{position:fixed;top:52px;left:10px;z-index:3;max-width:46%}
+.banner{background:#2d1517;border:1px solid ${DANGER};color:${DANGER};border-radius:6px;padding:6px 10px;margin-bottom:6px;font-size:12px}
+#wrap{position:relative;height:100vh;padding-top:46px}
+svg.canvas{display:block;width:100%;height:100%;cursor:grab;touch-action:none}
+#tip{position:absolute;display:none;max-width:340px;background:${PAGE_PANEL};border:1px solid ${PAGE_BORDER};border-radius:6px;padding:8px 10px;font-size:12px;color:${PAGE_FG};white-space:pre-line;pointer-events:none;z-index:4}
+#legend{position:fixed;top:56px;right:10px;width:256px;background:${PAGE_PANEL};border:1px solid ${PAGE_BORDER};border-radius:6px;padding:10px 12px;font-size:11px;color:${PAGE_DIM};z-index:2}
+#legend h2{font-size:11px;color:${PAGE_FG};margin:6px 0 4px}
+#legend .row{display:flex;align-items:center;gap:6px;margin:2px 0}
+#legend .caps{margin-top:8px;color:${PAGE_FG}}
+#legend .honesty{margin-top:4px;color:${PAGE_AMBER}}
+.gnode{cursor:pointer}
+.dim .gnode,.dim .gwire{opacity:.15}
+.dim .hi{opacity:1}
+`;
+
+// The page's whole behaviour, ES5-flavoured on purpose (no template strings, so this literal can
+// sit inside one), and with three hard rules the tests pin: no fetching of any kind, no markup
+// assembly on the client (textContent only), and the clock read spelled without the static
+// accessor this module's purity regex bans.
+const PAGE_JS = `
+(function () {
+  "use strict";
+  var svg = document.getElementById("graph");
+  var root = document.getElementById("root");
+  var tip = document.getElementById("tip");
+  var wrap = document.getElementById("wrap");
+  var stamp = document.getElementById("stamp");
+  var auto = document.getElementById("auto");
+  var reloadBtn = document.getElementById("reload");
+  var selected = null;
+  var autoTimer = null;
+  var hashTimer = null;
+
+  function nowClock() { return new Date().getTime(); }
+
+  function fmtAge(ms) {
+    var s = Math.max(0, Math.floor(ms / 1000));
+    if (s < 60) return s + "s";
+    var m = Math.floor(s / 60);
+    if (m < 60) return m + "m";
+    return Math.floor(m / 60) + "h";
+  }
+  function tickStamp() {
+    var age = nowClock() - GENERATED_AT;
+    stamp.textContent = "generated " + fmtAge(age) + " ago";
+    stamp.className = age > 600000 ? "stale" : "";
+  }
+  tickStamp();
+  setInterval(tickStamp, 1000);
+
+  if (reloadBtn) reloadBtn.addEventListener("click", function () { location.reload(); });
+  function applyAuto() {
+    if (autoTimer) { clearInterval(autoTimer); autoTimer = null; }
+    var s = auto ? parseInt(auto.value, 10) : 0;
+    if (s > 0) autoTimer = setInterval(function () { location.reload(); }, s * 1000);
+  }
+  if (auto) auto.addEventListener("change", function () { applyAuto(); writeHash(); });
+
+  if (!svg || !root) return;
+  var vb = svg.viewBox.baseVal;
+  var baseW = vb.width;
+
+  function writeHash() {
+    hashTimer = null;
+    var parts = ["vb=" + [vb.x, vb.y, vb.width, vb.height].map(function (v) { return Math.round(v * 10) / 10; }).join("_")];
+    if (selected) parts.push("sel=" + selected);
+    if (auto && auto.value !== "0") parts.push("ar=" + auto.value);
+    history.replaceState(null, "", "#" + parts.join("&"));
+  }
+  function scheduleHash() {
+    if (hashTimer) return;
+    hashTimer = setTimeout(writeHash, 300);
+  }
+  function readHash() {
+    var h = location.hash.replace(/^#/, "");
+    if (!h) return;
+    var kvs = h.split("&");
+    for (var i = 0; i < kvs.length; i++) {
+      var at = kvs[i].indexOf("=");
+      if (at < 0) continue;
+      var k = kvs[i].slice(0, at);
+      var v = kvs[i].slice(at + 1);
+      if (k === "vb") {
+        var n = v.split("_").map(parseFloat);
+        if (n.length === 4 && n.every(isFinite) && n[2] > 0 && n[3] > 0) {
+          vb.x = n[0]; vb.y = n[1]; vb.width = n[2]; vb.height = n[3];
+        }
+      } else if (k === "sel" && ownNode(v)) {
+        select(v);
+      } else if (k === "ar" && auto) {
+        auto.value = v === "5" || v === "30" ? v : "0";
+        applyAuto();
+      }
+    }
+  }
+
+  // With preserveAspectRatio meet, the browser scales UNIFORMLY (the smaller of the two ratios)
+  // and centres the letterboxed remainder; mapping each axis by its own ratio pans at the wrong
+  // speed and zooms beside the cursor whenever the element and viewBox aspects differ.
+  function view() {
+    var r = svg.getBoundingClientRect();
+    var s = Math.min(r.width / vb.width, r.height / vb.height);
+    return { r: r, s: s, ox: (r.width - vb.width * s) / 2, oy: (r.height - vb.height * s) / 2 };
+  }
+
+  var panning = null;
+  var suppressClick = false;
+  svg.addEventListener("pointerdown", function (e) {
+    if (e.button !== 0) return;
+    panning = { x: e.clientX, y: e.clientY, moved: 0 };
+    svg.setPointerCapture(e.pointerId);
+  });
+  svg.addEventListener("pointermove", function (e) {
+    if (panning) {
+      var v = view();
+      var dx = e.clientX - panning.x;
+      var dy = e.clientY - panning.y;
+      panning.moved += Math.abs(dx) + Math.abs(dy);
+      vb.x -= dx / v.s;
+      vb.y -= dy / v.s;
+      panning.x = e.clientX;
+      panning.y = e.clientY;
+      scheduleHash();
+    }
+    moveTip(e);
+  });
+  svg.addEventListener("pointerup", function (e) {
+    if (panning && svg.hasPointerCapture && svg.hasPointerCapture(e.pointerId)) svg.releasePointerCapture(e.pointerId);
+    // Pointer capture makes the click after a pan land on the svg, which would read as a
+    // background click and wipe the selection; a real drag therefore swallows that click.
+    suppressClick = panning !== null && panning.moved > 3;
+    panning = null;
+  });
+  svg.addEventListener("wheel", function (e) {
+    e.preventDefault();
+    var k = Math.exp(-e.deltaY * 0.0015);
+    var scale = baseW / (vb.width / k);
+    if (scale < 0.15 || scale > 4) return;
+    var v = view();
+    var px = vb.x + (e.clientX - v.r.left - v.ox) / v.s;
+    var py = vb.y + (e.clientY - v.r.top - v.oy) / v.s;
+    vb.x = px - (px - vb.x) / k;
+    vb.y = py - (py - vb.y) / k;
+    vb.width = vb.width / k;
+    vb.height = vb.height / k;
+    scheduleHash();
+  }, { passive: false });
+
+  // The ONLY indexed read of GRAPH.nodes: an id arriving from the hash (or a DOM id) could be a
+  // prototype-chain key like "constructor", which a bare truthy lookup would happily return and a
+  // later .nb dereference would throw on. A test pins this as the single raw read.
+  function ownNode(id) {
+    return Object.prototype.hasOwnProperty.call(GRAPH.nodes, id) ? GRAPH.nodes[id] : null;
+  }
+  function nodeAt(e) {
+    var el = e.target && e.target.closest ? e.target.closest(".gnode") : null;
+    return el && ownNode(el.id) ? el : null;
+  }
+  function moveTip(e) {
+    var el = nodeAt(e);
+    if (!el) { tip.style.display = "none"; return; }
+    tip.textContent = ownNode(el.id).tip;
+    tip.style.display = "block";
+    var wr = wrap.getBoundingClientRect();
+    tip.style.left = e.clientX - wr.left + 14 + "px";
+    tip.style.top = e.clientY - wr.top + 14 + "px";
+  }
+
+  function mark(id) {
+    var el = document.getElementById(id);
+    if (el) el.classList.add("hi");
+  }
+  function clearSel() {
+    selected = null;
+    root.classList.remove("dim");
+    var hi = root.querySelectorAll(".hi");
+    for (var i = 0; i < hi.length; i++) hi[i].classList.remove("hi");
+    scheduleHash();
+  }
+  function select(id) {
+    clearSel();
+    var g = ownNode(id);
+    if (!g) return;
+    selected = id;
+    root.classList.add("dim");
+    mark(id);
+    for (var i = 0; i < g.nb.length; i++) mark(g.nb[i]);
+    for (var j = 0; j < g.w.length; j++) mark(g.w[j]);
+    scheduleHash();
+  }
+  svg.addEventListener("click", function (e) {
+    if (suppressClick) { suppressClick = false; return; }
+    var el = nodeAt(e);
+    if (el) { if (selected === el.id) clearSel(); else select(el.id); }
+    else clearSel();
+  });
+  document.addEventListener("keydown", function (e) { if (e.key === "Escape") clearSel(); });
+
+  readHash();
+})();
+`;
+
+/**
+ * Build the complete page. Total function: no arguments, a malformed model, an empty model -- all
+ * yield a valid page (with an in-page banner saying what is wrong), never a throw, because this
+ * runs at the end of an operator command and a stack trace where a file should be is the worst of
+ * the available outcomes. `now` is the injected generation instant (ms epoch); the module never
+ * reads a clock of its own, so the same model and the same now are byte-identical forever.
+ */
+export function buildGraphHtml(model, { now } = {}) {
+  let norm;
+  try {
+    norm = normalizeModel(model);
+  } catch {
+    norm = normalizeModel(null);
+  }
+  const layout = layoutNormalized(norm);
+  const nowMs = Number.isFinite(now) ? now : (norm.meta.generatedAt ?? 0);
+
+  // Per-node flag lists and adjacency, keyed by ordinal ids only: the originals embed host paths.
+  const flagsByOrig = new Map();
+  for (const f of norm.flags) {
+    if (!flagsByOrig.has(f.nodeId)) flagsByOrig.set(f.nodeId, []);
+    flagsByOrig.get(f.nodeId).push(f);
+  }
+  const groupById = new Map(layout.groups.map((g) => [g.id, g]));
+  const hasIn = new Set();
+  const hasOut = new Set();
+  const adj = new Map(); // placed id -> { nb:Set, w:Set }
+  const touch = (id) => {
+    if (!adj.has(id)) adj.set(id, { nb: new Set(), w: new Set() });
+    return adj.get(id);
+  };
+  for (const w of layout.wires) {
+    hasOut.add(w.from);
+    hasIn.add(w.to);
+    touch(w.from).nb.add(w.to);
+    touch(w.from).w.add(w.id);
+    touch(w.to).nb.add(w.from);
+    touch(w.to).w.add(w.id);
+  }
+
+  const graphData = { nodes: {} };
+  const nodeParts = [];
+  for (const p of layout.nodes) {
+    const n = p.node;
+    const flags = norm.nodes.length > 0 ? findFlags(flagsByOrig, norm.nodes, p) : [];
+    const group = groupById.get(p.groupId);
+    const drawIn = hasIn.has(p.id) || (n.kind !== "trigger" && n.kind !== "injected");
+    const drawOut = hasOut.has(p.id) || n.kind === "trigger";
+    nodeParts.push(nodeSvg(p, flags, drawIn, drawOut));
+    const a = adj.get(p.id);
+    graphData.nodes[p.id] = {
+      tip: buildTip(n, flags, group ? group.label : null, nowMs),
+      nb: a ? [...a.nb].sort() : [],
+      w: a ? [...a.w].sort() : [],
+    };
+  }
+
+  const svgBody = [
+    layout.groups.map(groupSvg).join(""),
+    layout.wires.map(wireSvg).join(""),
+    nodeParts.join(""),
+  ].join("");
+  const vb = layout.viewBox;
+  const svgEl = [
+    `<svg id="graph" class="canvas" viewBox="${fmt(vb.x)} ${fmt(vb.y)} ${fmt(vb.w)} ${fmt(vb.h)}" role="img" aria-label="pi-dispatch trigger and flow graph" preserveAspectRatio="xMidYMid meet">`,
+    `<g id="root">${svgBody}</g>`,
+    `</svg>`,
+  ].join("");
+
+  return [
+    "<!doctype html>",
+    '<meta charset="utf-8">',
+    "<title>pi-dispatch graph</title>",
+    `<style>${PAGE_CSS}</style>`,
+    "<body>",
+    '<div id="hdr">',
+    "<h1>pi-dispatch graph</h1>",
+    '<span id="stamp"></span>',
+    '<button id="reload" type="button">Reload</button>',
+    '<select id="auto" aria-label="auto reload"><option value="0">off</option><option value="5">5s</option><option value="30">30s</option></select>',
+    "</div>",
+    bannersHtml(norm),
+    `<div id="wrap">${svgEl}<div id="tip"></div></div>`,
+    legendHtml(norm),
+    `<script>\n"use strict";\nvar GENERATED_AT = ${fmt(nowMs)};\nvar GRAPH = ${embedJson(graphData)};\n${PAGE_JS}</script>`,
+    "</body>",
+  ].join("\n");
+}
+
+// Flags were recorded against original node ids; the placed node still holds its normalised node,
+// whose id is the original, so the join is direct -- the original id just never reaches the page.
+function findFlags(flagsByOrig, _nodes, placed) {
+  return flagsByOrig.get(placed.node.id) ?? [];
+}

--- a/admin/src/graph-model.mjs
+++ b/admin/src/graph-model.mjs
@@ -67,12 +67,25 @@ export function findSiblingMentions(text, siblingNames) {
   const mentions = [];
   for (const name of siblingNames) {
     if (typeof name !== "string" || name === "") continue;
-    const re = new RegExp(`(?<![a-z0-9_-])${escapeRegExp(name)}(?![a-z0-9_-])`);
-    const at = text.search(re);
-    if (at === -1) continue;
-    const windowStart = Math.max(0, at - CHAIN_VOCAB_RADIUS);
-    const windowEnd = Math.min(text.length, at + name.length + CHAIN_VOCAB_RADIUS);
-    mentions.push({ name, strong: CHAIN_VOCAB_RE.test(text.slice(windowStart, windowEnd)) });
+    // EVERY occurrence is tested, not only the first (review finding): a skill mentioned early in
+    // prose and again beside the outbox vocabulary is a strong mention -- the distance rule is about
+    // any co-location, not the first one. Bounded, because a hostile SKILL.md could repeat a name
+    // thousands of times and this scan already runs once per sibling.
+    const re = new RegExp(`(?<![a-z0-9_-])${escapeRegExp(name)}(?![a-z0-9_-])`, "g");
+    let found = false;
+    let strong = false;
+    let match;
+    let occurrences = 0;
+    while ((match = re.exec(text)) !== null && occurrences++ < 32) {
+      found = true;
+      const windowStart = Math.max(0, match.index - CHAIN_VOCAB_RADIUS);
+      const windowEnd = Math.min(text.length, match.index + name.length + CHAIN_VOCAB_RADIUS);
+      if (CHAIN_VOCAB_RE.test(text.slice(windowStart, windowEnd))) {
+        strong = true;
+        break;
+      }
+    }
+    if (found) mentions.push({ name, strong });
   }
   return mentions;
 }
@@ -115,7 +128,7 @@ export const GRAPH_FLAGS = Object.freeze([
  * Total function: absent or malformed inputs degrade to an empty-but-well-formed model, never a
  * throw (the read-model's viewer doctrine, one layer up).
  */
-export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSkills, cronStats, runJoin, chainEdges, caps, nowMs } = {}) {
+export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSkills, foldersTruncated, cronStats, runJoin, chainEdges, caps, nowMs } = {}) {
   const triggerList = Array.isArray(triggers?.triggers) ? triggers.triggers : [];
   const schedulerList = Array.isArray(schedulers) ? schedulers : [];
   const folders = folderSkills && typeof folderSkills === "object" ? folderSkills : {};
@@ -142,11 +155,19 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
       unattributedRuns: Number.isInteger(runJoin?.unattributed) ? runJoin.unattributed : 0,
       chainRefusals: chainEdges?.refusals && typeof chainEdges.refusals === "object" ? chainEdges.refusals : {},
       truncated: {
-        folders: false,
+        // collectGraphInputs' cap flag rides its spread into this input (review finding: this was
+        // hardcoded false, so the cap-reached banner could never fire on any surface).
+        folders: foldersTruncated === true,
         skills: Object.values(folders).some((f) => f?.truncated === true),
         edges: chainEdges?.truncated === true,
       },
       droppedObservedEdges: 0,
+      // Injected dirs whose readdir failed (review finding): the OQ-022 badge is the one fact the
+      // injected enumeration exists for, and an unreadable dir must not make it silently vanish.
+      injectedUnreachable: Object.entries(injected)
+        .filter(([, r]) => typeof r?.unreachable === "string")
+        .map(([dir]) => dir)
+        .sort(),
     },
   };
 
@@ -181,7 +202,7 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
   };
 
   // ---- skill nodes from the enumerations ----
-  const skillNode = new Map(); // "folderKey name" -> node
+  const skillNode = new Map(); // "folderKey name" -> node
   const addSkill = (group, skill) => {
     const id = `skill:${group.key}:${skill.name}`;
     const node = {
@@ -197,7 +218,7 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
       isFlow: false, // set true when a config edge lands on it
       mentionedBy: 0,
     };
-    skillNode.set(`${group.key} ${skill.name}`, node);
+    skillNode.set(`${group.key} ${skill.name}`, node);
     model.nodes.push(node);
     group.skillIds.push(id);
     if (node.unread) model.flags.push({ nodeId: id, flag: "unread", detail: "SKILL.md unreadable at enumeration; gate read as closed" });
@@ -223,7 +244,7 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
   // A config edge may point at a flow the enumeration did not find; the target then exists as a
   // `skill-missing` node so the edge has a visible end. Created lazily, once per (group, name).
   const missingNode = (group, name) => {
-    const key = `${group.key} ${name}`;
+    const key = `${group.key} ${name}`;
     let node = skillNode.get(key);
     if (node) return node;
     node = { id: `skill:${group.key}:${name}`, kind: "skill-missing", name, folderKey: group.key, isSub: false, group: null, aiTrigger: false, meta: null, unread: false, isFlow: false, mentionedBy: 0 };
@@ -248,6 +269,17 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
           // says why its skills are unknown, rather than silently losing the edge.
           group = { key: `folder:${t.folder}`, path: t.folder, label: basenameOf(t.folder), kind: "local", head: null, unreachable: "not-enumerated", triggerIds: [], skillIds: [] };
           folderByPath.set(t.folder, group);
+          model.folders.push(group);
+        }
+      } else {
+        // A cron entry with no usable folder (only the fail-soft display normalizer can produce one;
+        // the worker refuses it at boot) still draws its trigger and config edge -- "every trigger
+        // naming a flow gets one, ALWAYS" admits no exception for broken entries, which are exactly
+        // the ones an operator needs to see (review finding).
+        group = folderByPath.get("") ?? null;
+        if (!group) {
+          group = { key: "folder:(none)", path: null, label: "(no folder)", kind: "local", head: null, unreachable: "no-folder", triggerIds: [], skillIds: [] };
+          folderByPath.set("", group);
           model.folders.push(group);
         }
       }
@@ -297,7 +329,7 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
         continue;
       }
       if (isCron && group && group.unreachable === null) {
-        const existing = skillNode.get(`${group.key} ${t.flow}`);
+        const existing = skillNode.get(`${group.key} ${t.flow}`);
         if (existing && existing.kind === "skill" && !existing.isSub) {
           existing.isFlow = true;
           model.edges.push({ from: id, to: existing.id, kind: "config" });
@@ -333,6 +365,13 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
       continue;
     }
     const group = matches[0];
+    if (group.unreachable !== null) {
+      // An unreachable folder has no real skill nodes to hang history on: minting them here would
+      // badge phantom "[missing at HEAD]" endpoints off a read that never happened (review finding),
+      // so the edge is dropped INTO THE COUNTER, same as the ambiguous case.
+      model.meta.droppedObservedEdges++;
+      continue;
+    }
     const from = missingNode(group, edge.parentFlow);
     const to = missingNode(group, edge.childFlow);
     model.edges.push({ from: from.id, to: to.id, kind: "observed", count: Number.isInteger(edge.count) ? edge.count : 0, lastEndedAt: edge.lastEndedAt ?? null });
@@ -343,10 +382,10 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
     const group = folderByPath.get(path);
     for (const skill of Array.isArray(result?.skills) ? result.skills : []) {
       if (skill?.isSub === true) continue;
-      const from = skillNode.get(`${group.key} ${skill?.name}`);
+      const from = skillNode.get(`${group.key} ${skill?.name}`);
       if (!from) continue;
       for (const mention of Array.isArray(skill?.mentions) ? skill.mentions : []) {
-        const to = skillNode.get(`${group.key} ${mention?.name}`);
+        const to = skillNode.get(`${group.key} ${mention?.name}`);
         if (!to || to.isSub) continue;
         to.mentionedBy++;
         model.edges.push({

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -53,7 +53,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 // pinned-extension-api.test.mjs and must keep its exact shape. VERSION is the HOST's pi version --
 // build.mjs keeps pi external, so this resolves against whatever pi actually loaded the extension.
 import { VERSION } from "@earendil-works/pi-coding-agent";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { Type } from "typebox";
 import {
   resolvePaths,
@@ -82,6 +82,8 @@ import {
   collectGraphInputs,
 } from "./read-model.mjs";
 import { buildGraphModel } from "./graph-model.mjs";
+import { buildGraphHtml } from "./graph-html.mjs";
+import { openBrowser } from "@edgehero/pi-dispatch/open-browser";
 // The deployment pointer (INT-DEPLOYMENT-POINTER-CONTRACT): the wizard-written file that aims this
 // extension at a deployment built in another directory. Layered into process.env once at factory load
 // (the operator's env always wins), so resolvePaths stays env-only by contract while every one of its
@@ -922,6 +924,17 @@ async function dispatch(pi: ExtensionAPI, args: string, ctx: any): Promise<void>
       return;
     }
     case "graph": {
+      // `graph html` writes the self-contained artifact and best-effort opens the browser
+      // (REQ-GRAPH-HTML-EXPORT); bare `graph` stays the plain-text render. The positional sub-verb is
+      // the `costs whatif` convention, not a flag on the base command.
+      if (tokens[1] === "html") {
+        await graphHtmlCommand(paths, tokens, notify);
+        return;
+      }
+      if (tokens.length > 1) {
+        notify?.(GRAPH_USAGE, "warning");
+        return;
+      }
       // Operator-typed read, ungated (DES-CLI-SURFACE: typing it is the approval); renders the same
       // model the GRAPH view draws, as plain text into the admin channel. Deliberately NOT an
       // LLM-callable tool: the folder enumeration spawns git per folder, and the text is a topology
@@ -1056,11 +1069,74 @@ async function assembleGraph(paths: any): Promise<any> {
     schedulers: Array.isArray(schedulers) ? schedulers : [],
     ...collectGraphInputs({ triggers: triggerList }),
     cronStats: cronRunStats({ records: recs, schedulerIds: triggerList.filter((t) => t.type === "cron" && typeof t.id === "string").map((t) => t.id) }),
-    runJoin: joinRunsToTriggers({ records: recs, triggerCount: triggers?.count }),
+    runJoin: joinRunsToTriggers({ records: recs, triggerCount: triggers?.count, triggerTypes: Object.fromEntries(triggerList.map((t: any) => [t.index, t.type])) }),
     chainEdges: observedChainEdges({ records: recs }),
     caps: { chainDepthMax: paths.chainDepthMax, chainMaxPerJob: paths.chainMaxPerJob, windowDays: GRAPH_LIMITS.windowDays },
     nowMs,
   });
+}
+
+const GRAPH_USAGE = "usage: /dispatch graph [html [--no-open]]";
+
+/** The real side-effect deps for graphHtmlCommand; tests inject fakes for every one of them. */
+function realGraphHtmlDeps(): any {
+  return { fs: nodeFs, openBrowser, env: process.env, now: () => Date.now(), platform: process.platform };
+}
+
+/**
+ * Why the spawn is skipped, or null when opening locally can work. Exported for its tests: the SSH
+ * check is deliberately first (a Mac over SSH has no DISPLAY either, but the reason the operator
+ * should see is the session, not the variable), and only linux gates on DISPLAY/WAYLAND_DISPLAY --
+ * darwin and win32 have openers that need no display variable.
+ */
+export function isHeadlessEnv(env: any, platform: string): string | null {
+  if (env?.SSH_CONNECTION || env?.SSH_TTY) return "SSH session";
+  if (platform === "linux" && !env?.DISPLAY && !env?.WAYLAND_DISPLAY) return "no display";
+  return null;
+}
+
+/**
+ * `/dispatch graph html [--no-open]` (REQ-GRAPH-HTML-EXPORT): assemble the same model as everything
+ * else, render the self-contained artifact, write it ATOMICALLY to the STABLE path
+ * `<graphDir>/graph.html` (tmp+rename, the writeTriggers idiom -- stable so re-running the command
+ * updates an already-open tab through its Reload/auto-reload controls, and atomic so that tab's
+ * reload never reads half a file), then print the file:// URL and best-effort open the browser.
+ *
+ * The print comes FIRST and unconditionally -- the setup-github doctrine: the URL is the contract,
+ * the spawn is a convenience, and over SSH or without a display the spawn is skipped AND SAID, never
+ * silently. A write failure notifies and never opens: opening a stale artifact after a failed write
+ * would show the operator yesterday's topology as today's. Exported for its tests.
+ */
+export async function graphHtmlCommand(paths: any, tokens: string[], notify: Notify, deps: any = realGraphHtmlDeps()): Promise<void> {
+  const rest = tokens.slice(2);
+  const noOpen = rest.includes("--no-open");
+  if (rest.some((t) => t !== "--no-open")) {
+    notify?.(GRAPH_USAGE, "warning");
+    return;
+  }
+  const model = await assembleGraph(paths);
+  const html = buildGraphHtml(model, { now: deps.now() });
+  const file = `${paths.graphDir}/graph.html`;
+  try {
+    deps.fs.mkdirSync(paths.graphDir, { recursive: true });
+    const tmp = `${file}.tmp`;
+    deps.fs.writeFileSync(tmp, html, { mode: 0o644 });
+    deps.fs.renameSync(tmp, file);
+  } catch (err: any) {
+    notify?.(`graph html: could not write ${file} (${err?.message ?? err})`, "error");
+    return;
+  }
+  // pathToFileURL, not concatenation (review finding): an operator-set PI_GRAPH_DIR with a space
+  // would otherwise print a URL that truncates in terminals and breaks the opener spawn.
+  const url = pathToFileURL(file).href;
+  notify?.(`graph written: ${url}`, "info");
+  if (noOpen) return;
+  const headless = isHeadlessEnv(deps.env, deps.platform);
+  if (headless) {
+    notify?.(`not opening a browser (${headless}): open the URL on this machine's desktop, or scp the file there`, "info");
+    return;
+  }
+  deps.openBrowser(url);
 }
 
 /**
@@ -1651,6 +1727,11 @@ function completeArguments(prefix: string) {
     const items = ["7d", "30d", "mtd", "whatif"]
       .filter((w) => w.startsWith(partial))
       .map((w) => ({ value: `costs ${w}`, label: w }));
+    return items.length > 0 ? items : null;
+  }
+  if (parts[0] === "graph" && parts.length === 2) {
+    const partial = parts[1];
+    const items = ["html"].filter((w) => w.startsWith(partial)).map((w) => ({ value: `graph ${w}`, label: w }));
     return items.length > 0 ? items : null;
   }
   if ((parts[0] === "set" || parts[0] === "unset") && parts.length === 2) {

--- a/admin/src/read-model.mjs
+++ b/admin/src/read-model.mjs
@@ -878,22 +878,38 @@ export function cronRunStats({ records, schedulerIds } = {}) {
 }
 
 /**
- * Join forge run records to their triggers.json entry via the persisted `triggerIndex`
- * (INT-RUN-HISTORY-FILE-CONTRACT, issue #54). `triggerCount` is the CURRENT file's length, and the
- * range guard is the honesty rule: the file live-reloads (OQ-008), so a record whose index no longer
- * exists -- or predates the field -- counts under `unattributed` rather than landing on whatever entry
- * now occupies that row. Index 0 attributes; only a forge-kind record can be unattributed, because
- * cron/local/chained runs never carried a matched index and their attribution lives elsewhere.
+ * Join forge run records to their triggers.json entry via the persisted `triggerIndex` AND
+ * `triggerType` (INT-RUN-HISTORY-FILE-CONTRACT, issue #54). `triggerCount` is the CURRENT file's
+ * length and `triggerTypes` maps each raw index to the entry's CURRENT `on.type`; both guards are
+ * the honesty rule, because the file live-reloads (OQ-008). A record whose index no longer exists,
+ * predates the field, points at a row the display dropped, or DISAGREES ON TYPE with the entry now
+ * at that index counts under `unattributed` -- an edit that shifted a different kind of trigger onto
+ * the row is detectable from the persisted pair and refused (found by adversarial review: without
+ * the type check, deleting a cron above a comment trigger moved the comment's run history onto
+ * whatever slid into its slot). The residual the pair cannot see -- a SAME-type reorder within range
+ * -- is beneath these two integers-and-enums' resolution; catching it would need a persisted entry
+ * identity, and the record's PII posture prices strings high, so it is documented in
+ * REQ-TOPOLOGY-GRAPH instead of half-solved here. Index 0 attributes; only a forge-kind record can
+ * be unattributed, because cron/local/chained runs never carried a matched index and their
+ * attribution lives elsewhere.
  */
-export function joinRunsToTriggers({ records, triggerCount } = {}) {
+export function joinRunsToTriggers({ records, triggerCount, triggerTypes } = {}) {
   const byIndex = {};
   let unattributed = 0;
   if (!Array.isArray(records)) return { byIndex, unattributed };
   const count = Number.isInteger(triggerCount) && triggerCount >= 0 ? triggerCount : 0;
+  const types = triggerTypes && typeof triggerTypes === "object" ? triggerTypes : null;
   for (const record of records) {
     if (!isForgeKind(record?.kind)) continue;
     const idx = record?.triggerIndex;
     if (!Number.isInteger(idx) || idx < 0 || idx >= count) {
+      unattributed++;
+      continue;
+    }
+    // Type agreement, when the caller supplied the current types: an undefined slot means the row
+    // exists in the file but not on the display (an unusable entry), so there is no node to carry
+    // the count -- unattributed keeps it visible instead of vanishing it.
+    if (types && (types[idx] === undefined || types[idx] !== record.triggerType)) {
       unattributed++;
       continue;
     }
@@ -934,7 +950,7 @@ export function observedChainEdges({ records } = {}) {
     if (!parent) continue; // parent outside the window/retention: an edge with one visible end is no edge
     if (typeof parent.flow !== "string" || typeof child.flow !== "string") continue;
     if (parent.target !== child.target) continue; // unrepresentable by construction; never drawn
-    const key = `${parent.flow} ${child.flow} ${parent.target ?? ""}`;
+    const key = `${parent.flow} ${child.flow} ${parent.target ?? ""}`;
     let edge = folded.get(key);
     if (!edge) {
       if (folded.size >= GRAPH_LIMITS.maxEdges) {
@@ -950,7 +966,11 @@ export function observedChainEdges({ records } = {}) {
   }
   for (const record of records) {
     if (Number.isInteger(record?.chainRefused) && record.chainRefused > 0 && typeof record?.flow === "string") {
-      refusals[record.flow] = (refusals[record.flow] ?? 0) + record.chainRefused;
+      // Folder-scoped like the edges (adversarial-review finding): chaining is same-folder-only, so
+      // two folders' same-named flows are genuinely different flows, and a flat per-flow counter
+      // would blur their refusals into one number nobody can place.
+      const scope = typeof record.target === "string" && record.target.startsWith("local:") ? `${record.target.slice("local:".length)}/${record.flow}` : record.flow;
+      refusals[scope] = (refusals[scope] ?? 0) + record.chainRefused;
     }
   }
   return { edges: [...folded.values()], refusals, truncated };

--- a/admin/src/render.mjs
+++ b/admin/src/render.mjs
@@ -439,7 +439,8 @@ export function renderGraph(model) {
   if (trunc.folders) out.push("folder scan truncated (cap reached): unlisted folders are not empty, they are unscanned");
   if (trunc.skills) out.push("skill enumeration truncated or partly unread");
   if (trunc.edges) out.push("observed edges truncated (cap reached)");
-  if ((m.meta?.droppedObservedEdges ?? 0) > 0) out.push(`${m.meta.droppedObservedEdges} observed edges dropped (no unique folder to attach them to)`);
+  if ((m.meta?.droppedObservedEdges ?? 0) > 0) out.push(`${m.meta.droppedObservedEdges} observed edges dropped (no unique readable folder to attach them to)`);
+  if ((m.meta?.injectedUnreachable ?? []).length > 0) out.push(`injected skills dir unreadable: ${m.meta.injectedUnreachable.join(", ")}`);
   out.push("edges: -> configured, observed xN (from records), mention (potential; a mention is not a promise)");
   out.push(capsLine(m.caps));
   return out.join("\n");

--- a/admin/test/dashboard.test.mjs
+++ b/admin/test/dashboard.test.mjs
@@ -1968,3 +1968,41 @@ test("GRAPH in ascii mode leaks no box-drawing or graph glyphs", async () => {
   assert.ok(!/[┌┐└┘├┤│─▾▸↻▶]/.test(joined), "the ascii graph is pure ASCII, frame and rows alike");
   assert.match(stripAnsi(joined), /-> build-report/, "the ascii arrow twin renders");
 });
+
+test("Esc from a GRAPH-entered trigger drill returns to GRAPH, not LIST (one layer per Esc)", async () => {
+  const comp = await openGraph(graphDeps());
+  comp.handleInput("\x1b[B"); // down: onto the cron trigger row
+  comp.handleInput("\r");
+  await flush();
+  assert.match(stripAnsi(comp.render(80).join("\n")), /trigger · cron/, "the drill opened");
+  comp.handleInput("\x1b");
+  await flush();
+  const back = stripAnsi(comp.render(80).join("\n"));
+  assert.match(back, /GRAPH · triggers and flows/, "Esc pops back to the graph the drill came from (review finding)");
+  comp.handleInput("\x1b");
+  await flush();
+  const list = stripAnsi(comp.render(80).join("\n"));
+  await comp.dispose();
+  assert.match(list, /RUNS /, "and one more Esc reaches LIST");
+});
+
+test("a LIST trigger row carries the RAW file index, so delete targets the right entry past a dropped row", async () => {
+  // The display drops unusable entries but keeps raw indexes; the row using its display POSITION was
+  // a live-fire wrong-delete: garbage at file row 0, x+y on the visible trigger deleted the garbage
+  // and reported the real trigger gone while it kept firing (review finding).
+  const snap = {
+    ...SNAPSHOT,
+    triggers: { count: 2, triggers: [{ type: "label", index: 1, any: ["ai"], all: [], none: [], flow: "fix", packages: true, image: null, skillsDir: null, instructions: false, resume: false, replicas: null, forge: "github" }] },
+  };
+  let payload = null;
+  const comp = makeDashboard({ paths: {}, done: (p) => (payload = p), tui: fakeTui(), intervalMs: 100000, deps: cannedDeps({ fetchSnapshot: async () => snap }) });
+  await flush();
+  comp.handleInput("\r"); // cursor starts on the one trigger row
+  await flush();
+  comp.handleInput("x");
+  comp.handleInput("y");
+  await flush();
+  await comp.dispose();
+  assert.equal(payload?.action, "deleteTrigger");
+  assert.equal(payload?.index, 1, "the RAW file index, not the display position 0");
+});

--- a/admin/test/graph-command.test.mjs
+++ b/admin/test/graph-command.test.mjs
@@ -1,0 +1,136 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The graph HTML export command (REQ-GRAPH-HTML-EXPORT): write atomically to the STABLE path, print
+ * the file:// URL FIRST, best-effort open, skip-and-say over SSH/headless. Every side effect is
+ * injected (the github-app-setup harness shape), so nothing here touches the real fs, spawns, or the
+ * network -- assembleGraph's reads resolve against a temp triggers file, an empty temp logs dir, and
+ * an unparseable VALKEY_URL that degrades synchronously.
+ */
+process.env.PI_LOGS_DIR = mkdtempSync(join(tmpdir(), "admin-graph-cmd-"));
+process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), "admin-graph-cmd-agent-"));
+
+const piRequire = createRequire(import.meta.resolve("@earendil-works/pi-coding-agent"));
+const { createJiti } = piRequire("jiti");
+const jiti = createJiti(import.meta.url);
+const mod = await jiti.import(fileURLToPath(new URL("../src/index.ts", import.meta.url)));
+
+const fixtureDir = mkdtempSync(join(tmpdir(), "admin-graph-cmd-fixture-"));
+const triggersPath = join(fixtureDir, "triggers.json");
+writeFileSync(
+  triggersPath,
+  JSON.stringify({ triggers: [{ on: { type: "cron", id: "n", pattern: "0 3 * * *" }, run: { kind: "local", folder: join(fixtureDir, "absent"), flow: "tidy", task: "t" } }] }),
+);
+
+function cannedPaths() {
+  return {
+    graphDir: "/gdir",
+    triggersPath,
+    logsDir: process.env.PI_LOGS_DIR,
+    valkeyUrl: "not-a-url", // degrades readSchedulers synchronously; a dead PORT would leak an async error event
+    chainDepthMax: 1,
+    chainMaxPerJob: 2,
+  };
+}
+
+/** One ordered event log shared by every fake, so ordering claims are real assertions. */
+function harness({ writeThrows = false, env = {}, platform = "darwin" } = {}) {
+  const events = [];
+  const deps = {
+    fs: {
+      mkdirSync: (dir, opts) => events.push(["mkdir", dir, opts?.recursive === true]),
+      writeFileSync: (path, data, opts) => {
+        if (writeThrows) throw new Error("ENOSPC");
+        events.push(["write", path, opts?.mode, typeof data === "string" && data.length > 0]);
+      },
+      renameSync: (a, b) => events.push(["rename", a, b]),
+    },
+    openBrowser: (url) => events.push(["open", url]),
+    env,
+    platform,
+    now: () => 1770000000000,
+  };
+  const notify = (msg, level) => events.push(["notify", level, msg]);
+  return { events, deps, notify };
+}
+
+test("graph html writes atomically to the STABLE path and prints the file:// URL before opening", async () => {
+  const { events, deps, notify } = harness();
+  await mod.graphHtmlCommand(cannedPaths(), ["graph", "html"], notify, deps);
+
+  assert.deepEqual(events[0], ["mkdir", "/gdir", true], "the artifact dir is created recursively first");
+  const [, tmpPath, mode, nonEmpty] = events[1];
+  assert.equal(events[1][0], "write");
+  assert.equal(tmpPath, "/gdir/graph.html.tmp", "the write goes to the .tmp sibling");
+  assert.equal(mode, 0o644);
+  assert.ok(nonEmpty, "a real page was rendered");
+  assert.deepEqual(events[2], ["rename", "/gdir/graph.html.tmp", "/gdir/graph.html"], "tmp+rename: a reload never reads half a file");
+
+  const notifyAt = events.findIndex((e) => e[0] === "notify");
+  const openAt = events.findIndex((e) => e[0] === "open");
+  assert.ok(notifyAt >= 0 && openAt > notifyAt, "the URL prints BEFORE the spawn -- the URL is the contract, the spawn a convenience");
+  assert.match(events[notifyAt][2], /^graph written: file:\/\/\/gdir\/graph\.html$/);
+  assert.equal(events[openAt][1], "file:///gdir/graph.html", "the opened URL is the notified one");
+});
+
+test("a second run renames onto the SAME path: stable filename, no timestamped strays", async () => {
+  const { events, deps, notify } = harness();
+  await mod.graphHtmlCommand(cannedPaths(), ["graph", "html"], notify, deps);
+  await mod.graphHtmlCommand(cannedPaths(), ["graph", "html"], notify, deps);
+  const renames = events.filter((e) => e[0] === "rename").map((e) => e[2]);
+  assert.deepEqual(renames, ["/gdir/graph.html", "/gdir/graph.html"], "re-running updates the tab an operator already has open");
+});
+
+test("--no-open writes and prints but never spawns", async () => {
+  const { events, deps, notify } = harness();
+  await mod.graphHtmlCommand(cannedPaths(), ["graph", "html", "--no-open"], notify, deps);
+  assert.ok(events.some((e) => e[0] === "rename"), "the artifact still writes");
+  assert.ok(events.some((e) => e[0] === "notify" && /graph written/.test(e[2])), "the URL still prints");
+  assert.equal(events.filter((e) => e[0] === "open").length, 0);
+});
+
+test("over SSH the spawn is skipped AND SAID; on linux without a display likewise; darwin opens", async () => {
+  for (const [env, platform, reason] of [
+    [{ SSH_CONNECTION: "10.0.0.1 22" }, "darwin", /SSH session/],
+    [{ SSH_TTY: "/dev/pts/1" }, "linux", /SSH session/],
+    [{}, "linux", /no display/],
+  ]) {
+    const { events, deps, notify } = harness({ env, platform });
+    await mod.graphHtmlCommand(cannedPaths(), ["graph", "html"], notify, deps);
+    assert.equal(events.filter((e) => e[0] === "open").length, 0, `no spawn for ${reason}`);
+    assert.ok(events.some((e) => e[0] === "notify" && reason.test(e[2])), `the skip is said, never silent (${reason})`);
+  }
+  const { events, deps, notify } = harness({ env: {}, platform: "darwin" });
+  await mod.graphHtmlCommand(cannedPaths(), ["graph", "html"], notify, deps);
+  assert.equal(events.filter((e) => e[0] === "open").length, 1, "a local darwin session opens");
+});
+
+test("a write failure notifies the path and NEVER opens -- a stale artifact must not pass as fresh", async () => {
+  const { events, deps, notify } = harness({ writeThrows: true });
+  await mod.graphHtmlCommand(cannedPaths(), ["graph", "html"], notify, deps);
+  assert.ok(events.some((e) => e[0] === "notify" && e[1] === "error" && e[2].includes("/gdir/graph.html")), "the error names the path");
+  assert.equal(events.filter((e) => e[0] === "open").length, 0);
+  assert.equal(events.filter((e) => e[0] === "rename").length, 0);
+});
+
+test("an unknown argument is a usage warning, and nothing writes", async () => {
+  const { events, deps, notify } = harness();
+  await mod.graphHtmlCommand(cannedPaths(), ["graph", "html", "--yes"], notify, deps);
+  assert.deepEqual(events.filter((e) => e[0] !== "notify"), [], "no side effect on a usage mistake");
+  assert.ok(events.some((e) => e[0] === "notify" && e[1] === "warning" && e[2].includes("usage")), "the usage line answers");
+});
+
+test("isHeadlessEnv: SSH wins over the display check, and only linux gates on DISPLAY", () => {
+  assert.equal(mod.isHeadlessEnv({ SSH_CONNECTION: "x" }, "darwin"), "SSH session");
+  assert.equal(mod.isHeadlessEnv({}, "linux"), "no display");
+  assert.equal(mod.isHeadlessEnv({ DISPLAY: ":0" }, "linux"), null);
+  assert.equal(mod.isHeadlessEnv({ WAYLAND_DISPLAY: "wayland-0" }, "linux"), null);
+  assert.equal(mod.isHeadlessEnv({}, "darwin"), null, "darwin's opener needs no display variable");
+  assert.equal(mod.isHeadlessEnv({}, "win32"), null);
+});

--- a/admin/test/graph-html.test.mjs
+++ b/admin/test/graph-html.test.mjs
@@ -1,0 +1,329 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { buildGraphHtml, layoutGraph, GRAPH_HTML_KINDS } from "../src/graph-html.mjs";
+import { buildGraphModel, GRAPH_EDGE_KINDS } from "../src/graph-model.mjs";
+
+const NOW = 1770000000000;
+
+// The same canned deployment graph-model.test.mjs uses, built THROUGH buildGraphModel: the HTML
+// generator's contract is the assembler's output shape, so hand-rolled model literals would pin
+// this suite to a shape the assembler might stop producing.
+const CANNED = () => ({
+  triggers: {
+    triggers: [
+      { type: "cron", index: 0, id: "nightly", pattern: "0 3 * * *", folder: "/srv/site", flow: "build-report", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false },
+      { type: "label", index: 1, any: ["ai"], all: [], none: [], flow: "triage", packages: true, image: null, skillsDir: null, instructions: false, resume: false, replicas: null, forge: "github" },
+      { type: "cron", index: 2, id: "gone", pattern: "0 4 * * *", folder: "/srv/site", flow: "deleted-flow", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false },
+    ],
+  },
+  schedulers: [{ key: "nightly", name: "nightly", pattern: "0 3 * * *", every: null, next: "2026-08-12T03:00:00.000Z", overdueMs: null }],
+  folderSkills: {
+    "/srv/site": {
+      head: "abc123",
+      truncated: false,
+      unreachable: null,
+      skills: [
+        { name: "build-report", isSub: false, group: null, aiTrigger: true, meta: { name: "build-report", description: "d" }, mentions: [{ name: "notify", strong: true }], unread: false },
+        { name: "notify", isSub: false, group: null, aiTrigger: true, meta: null, mentions: [], unread: false },
+        { name: "old-import", isSub: false, group: null, aiTrigger: false, meta: null, mentions: [], unread: false },
+        { name: "group/sub", isSub: true, group: "group", aiTrigger: false, meta: null, mentions: [], unread: false },
+        { name: "group", isSub: false, group: null, aiTrigger: false, meta: null, mentions: [], unread: false },
+      ],
+    },
+  },
+  injectedSkills: { "/inj": { skills: [{ name: "tidy", aiTrigger: true }], truncated: false, unreachable: null } },
+  cronStats: { byId: { nightly: { runs: 41, lastOutcome: "completed", lastEndedAt: "2026-08-11T00:00:00.000Z" }, gone: { runs: 0, lastOutcome: null, lastEndedAt: null } } },
+  runJoin: { byIndex: { 1: { runs: 12, lastOutcome: "completed", lastEndedAt: "2026-08-11T01:00:00.000Z" } }, unattributed: 2 },
+  chainEdges: { edges: [{ parentFlow: "build-report", childFlow: "notify", target: "local:site", count: 3, lastEndedAt: "2026-08-10T00:00:00.000Z" }], refusals: { "build-report": 1 }, truncated: false },
+  caps: { chainDepthMax: 1, chainMaxPerJob: 2, windowDays: 30 },
+  nowMs: NOW,
+});
+
+const cannedHtml = () => buildGraphHtml(buildGraphModel(CANNED()), { now: NOW });
+
+// ---- 1. purity ----
+
+test("graph-html.mjs is fully pure: no module loads, no clock, no randomness, no environment", () => {
+  // FIRST, per the render.mjs/costs.mjs/graph-model.mjs doctrine. The bans are substring-level on
+  // purpose: the page script embedded in this module is still module source, so even IT may not
+  // spell the static clock accessor (it reads the clock via new Date().getTime() instead).
+  const src = readFileSync(fileURLToPath(new URL("../src/graph-html.mjs", import.meta.url)), "utf8");
+  assert.ok(!src.includes("import"), "no module loads of any kind, not even node: builtins");
+  assert.ok(!src.includes("require("), "no CJS loads either");
+  assert.ok(!src.includes("Date.now"), "the generation instant is injected as `now`, never read");
+  assert.ok(!src.includes("Math.random"), "determinism is the test one block down");
+  assert.ok(!/process\./.test(src), "no environment access");
+});
+
+// ---- 2. kind parity ----
+
+test("GRAPH_HTML_KINDS is the assembler's GRAPH_EDGE_KINDS, byte for byte, frozen", () => {
+  // The HTML module may not use the `from` clause, so this test IS the anti-drift wire: a kind
+  // minted in graph-model without a drawing arm here must go red, not render as nothing.
+  assert.deepEqual([...GRAPH_HTML_KINDS], [...GRAPH_EDGE_KINDS]);
+  assert.ok(Object.isFrozen(GRAPH_HTML_KINDS));
+});
+
+// ---- 3. escaping / breakout ----
+
+test("hostile trigger and flow strings cannot break out of markup or the embedded json", () => {
+  const inputs = CANNED();
+  // The comment phrase lands verbatim in the trigger's display label; the flow name fails
+  // SKILL_NAME_RE so it travels the charset-invalid path into a node name and a flag detail.
+  inputs.triggers.triggers.push({ type: "comment", index: 3, phrase: '"><script>alert(1)</script>', any: [], all: [], none: [], flow: "x", packages: true, image: null, skillsDir: null, instructions: false, resume: false, replicas: null, forge: "github" });
+  inputs.triggers.triggers.push({ type: "cron", index: 4, id: "evil", pattern: "0 5 * * *", folder: "/srv/site", flow: "</script><script>evil()", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false });
+  const out = buildGraphHtml(buildGraphModel(inputs), { now: NOW });
+
+  assert.equal(out.split("<script").length - 1, 1, "exactly ONE script open tag: the page's own");
+  assert.equal(out.split("</script").length - 1, 1, "and exactly one close: nothing embedded can spell it");
+  assert.ok(!out.includes("<script>alert"), "the attack string never appears unescaped");
+  assert.ok(out.includes("&lt;script&gt;") || out.includes("&lt;/script&gt;"), "it appears as entities instead");
+  assert.ok(out.includes("\\u003c"), "the embedded json carries < as an escape, never a literal");
+});
+
+// ---- 4. determinism ----
+
+test("same model + same now is byte-identical, and input array order is irrelevant", () => {
+  const model = buildGraphModel(CANNED());
+  assert.equal(buildGraphHtml(model, { now: NOW }), buildGraphHtml(model, { now: NOW }));
+
+  const permuted = buildGraphModel(CANNED());
+  permuted.nodes.reverse();
+  permuted.edges.reverse();
+  permuted.flags.reverse();
+  permuted.folders.reverse();
+  assert.equal(buildGraphHtml(permuted, { now: NOW }), buildGraphHtml(model, { now: NOW }), "normalisation sorts everything; a permuted model may not move a byte");
+});
+
+// ---- 5. well-formedness smoke ----
+
+test("the page is balanced, finite, and every path d stays inside the SVG path grammar", () => {
+  const out = cannedHtml();
+  assert.equal(out.split("<svg").length, out.split("</svg>").length, "balanced <svg>");
+  assert.equal((out.match(/<g[ >]/g) ?? []).length, (out.match(/<\/g>/g) ?? []).length, "balanced <g>");
+  for (const word of ["NaN", "undefined", "Infinity"]) {
+    assert.ok(!out.includes(word), `a non-finite value leaked into the page as ${word}`);
+  }
+  const vb = /viewBox="([^"]+)"/.exec(out);
+  assert.ok(vb, "the main svg carries a viewBox");
+  const nums = vb[1].split(" ").map(Number);
+  assert.equal(nums.length, 4);
+  assert.ok(nums.every(Number.isFinite), "viewBox is four finite numbers");
+  const ds = [...out.matchAll(/ d="([^"]*)"/g)];
+  assert.ok(ds.length > 0, "there are wires and dividers to check");
+  for (const [, d] of ds) assert.match(d, /^[MmCcLlHhVvZzAaQq0-9eE .,+-]+$/, `path grammar violated: ${d}`);
+  assert.ok(out.includes('role="img" aria-label="pi-dispatch trigger and flow graph"'));
+});
+
+// ---- 6. layout invariants ----
+
+test("layoutGraph: finite coords, left-to-right wires, group containment, no overlaps", () => {
+  const layout = layoutGraph(buildGraphModel(CANNED()));
+  assert.ok(layout.nodes.length > 0 && layout.wires.length > 0 && layout.groups.length > 0);
+
+  const byId = new Map(layout.nodes.map((n) => [n.id, n]));
+  const groups = new Map(layout.groups.map((g) => [g.id, g]));
+  for (const n of layout.nodes) {
+    for (const v of [n.x, n.y, n.w, n.h]) assert.ok(Number.isFinite(v), `non-finite coord on ${n.id}`);
+    const g = groups.get(n.groupId);
+    assert.ok(g, `node ${n.id} has no group`);
+    assert.ok(n.x >= g.x && n.y >= g.y && n.x + n.w <= g.x + g.w && n.y + n.h <= g.y + g.h, `node ${n.id} escapes its group rect`);
+  }
+  for (const w of layout.wires) {
+    if (!["config", "observed", "potential"].includes(w.kind)) continue;
+    if (w.self) continue; // the explicit self-loop is the one sanctioned non-forward route
+    const f = byId.get(w.from);
+    const t = byId.get(w.to);
+    assert.ok(f && t, `wire ${w.id} references a missing node`);
+    assert.ok(f.x + f.w <= t.x, `wire ${w.id} (${w.kind}) does not travel left to right`);
+  }
+  for (let i = 0; i < layout.nodes.length; i++) {
+    for (let j = i + 1; j < layout.nodes.length; j++) {
+      const a = layout.nodes[i];
+      const b = layout.nodes[j];
+      const apart = a.x + a.w <= b.x || b.x + b.w <= a.x || a.y + a.h <= b.y || b.y + b.h <= a.y;
+      assert.ok(apart, `nodes ${a.id} and ${b.id} overlap`);
+    }
+  }
+  for (const v of [layout.viewBox.x, layout.viewBox.y, layout.viewBox.w, layout.viewBox.h]) assert.ok(Number.isFinite(v));
+  assertUnderRoutesClearChips(layout);
+});
+
+// The regression the first shipped layout had: ROW_GAP alone under a row with a self-loop put the
+// cron-rearm label INSIDE the next row's chip (CANNED's two same-folder cron triggers reproduce it
+// exactly). No wire label point may sit inside any chip, and the horizontal run of an under-row
+// route (self or back; it sits 12px above the label) may not cross any chip either.
+function assertUnderRoutesClearChips(layout) {
+  const byId = new Map(layout.nodes.map((n) => [n.id, n]));
+  const inside = (x, y, n) => x > n.x && x < n.x + n.w && y > n.y && y < n.y + n.h;
+  for (const w of layout.wires) {
+    for (const n of layout.nodes) {
+      assert.ok(!inside(w.labelX, w.labelY, n), `label of wire ${w.id} (${w.kind}) sits inside node ${n.id}`);
+    }
+    if (!w.self && !w.back) continue;
+    const f = byId.get(w.from);
+    const t = byId.get(w.to);
+    const runY = w.labelY - 12;
+    const lo = Math.min(t.x, f.x + f.w);
+    const hi = Math.max(t.x, f.x + f.w);
+    for (const n of layout.nodes) {
+      const crosses = runY > n.y && runY < n.y + n.h && hi > n.x && lo < n.x + n.w;
+      assert.ok(!crosses, `under-row run of wire ${w.id} crosses node ${n.id}`);
+    }
+  }
+}
+
+test("parallel wires between one pair separate their curves and labels, and no label sits on a port", () => {
+  // The regression: an observed edge and a potential mention both join build-report -> notify, and
+  // both labels rendered at the same midpoint -- "(3×)" and "mention" garbled into one smear.
+  const layout = layoutGraph(buildGraphModel(CANNED()));
+  const byPair = new Map();
+  for (const w of layout.wires) {
+    const key = `${w.from} ${w.to}`;
+    if (!byPair.has(key)) byPair.set(key, []);
+    byPair.get(key).push(w);
+  }
+  const multi = [...byPair.values()].filter((list) => list.length > 1);
+  assert.ok(multi.length >= 1, "CANNED must exercise the shared-pair case (observed + potential)");
+  for (const list of multi) {
+    for (let i = 0; i < list.length; i++) {
+      for (let j = i + 1; j < list.length; j++) {
+        const gap = Math.hypot(list[i].labelX - list[j].labelX, list[i].labelY - list[j].labelY);
+        assert.ok(gap >= 10, `label anchors of ${list[i].id} and ${list[j].id} are only ${gap}px apart`);
+        assert.notEqual(list[i].d, list[j].d, `wires ${list[i].id} and ${list[j].id} overlay exactly`);
+      }
+    }
+  }
+  // No label anchor inside any port square -- conservatively both squares of every node, drawn or
+  // not: input at (x-5, y+10), output at (x+w-5, y+10), 10x10 each.
+  for (const w of layout.wires) {
+    for (const n of layout.nodes) {
+      for (const px of [n.x - 5, n.x + n.w - 5]) {
+        const inPort = w.labelX > px && w.labelX < px + 10 && w.labelY > n.y + 10 && w.labelY < n.y + 20;
+        assert.ok(!inPort, `label of wire ${w.id} sits on a port square of node ${n.id}`);
+      }
+    }
+  }
+});
+
+test("a mention cycle marks one back edge and routes it under the rows without crossing chips", () => {
+  const inputs = CANNED();
+  // notify already receives a mention from build-report; mentioning back closes the cycle.
+  inputs.folderSkills["/srv/site"].skills[1].mentions = [{ name: "build-report", strong: false }];
+  const layout = layoutGraph(buildGraphModel(inputs));
+  const byId = new Map(layout.nodes.map((n) => [n.id, n]));
+  const potentials = layout.wires.filter((w) => w.kind === "potential" && !w.self);
+  assert.equal(potentials.length, 2, "both sides of the cycle draw");
+  assert.equal(potentials.filter((w) => w.back).length, 1, "exactly one side is the back edge -- a rank function cannot satisfy both");
+  for (const w of potentials.filter((w) => !w.back)) {
+    const f = byId.get(w.from);
+    const t = byId.get(w.to);
+    assert.ok(f.x + f.w <= t.x, "the forward side still travels left to right");
+  }
+  assertUnderRoutesClearChips(layout);
+});
+
+// ---- 7. content canary ----
+
+test("an unexpected model field and a folder's absolute path never reach the page", () => {
+  const inputs = CANNED();
+  inputs.folderSkills["/Users/someone/private"] = {
+    head: "def456",
+    truncated: false,
+    unreachable: null,
+    skills: [{ name: "solo", isSub: false, group: null, aiTrigger: false, meta: null, mentions: [], unread: false }],
+  };
+  const model = buildGraphModel(inputs);
+  model.nodes[0].secret = "CANARY-9f3"; // a field no allowlist names; a spread would leak it
+  const out = buildGraphHtml(model, { now: NOW });
+  assert.ok(!out.includes("CANARY-9f3"), "unknown fields must be structurally unreachable, not merely unused");
+  assert.ok(!out.includes("/Users/someone/private"), "groups render their label (basename), never group.path");
+  assert.ok(out.includes("private"), "the basename label itself still renders");
+});
+
+// ---- 8. file:// posture ----
+
+test("nothing on the page can reach outside the file", () => {
+  const out = cannedHtml();
+  for (const needle of ["src=", "<link", "url(", "@import", "fetch", "XMLHttpRequest", "innerHTML"]) {
+    assert.ok(!out.includes(needle), `forbidden over file://: ${needle}`);
+  }
+});
+
+// ---- 9. state twins ----
+
+test("orphan dash, potential-vs-observed labels, the caps digits, and honesty counters", () => {
+  const out = cannedHtml();
+  // CANNED holds exactly two orphans (old-import, and group: no trigger, no ai-trigger, no
+  // mention): those two chips plus the one legend swatch carry the disabled treatment, and the
+  // exact count is the negative claim -- no non-orphan chip may wear it.
+  assert.equal((out.match(/stroke-dasharray="8,3"/g) ?? []).length, 3, "two orphan chips and the one legend swatch, nothing else");
+  assert.equal((out.match(/\(\d+×\)/g) ?? []).length, 1, "one observed edge, one count label; a potential wire NEVER carries a count");
+  assert.ok(out.includes(">mention</text>"), "a potential wire is labelled mention instead");
+  assert.ok(out.includes("chains: depth ≤ 1 · ≤ 2 per job · same folder only · window 30d"), "the caps line renders the model's exact digits");
+  assert.ok(out.includes("2 runs unattributed"), "honesty counters render when set");
+
+  const dropped = buildGraphModel(CANNED());
+  dropped.meta.droppedObservedEdges = 4;
+  assert.ok(buildGraphHtml(dropped, { now: NOW }).includes("4 observed edges dropped"), "dropped-edge counter renders when set");
+});
+
+// ---- 10. refresh features ----
+
+test("reload, auto-reload, staleness stamp, and hash view-state are wired without any fetching", () => {
+  const out = cannedHtml();
+  assert.ok(out.includes(">Reload</button>"));
+  for (const opt of [">off<", ">5s<", ">30s<"]) assert.ok(out.includes(opt), `auto-reload option ${opt}`);
+  assert.ok(out.includes("location.reload"));
+  assert.ok(out.includes("location.hash"), "view state survives a reload via the hash");
+  assert.ok(out.includes(`GENERATED_AT = ${NOW}`), "the staleness stamp compares against the baked-in generation instant");
+  assert.ok(out.includes("setInterval"));
+  assert.ok(!out.includes("fetch"), "refresh means reloading regenerated bytes, never fetching");
+});
+
+// ---- 10b. page-script hardening (the page cannot run under node:test, so these are the strongest
+// claims the emitted string supports: the exact guard/mapping expressions, plus a parse check) ----
+
+test("the page script letterbox-maps the cursor, survives a pan without wiping selection, and guards GRAPH.nodes", () => {
+  const out = cannedHtml();
+  const script = /<script>([\s\S]*?)<\/script>/.exec(out)[1];
+
+  // meet letterboxing: a uniform scale (min of the two ratios) plus centring offsets; the
+  // per-axis ratios this replaced panned at the wrong speed whenever the aspects differed.
+  assert.ok(script.includes("Math.min(r.width / vb.width, r.height / vb.height)"), "uniform meet scale");
+  assert.ok(script.includes("(r.width - vb.width * s) / 2"), "letterbox x offset");
+  assert.ok(script.includes("(r.height - vb.height * s) / 2"), "letterbox y offset");
+
+  // pan-then-click: pointer capture retargets the post-pan click at the svg, which reads as a
+  // background click; a drag beyond the threshold must swallow it or every pan clears the selection.
+  assert.ok(script.includes("panning.moved > 3"), "drag threshold present");
+  assert.ok(script.includes("suppressClick"), "the following click is suppressed");
+
+  // prototype-chain ids: #sel=constructor must die at the guard, not at a .nb dereference.
+  assert.ok(script.includes("Object.prototype.hasOwnProperty.call(GRAPH.nodes, id)"), "own-property guard present");
+  assert.equal((script.match(/GRAPH\.nodes\[/g) ?? []).length, 1, "exactly one raw indexed read of GRAPH.nodes: the one inside the guard");
+
+  new Function(script); // parse check: a syntax break in the emitted script goes red here, not in a browser
+});
+
+// ---- 11. degrades ----
+
+test("no arguments and degraded models still produce a valid page that says what is wrong", () => {
+  const bare = buildGraphHtml();
+  assert.ok(bare.startsWith("<!doctype html>"));
+  assert.ok(bare.includes("<title>pi-dispatch graph</title>"));
+  assert.ok(bare.includes("no graph model supplied"));
+
+  const missing = buildGraphHtml(buildGraphModel({ triggers: { missing: true } }), { now: NOW });
+  assert.ok(missing.includes("no triggers file found"));
+
+  const invalid = buildGraphHtml(buildGraphModel({ triggers: { invalid: "bad json" } }), { now: NOW });
+  assert.ok(invalid.includes("triggers file invalid: bad json"));
+
+  for (const junk of [null, 42, "x", { nodes: "no", edges: 7, folders: null, flags: false }]) {
+    const page = buildGraphHtml(junk, { now: NOW });
+    assert.ok(page.includes("<svg"), "malformed input still yields a page, never a throw");
+  }
+});

--- a/admin/test/graph-model.test.mjs
+++ b/admin/test/graph-model.test.mjs
@@ -247,3 +247,45 @@ test("buildGraphModel: meta carries the honesty counters (unattributed, refusals
   assert.deepEqual(m.meta.truncated, { folders: false, skills: false, edges: false });
   assert.equal(m.meta.generatedAt, 1770000000000);
 });
+
+// ---- review-driven honesty hardening (adversarial + code review findings) ----
+
+test("an observed edge into an UNREACHABLE folder is dropped and counted, never phantom-badged", () => {
+  // Without this, the edge minted skill-missing endpoints off a read that never happened -- a red
+  // "[missing at HEAD]" on a folder whose HEAD was never read -- and the renderers then skipped the
+  // edge row anyway, with droppedObservedEdges still claiming zero (review finding).
+  const inputs = CANNED();
+  inputs.folderSkills["/srv/site"] = { head: null, skills: [], truncated: false, unreachable: "not-a-git-repo" };
+  const m = buildGraphModel(inputs);
+  assert.equal(m.edges.filter((e) => e.kind === "observed").length, 0, "no observed edge hangs on an unreadable folder");
+  assert.equal(m.meta.droppedObservedEdges, 1, "and the drop is counted, not silent");
+  assert.equal(m.nodes.filter((n) => n.kind === "skill-missing").length, 0, "no phantom missing-at-HEAD endpoints");
+});
+
+test("a cron entry with no folder still draws its trigger and config edge, on a group that says so", () => {
+  const inputs = CANNED();
+  inputs.triggers.triggers.push({ type: "cron", index: 3, id: "broken", pattern: "0 5 * * *", folder: null, flow: "f", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false });
+  const m = buildGraphModel(inputs);
+  const group = m.folders.find((f) => f.key === "folder:(none)");
+  assert.equal(group.unreachable, "no-folder", "the broken entry is exactly what an operator needs to see");
+  assert.ok(m.edges.some((e) => e.from === "trigger:3" && e.kind === "config"), "every trigger naming a flow gets its edge, ALWAYS");
+});
+
+test("an unreadable injected skills dir surfaces in meta, so the OQ-022 badge cannot silently vanish", () => {
+  const inputs = CANNED();
+  inputs.injectedSkills["/broken"] = { skills: [], truncated: false, unreachable: "unreadable" };
+  const m = buildGraphModel(inputs);
+  assert.deepEqual(m.meta.injectedUnreachable, ["/broken"]);
+  assert.deepEqual(buildGraphModel(CANNED()).meta.injectedUnreachable, [], "readable dirs report nothing");
+});
+
+test("collectGraphInputs' folder cap flag reaches meta.truncated.folders", () => {
+  // It was hardcoded false, so the cap-reached banner could never fire on any surface (review finding).
+  const m = buildGraphModel({ ...CANNED(), foldersTruncated: true });
+  assert.equal(m.meta.truncated.folders, true);
+});
+
+test("findSiblingMentions marks strong on ANY occurrence near the vocabulary, not only the first", () => {
+  const text = `See the notify skill for background.${" filler".repeat(60)} Then write /outbox/request-1.json with {"flow": "notify"}.`;
+  assert.deepEqual(findSiblingMentions(text, ["notify"]), [{ name: "notify", strong: true }], "an early weak mention must not mask a later strong one");
+});

--- a/admin/test/read-model.test.mjs
+++ b/admin/test/read-model.test.mjs
@@ -1313,7 +1313,41 @@ test("observedChainEdges folds child->parent joins per (parentFlow, childFlow, t
   assert.deepEqual(notify, { parentFlow: "build", childFlow: "notify", target: "local:proj", count: 2, lastEndedAt: "2026-08-04T00:00:00.000Z" });
   const self = edges.find((e) => e.childFlow === "build");
   assert.equal(self.parentFlow, "build", "a flow chaining to itself is a real observed self-edge");
-  assert.deepEqual(refusals, { build: 2 }, "chainRefused counts surface per parent flow");
+  assert.deepEqual(refusals, { "proj/build": 2 }, "chainRefused counts are folder-scoped, like the edges");
+});
+
+test("observedChainEdges keeps two folders' same-named flows' refusals apart", () => {
+  // Chaining is same-folder-only, so site/build and other/build are genuinely different flows; a flat
+  // per-flow counter would blur 2+5 into one number nobody can place (adversarial-review finding).
+  const records = [
+    runRec({ jobId: "local-a", kind: "local", target: "local:site", flow: "build", chainRefused: 2 }),
+    runRec({ jobId: "local-b", kind: "local", target: "local:other", flow: "build", chainRefused: 5 }),
+  ];
+  assert.deepEqual(observedChainEdges({ records }).refusals, { "site/build": 2, "other/build": 5 });
+});
+
+test("joinRunsToTriggers refuses a TYPE-changing in-range shift, and pins the same-type residual", () => {
+  // The adversarial review's live-fire lie: delete the cron above a comment trigger and the comment's
+  // run history slid onto whatever now occupies its row. With the current types supplied, the
+  // persisted triggerType catches every cross-type shift. The SAME-type reorder is beneath the two
+  // persisted fields' resolution -- the third assertion pins that residual on purpose, so a future
+  // fix is a deliberate edit here, not an accident.
+  const records = [runRec({ triggerIndex: 1, triggerType: "comment" })];
+  const shifted = joinRunsToTriggers({ records, triggerCount: 2, triggerTypes: { 0: "comment", 1: "label" } });
+  assert.deepEqual(shifted.byIndex, {}, "a label entry now at row 1 must not inherit a comment run's history");
+  assert.equal(shifted.unattributed, 1);
+
+  const matching = joinRunsToTriggers({ records, triggerCount: 2, triggerTypes: { 0: "cron", 1: "comment" } });
+  assert.equal(matching.byIndex[1].runs, 1, "a type-agreeing row attributes");
+
+  const sameTypeReorder = joinRunsToTriggers({ records, triggerCount: 2, triggerTypes: { 0: "comment", 1: "comment" } });
+  assert.equal(sameTypeReorder.byIndex[1].runs, 1, "RESIDUAL, pinned: two same-type rows reordered are indistinguishable to index+type");
+
+  const droppedRow = joinRunsToTriggers({ records, triggerCount: 3, triggerTypes: { 0: "comment" } });
+  assert.equal(droppedRow.unattributed, 1, "an in-file but undisplayable row has no node to carry the count");
+
+  const noTypes = joinRunsToTriggers({ records, triggerCount: 2 });
+  assert.equal(noTypes.byIndex[1].runs, 1, "callers that supply no types keep the range-only join");
 });
 
 test("observedChainEdges drops a cross-target pair and a parent outside the window", () => {

--- a/admin/test/render.test.mjs
+++ b/admin/test/render.test.mjs
@@ -492,5 +492,7 @@ test("renderGraph surfaces truncation and dropped edges rather than pretending c
   const out = renderGraph(model);
   assert.match(out, /folder scan truncated .*unscanned/);
   assert.match(out, /observed edges truncated/);
-  assert.match(out, /2 observed edges dropped \(no unique folder/);
+  assert.match(out, /2 observed edges dropped \(no unique readable folder/);
+  model.meta.injectedUnreachable = ["/inj"];
+  assert.match(renderGraph(model), /injected skills dir unreadable: \/inj/, "an unreadable injected dir says so (OQ-022's badge must not silently vanish)");
 });

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -15,6 +15,22 @@ trigger row opens the same trigger detail the LIST offers. `r` refreshes the mod
 re-read besides entry, because assembling the graph enumerates each folder's committed skills with
 git, and topology changes when you edit things, not per second. `Esc` returns to the LIST.
 
+## `/dispatch graph html`: the browser view
+
+`/dispatch graph html` renders the same model as a Node-RED-style diagram: trigger nodes wired to
+their flows, observed chain edges with their counts, potential (mentioned) edges dashed, folders as
+group boxes, orphans dimmed and dashed, dangling triggers flagged. It writes **one self-contained
+HTML file** (inline SVG/CSS/JS, no network requests of any kind) to a stable temp path
+(`PI_GRAPH_DIR` override) and opens your browser; the `file://` URL is always printed first, so over
+SSH you copy the file instead (`--no-open` skips the browser unconditionally).
+
+The page is a snapshot with its own refresh loop: a Reload button, an auto-reload toggle (off, 5s,
+30s) and a "generated N ago" stamp. Because the command overwrites the **same file atomically**,
+the workflow is: keep the tab open, re-run `/dispatch graph html` after editing triggers or skills,
+and the tab picks up the new topology within the auto-reload interval — pan/zoom and selection
+survive the reload. Pan by dragging, zoom with the wheel, hover a node for its details, click one to
+highlight what it triggers and what reaches it.
+
 ## `/dispatch graph`
 
 ```

--- a/specs/design.md
+++ b/specs/design.md
@@ -125,8 +125,9 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
 - **Why**: BullMQ supplies priorities, a rate limiter, a dedup window, and stalled-job recovery with a
   retry policy — each of which is an independent requirement here, not a bonus. Building four mechanisms
   to avoid one dependency is precisely how a solo-maintainer project drowns in maintenance. Its Bull
-  Board dashboard was a fifth draw; `DES-ADMIN-VIA-PI-EXTENSION` drops the web surface entirely, so the
-  case now stands on the four queue mechanisms alone. Redis persistence (AOF) is what makes
+  Board dashboard was a fifth draw; `DES-ADMIN-VIA-PI-EXTENSION` drops the **served** web surface
+  entirely (the graph HTML artifact is a static file the operator's own browser opens — nothing serves
+  it, nothing listens), so the case now stands on the four queue mechanisms alone. Redis persistence (AOF) is what makes
   `REQ-QUEUE-BURST-NO-DROP` survive a reboot; an in-memory queue would lose the wait-list on the first
   restart.
 - **Evidence (upstream)**: BullMQ is MIT (`taskforcesh/bullmq → LICENSE`, © BullForce Labs AB)
@@ -902,7 +903,18 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   TRIGGER_DETAIL drill by raw file index. The graph data path is the **strictest** of the three view
   policies: fetched on entry and on `r` only, NEVER on the poll tick, because the enumeration spawns
   git per folder — heavier than even the costs scan, and topology changes when the operator edits
-  things, not per second. The unframed degrade reuses `renderGraph` whole. The
+  things, not per second. The unframed degrade reuses `renderGraph` whole. `graph html`
+  (`REQ-GRAPH-HTML-EXPORT`) additionally renders the same model as a **self-contained HTML artifact**
+  (inline SVG/CSS/JS, zero external requests, works over `file://`) written **atomically to the stable
+  path** `<graphDir>/graph.html` (tmp+rename — stable so re-running updates an already-open tab
+  through the page's own Reload/auto-reload controls, atomic so that tab's reload never reads half a
+  file), then prints the `file://` URL **first** and best-effort opens the platform browser through
+  the worker's shared opener — skipped and said over SSH or without a display, `--no-open` always. The
+  extension still **binds no network port at all**: a file with no server is not a surface — nothing
+  listens, nothing off-machine gained reachability — so this stays strictly narrower than the
+  superseded `127.0.0.1` panel. The artifact carries **run-record fields and operator-authored
+  trigger/skill strings only, never `.log` bytes and never a host path beyond the folder's basename**
+  — the same placement boundary as everything else here, applied to a file that outlives the session. The
   LLM-callable tools are reads (`status`/`runs`/`triggers`/`costs` — `dispatch_costs` returns the fold as
   JSON whose every monetary value carries its `class`, so a model consuming it cannot launder an estimate
   into a fact), `pause`/`resume`, the gated `dispatch_run`
@@ -991,6 +1003,14 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
     named: an operator on a divergent pi version gets no admin surface and falls back to direct Valkey and
     file inspection, rather than a silently degraded one.
 - **Rejected**:
+  - *A served graph page (a localhost listener for the HTML view, or live data via a socket)* — the
+    exact surface this entry removed, re-proposed with a prettier face; the socket→file substitution
+    `DES-JOB-OUTBOX-CHAINING` canonised applies symmetrically here, so the browser view is a written
+    artifact and refresh is the page reloading a re-written file, never a connection.
+  - *Raw `.log` bytes in the HTML artifact* — the `.log` is untrusted, PII-bearing text whose boundary
+    is placement (overlay-viewer-only), not filtering; an escaped copy in a durable file outside the
+    overlay would trade that structural defence for an HTML-escaping promise, the one trade this
+    design refuses everywhere else.
   - *The web panel + Bull Board* — an entire localhost web app for a solo, terminal-native operator. The
     superseded `DES-PANEL-SEPARATE-FROM-RECEIVER` holds the full original reasoning; it was correct for a
     networked panel and is removed because the network surface is removed.
@@ -1922,6 +1942,7 @@ a tunnel.
 
 | Date | Change |
 |---|---|
+| 2026-08-11 | Issue #54 (the HTML export — the slice #54's own text ruled out, landed by narrowing what was actually ruled out). **DES-ADMIN-VIA-PI-EXTENSION AMENDED**: `graph html` writes a self-contained HTML artifact (inline SVG/CSS/JS, `file://`, zero external requests) atomically to the stable `<graphDir>/graph.html` and best-effort opens the browser via the worker's shared opener, printed-URL-first, skip-and-say over SSH/headless. The Why this row exists: issue #54 said "no web/HTML surface — the admin binds no port; that property is load-bearing", and the property survives INTACT, because the property was always the **port**. A file with no server is not a surface: nothing listens, nothing off-machine gained reachability, and the socket→file substitution is the same one `DES-JOB-OUTBOX-CHAINING` canonised for the outbox. `DES-QUEUE-BULLMQ-OVER-CUSTOM`'s "drops the web surface entirely" line — the one a reviewer would quote against this — is REWORDED to "drops the SERVED web surface" rather than argued around. Two new Rejected entries record the real lines: a served graph page (the removed surface re-proposed with a prettier face) and raw `.log` bytes in the artifact (the placement boundary does not become an escaping promise in a durable file). Content rule: run-record fields and operator-authored strings only; folder basenames, never host paths. The write is the writeTriggers idiom (atomic, named path, fail-loud); the spawn seam is `index.ts`'s, the dashboard stays I/O-free, USED_API stays four members. New `OQ-024` records the opener-spawn WATCH residual. |
 | 2026-08-11 | Issue #54 (the GRAPH view). **DES-ADMIN-VIA-PI-EXTENSION AMENDED**: the overlay gains its sixth view, **GRAPH** (`g`) — the topology from the same assembled model as `/dispatch graph`, so the two surfaces cannot disagree (`DES-GRAPH-EDGE-DERIVATION` stays the one home of the edge rules). The data path is stricter than COSTS on purpose: fetch on entry and on `r` only, never on the poll tick, because `fetchGraph` spawns git per enumerated folder — pinned by a test that runs a real 10ms poll and counts fetches. The LIST footer absorbed `g graph` by merging the pause/resume pair into one `p/r pause` hint and dropping `↵` from the nav hint — still exactly 76 visible columns at width 80, ellipsis-free, pinned. Two overdue postures landed with the view: `PI_DISPATCH_ASCII=1` now flips the OVERLAY styler too (`makeStyler`'s per-instance `ascii`, threaded from the same resolved paths as the `setGlyphs` funnel — the half-ASCII gap the 2026-08-01 row's "at extension load" phrasing papered over), and the graph rows' glyphs (`arrowRight`/`foldOpen`/`foldClosed`/`rearm`) join the styler twin tables width-identical, so the 80-col invariant holds on ASCII terminals. The unframed degrade reuses `renderGraph` whole (uncollapsed, the everything-else-failed rendering). The fs ban UNCHANGED, checked — `fetchGraph` is a `createDashboardDeps` seam over read-model functions like every other byte the overlay renders. The tool surface UNCHANGED, checked (no `dispatch_graph`; the count pin stands). |
 | 2026-08-11 | Issue #54 (`/dispatch graph`). **DES-ADMIN-VIA-PI-EXTENSION AMENDED**: `graph` joins the slash-command list — an operator-typed, ungated read on the `runs`/`costs` tier, rendering `renderGraph(assembleGraph(...))` into the admin channel with `triggerTurn` never set. The subcommand is deliberately NOT an LLM-callable tool (the enumeration spawns git per folder; the tool-count pin stands). The USAGE string and KNOWN_SUBCOMMANDS array are now pinned to agree member-for-member by a wiring test, closing a drift class this amendment would otherwise have widened. The dashboard's source-regex fs ban UNCHANGED, checked; the five-views count UNCHANGED for now (the GRAPH view is the next slice and will amend the Decision when it lands). |
 | 2026-08-11 | Issue #54 (the model assembler). **NEW `DES-GRAPH-EDGE-DERIVATION`**: the graph's edge honesty rules, in one pure fold (`buildGraphModel`). Four evidence classes (`config`/`observed`/`potential`/`cron-rearm`, a closed test-pinned vocabulary), the two OQ-009 structural prohibitions (no forge-parent chain edges, no cross-folder chain edges — the harness makes both unrepresentable, so drawing either would draw a lie), precise dangling (`no-skill` only where enumeration succeeded; unverified is not dangling; `charset-invalid` is its own flag because the gate's `deny` proves nothing about existence), three-way orphanhood, caps and honesty counters on every model. The interesting rejections are recorded: an all-pairs gate-eligibility fabric (eligibility is a node badge, a mention is the edge, or the graph is noise) and first-match resolution of ambiguous observed-edge targets (dropped-and-counted beats pinning real history onto the wrong folder). **DES-JOB-OUTBOX-CHAINING UNCHANGED, checked** (the graph consumes its record fields and caps; nothing about collection moves). **DES-COST-FOLD-BY-SCAN UNCHANGED, checked** (same scan, second consumer, still fold-time-derived and never stored). |

--- a/specs/open-questions.md
+++ b/specs/open-questions.md
@@ -760,10 +760,31 @@ adversarial passes did.
 
 ---
 
+## OQ-024 — the graph export's browser spawn is verified by reading, not by running everywhere
+
+- **Question**: `graph html` best-effort spawns the platform opener (`open`/`xdg-open`/`cmd start`)
+  through the worker's shared `open-browser` module. The argv table is pinned per platform by unit
+  test and the module is the same one `setup github` has shipped since issue #81 — but no CI runs a
+  desktop session on all three platforms, so "the browser actually appears" is verified by reading
+  and by field use, not by an automated end-to-end.
+- **Status**: WATCH, on the `OQ-016` precedent (the sandbox `docker run -it` spawn carries the same
+  shape of residual): the failure mode is cosmetic and self-announcing — the printed `file://` URL is
+  the contract, the spawn a convenience, and a missing opener is swallowed by design with the URL
+  already on screen.
+- **What bounds it**: the spawn is skipped entirely (and said) over SSH and on display-less linux;
+  `--no-open` removes it; a swallowed spawn failure costs the operator one manual click on a URL they
+  already have.
+- **What would close it**: a per-platform desktop CI job, which this project will not buy for a
+  convenience spawn.
+- **Raised by**: issue #54, while landing `REQ-GRAPH-HTML-EXPORT`.
+
+---
+
 ## Revision History
 
 | Date | Change |
 |---|---|
+| 2026-08-11 | Issue #54 (`REQ-GRAPH-HTML-EXPORT`). Added **OQ-024** (`WATCH`, the `OQ-016` shape): the graph export's browser spawn is verified by reading and by the pinned per-platform argv table, not by a desktop CI on three platforms this project will not buy for a convenience spawn; the printed `file://` URL is the contract and the failure mode is one manual click. **OQ-008 and OQ-009 pointers already in place from the earlier #54 slices, UNCHANGED, checked**: the export re-reads the triggers file per run like every other graph consumer, and draws no forge-parent or cross-folder chain edge because the model it renders cannot contain one. |
 | 2026-08-09 | Follow-up audit after issue #60. Added **`OQ-023`**: a prepare-stage refusal posts no comment on the issue, so a requester sees a label applied and then nothing. True of `sha-gone` since it shipped and now true of six reasons, because #60 added five. Recorded rather than fixed, and recorded as NOTICED rather than designed: the ordering that makes these refusals free is what puts them past the point the processor's `comment` seam is wired for, so the silence is a consequence of `CONST-BUDGET-BEFORE-TOKENS` rather than a judgement about what is worth saying. What bounds it is that every one is in the run record with its own reason token and that `doctor` reports the `skills-dir-*` causes before anything fires. What would close it is threading the `comment` seam into the policy branch, which carries one real question: a repo over a cap would then comment on every delivery, so it wants the dedup the spend refusals already have. This entry exists because the #60 plan said it was worth an OQ and then did not write one. |
 | 2026-08-09 | Issue #60 (Gap 2). Added **`OQ-022`**: injected skills are deliberately not AI-reachable, because `DES-AI-TRIGGER-FLOW-GATE` reads the target repo's committed `.pi/skills` at a pinned sha and an injected skill is not there. Recorded as ACCEPTED rather than as a risk row, because it is the fail-CLOSED direction and the residual is an operator SURPRISE rather than a hole: an injected `SKILL.md` carrying `ai-trigger: allow` is never read, so the opt-in is written and nothing honours it, which is why `doctor` now warns. Records what would NOT be an acceptable close -- reading the frontmatter out of the injected tree, since that opt-in is meaningful in a repo only because a merge gated it, and in a runtime-editable directory it would put the authorization inside the content being authorized. `OQ-012` **UNCHANGED, checked**: an operator-built image is unaffected, since the injected root is a worker-side copy into `/job` and needs nothing of the image. `OQ-004` **UNCHANGED in kind**: the injected tier adds instructions, not egress. |
 | 2026-08-08 | Issue #66 (ingest `pull_request_review`). Added **`OQ-020`** (`ACCEPTED RISK`): a review trigger is the first GitHub trigger with no second gate — a comment needs its phrase and a label needs its label, both typed on purpose, while a review needs only that the reviewer clears `author_association` — and the sharper half is that the bot-loop guard compares `sender.id` against **our own** identity alone, so a third-party review bot holding `MEMBER` sits outside it and, if it reviews every push while the armed flow pushes, forms a recursion neither party's guard can see. Accepted rather than closed because the obvious fix (refuse any `sender.type: "Bot"`) needs a new subset field and a new constitutional clause, would refuse an operator whose own review bot is *meant* to start jobs, and is one narrow instrument for the general problem of a spend loop between two automated actors; what bounds it meanwhile is the spend caps, dedup, and the fact that the trigger is opt-in. Added **`OQ-021`** (`ACCEPTED RISK`): a Comment-type review of inline comments only arrives with an empty body and is refused as `no-review-body`, indistinguishable inside a pure filter from a genuinely empty review, because the line comments ride `pull_request_review_comment` (not ingested) and the payload carries no count of them — the narrower fix would need an API call from inside the gate and cost the purity that makes the security decision testable offline. Both rows are named in `SECURITY.md` so an operator meets them before arming rather than on the bill. **`OQ-017` UNCHANGED, checked** — a review-triggered replica set shares the PR head branch exactly as any other pull_request-typed target does, so the row's scope is unchanged by a new way of reaching it. **`OQ-013` UNCHANGED, checked** — GitLab's approval gate is an API lookup and is untouched by GitHub gaining a review action. |

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -688,9 +688,14 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   (a) every trigger naming a `run.flow` renders its config edge — dangling, unverifiable and
   charset-invalid included;
   (b) a cron trigger's run count and last outcome are **exact** over the stated window (the jobId
-  join), and a forge trigger's come **only** from the persisted `triggerIndex` — a record the
-  current file cannot claim renders under an explicit `unattributed` count, never on whatever entry
-  now occupies its row;
+  join), and a forge trigger's come **only** from the persisted `triggerIndex` **and**
+  `triggerType`, both of which must agree with the entry now at that index — a record whose index is
+  out of range, whose row the display dropped, or whose type disagrees renders under an explicit
+  `unattributed` count, never attributed across a type change. The one shift the persisted pair
+  cannot see — two SAME-type entries reordered within range — is beneath an integer-and-enum's
+  resolution, is pinned as a residual by test, and is why every attribution renders under the
+  standing "as of the current triggers file" caveat; closing it would need a persisted entry
+  identity string, which the record's no-attacker-chosen-string posture prices deliberately high;
   (c) an **observed** edge is always labelled with its count and source (records over the window);
   a **potential** edge is always labelled as a mention, with whether it could ever fire (the
   target's `ai-trigger`), and the two vocabularies never mix in one line;
@@ -720,6 +725,37 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   then it renders unverified with no dangling flag; given any output, then the caps line
   (`chain depth`, `per job`, `same folder only`, window) is present; given an observed chain edge,
   then its line carries `observed x<count>`, and no potential line carries a count.
+
+## REQ-GRAPH-HTML-EXPORT
+
+- **Statement**: The harness shall render the assembled topology (`REQ-TOPOLOGY-GRAPH`) as a
+  **self-contained HTML artifact** on operator command: `/dispatch graph html [--no-open]` writes one
+  file — inline SVG/CSS/JS, working over `file://` with **zero external requests** — atomically
+  (tmp+rename) to the **stable path** `<graphDir>/graph.html`, prints its `file://` URL **before any
+  spawn**, and best-effort opens the platform browser. The page carries its own refresh: a Reload
+  control, an off/5s/30s auto-reload, a live staleness stamp, and view state (pan/zoom, selection,
+  the auto-reload setting) that survives its own reloads via the URL hash — so a re-run of the
+  command updates an already-open tab. **No port is ever bound; nothing serves the file.**
+- **Scope**: Display only. The artifact carries run-record fields and operator-authored
+  trigger/skill strings only — **never `.log` bytes, never a host path beyond a folder's basename**.
+  Over SSH or without a display the spawn is skipped and the skip is stated; `--no-open` skips it
+  unconditionally; a write failure notifies the path and never opens. Zero new dependencies.
+- **Why**: The interactivity a topology needs (pan/zoom, hover detail, click-to-trace) needs a
+  browser; it does not need a server. A static file keeps `DES-ADMIN-VIA-PI-EXTENSION`'s load-bearing
+  no-port property intact — the socket→file substitution `DES-JOB-OUTBOX-CHAINING` canonised — and
+  the stable-path atomic overwrite is what turns "a snapshot file" into "a tab that stays current":
+  the page reloads bytes on disk, and tmp+rename means it never reads half of them.
+- **Traces to**: `REQ-TOPOLOGY-GRAPH`, `DES-GRAPH-EDGE-DERIVATION`, `DES-ADMIN-VIA-PI-EXTENSION`,
+  `INT-RUN-HISTORY-FILE-CONTRACT`, `OQ-024`
+- **Acceptance**: Given `/dispatch graph html`, then exactly one artifact lands at
+  `<graphDir>/graph.html` via a `.tmp` rename with mode 0644, the `file://` URL is notified before
+  any opener spawn, and the rendered bytes contain no external `src`/`href`/`url()`/`@import`, no
+  `fetch`/`XMLHttpRequest`, no `innerHTML`, no `.log` content, and no absolute host path; given a
+  second run, the artifact lands at the **same** path; given `SSH_CONNECTION`/`SSH_TTY` (any
+  platform) or linux without `DISPLAY`/`WAYLAND_DISPLAY`, the spawn is skipped and the reason
+  notified; given `--no-open`, no spawn ever; given a write failure, an error names the path and no
+  browser opens; given the page open in a browser, its auto-reload reflects a re-run's changes
+  without resetting the view.
 
 ## REQ-SCOPED-PAUSE-WINDOWS
 
@@ -1191,6 +1227,8 @@ wait-list working as designed, not a failure — see `README.md`.
 
 | Date | Change |
 |---|---|
+| 2026-08-11 | Issue #54 (adversarial-review hardening). **REQ-TOPOLOGY-GRAPH (b) AMENDED to a promise the persisted fields can actually keep** — the review CONFIRMED the old sentence over-promised: `joinRunsToTriggers` guarded only the index RANGE, so deleting a cron above a comment trigger slid the comment's run history onto whatever entry occupied its row, exactly the lie the sentence forbade. The join now also requires TYPE agreement with the entry currently at that index (the persisted `triggerType` was sitting unused), which catches every cross-type shift; the same-type-reorder residual is named in the requirement, pinned by a test, and priced honestly (closing it needs a persisted identity string, against the record's posture). Also folder-scoped the `chainRefused` counters (same-folder-only chaining makes two folders' same-named flows different flows; a flat counter blurred 2+5 into one number nobody could place), dropped-and-counted observed edges whose folder is unreachable (they minted phantom "[missing at HEAD]" endpoints off a read that never happened), gave a folderless cron entry its config edge on a "(no folder)" group ("every trigger gets its edge, ALWAYS" admits no exception for the broken entries an operator most needs to see), surfaced unreadable injected dirs in meta (the OQ-022 badge must not silently vanish), wired `collectGraphInputs`' folder-cap flag into `meta.truncated.folders` (hardcoded false meant the cap banner could never fire), and made the mention heuristic test EVERY occurrence for vocabulary distance. |
+| 2026-08-11 | Issue #54 (the HTML export). **NEW `REQ-GRAPH-HTML-EXPORT`**: the topology as a self-contained `file://` artifact with its own refresh loop (Reload, off/5s/30s auto-reload, hash-persisted view state), atomically overwritten at one stable path so an open tab stays current across re-runs. The acceptance pins the postures that make this spec-clean rather than spec-adjacent: no port, no server, no external requests, no `.log` bytes, no host paths, printed-URL-before-spawn, skip-and-say when headless. **REQ-TOPOLOGY-GRAPH AMENDED implicitly completed**: its "the HTML export remains a later slice" note is discharged by this row. **REQ-ADMIN-VIA-PI-EXTENSION UNCHANGED, checked** (`graph` was already in the command list; `html` is its sub-verb, the `costs whatif` shape). |
 | 2026-08-11 | Issue #54 (the GRAPH view). **REQ-TOPOLOGY-GRAPH AMENDED** as its own prior row promised: the GRAPH dashboard view (sixth view, `g`) joins the Statement beside the command; the honesty rules bind both surfaces because both render the one assembled model. The refresh posture is part of the requirement's spirit made concrete: entry and `r` only, never the poll tick (the enumeration spawns git per folder). **REQ-ADMIN-VIA-PI-EXTENSION UNCHANGED, checked** (the command list already named `graph`; the view is the same surface's overlay half). The HTML export remains a later slice. |
 | 2026-08-11 | Issue #54 (`/dispatch graph`). **NEW `REQ-TOPOLOGY-GRAPH`**: the trigger/flow topology as one assembled model with the honesty rules written as requirements, on the `REQ-COST-ANALYTICS` precedent — the estimate-never-mislabeled-as-truth discipline applied to topology (a mention must never read like history, a stale index must never land on today's row, a capped scan must never read as complete coverage, the chain caps render on every output). Display-only and deliberately NOT a model-callable tool: the enumeration spawns git per folder, and the topology is for the operator's eyes (`DES-CLI-SURFACE`'s operator-typed ungated tier; the registered-tool count is untouched, pinned by test). **REQ-ADMIN-VIA-PI-EXTENSION AMENDED**: `graph` joins the observability command list. **REQ-COST-ANALYTICS UNCHANGED, checked** (same scan, sibling consumer). The GRAPH dashboard view and the HTML export are later slices and will amend this entry when they land. |
 | 2026-08-09 | Issue #60 (Gap 3). **NEW `REQ-PER-TRIGGER-INSTRUCTION`**: the three webhook types may carry one line of operator standing text, rendered into the user prompt's envelope above the fenced data region. Refused on cron, and that is a decision rather than a gap: a local job's prompt IS `run.task`, with no envelope and no fence, so there is no standing region distinct from the task for a second field to occupy, and two fields writing one region with an undefined order would both appear to work. Capped at 2000 characters and refused rather than truncated, with the reasoning recorded because the obvious one does not hold -- the cap is not about caching, it bounds a context overflow inside a PAID container that has no pre-spend signal, and keeps the field in its lane. **REQ-PER-TRIGGER-SKILLS UNCHANGED, checked**: the two fields are independent and a trigger may set either, neither or both. |


### PR DESCRIPTION
Final slice of issue #54, plus the fixes from a three-agent adversarial/code review of the whole delivery.

## The export

`/dispatch graph html [--no-open]` renders the same assembled model as every other graph surface into **one self-contained HTML file**: inline SVG/CSS/JS, zero external requests, works over `file://`, nothing listens anywhere. Node-RED shape language (pale category chips on the 20px grid, ports, status dots, folder group rects) on the repo's dark chrome; hand-rolled Sugiyama-lite layout; evidence-labelled wires with a legend, the caps line, and the honesty counters; pan/zoom, hover tooltips (textContent-only), click-to-highlight.

**The refresh loop**: a Reload button, off/5s/30s auto-reload, a live staleness stamp, and hash-persisted view state — made useful by the **stable artifact path**: the command overwrites `<graphDir>/graph.html` atomically (tmp+rename), so an open tab picks up a re-run without losing its pan/zoom. URL printed before the spawn; skip-and-say over SSH/headless; a write failure names the path and never opens.

## The review hardening (all CONFIRMED by executing reviewers, all regression-pinned)

- `joinRunsToTriggers` guarded only the index **range**, so an in-range `triggers.json` edit slid one trigger's run history onto whatever entry took its row — the exact lie `REQ-TOPOLOGY-GRAPH` forbade. The persisted `triggerType` (sitting unused) now must agree; the same-type-reorder residual is named in the requirement and pinned by test.
- `chainRefused` counters folder-scoped; observed edges into unreachable folders dropped-and-counted instead of minting phantom "[missing at HEAD]" endpoints; folderless cron entries keep their config edge; unreadable injected dirs surface in the counters; the folder-cap flag actually reaches `meta.truncated.folders`; the mention heuristic tests every occurrence.
- LIST trigger rows now carry the **raw file index** (the display position was a live-fire wrong-delete past a dropped row); Esc from a GRAPH-entered drill returns to GRAPH.
- In the page: under-row routes no longer collide with the next row of chips; the pan/zoom mapping respects `preserveAspectRatio` letterboxing; a background pan no longer wipes the selection; `#sel=constructor` no longer throws; parallel wires bow apart and their labels never stack. All mutation-verified.
- Eight literal NUL bytes (the recurring trap) found by the pre-push scan and repaired; the whole tree scans clean.

## Specs (same PR)

`DES-ADMIN-VIA-PI-EXTENSION` AMENDED (a file with no server is not a surface; the socket→file substitution is `DES-JOB-OUTBOX-CHAINING`'s own; two new Rejected entries: a served graph page, and `.log` bytes in the artifact). `DES-QUEUE-BULLMQ-OVER-CUSTOM`'s "drops the web surface entirely" **reworded** to "the served web surface" rather than argued around. NEW `REQ-GRAPH-HTML-EXPORT`; `REQ-TOPOLOGY-GRAPH` (b) amended to a promise the persisted fields can keep; NEW `OQ-024` (opener-spawn WATCH); SECURITY.md export paragraph; docs + READMEs.

## Verification

Suite in the CI posture: **2166 pass, 0 skipped**; `node admin/build.mjs` builds. End-to-end: the artifact generated from a real fixture deployment (git repo with three skills, three triggers, chain + forge records) renders in headless Chrome with all controls working and no console errors — screenshots taken before and after each fix round.