### PR TITLE
release: v0.10.0 (worker 0.3.0, receiver 0.2.1, admin 0.7.0)

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -52,7 +52,7 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
  * follows in the same change.
  */
-export const RUNTIME_VERSION = "0.2.0";
+export const RUNTIME_VERSION = "0.3.0";
 
 /**
  * The `@edgehero/pi-dispatch-receiver` version the trigger-edge step installs -- pinned for exactly the
@@ -62,7 +62,7 @@ export const RUNTIME_VERSION = "0.2.0";
  * independently (the receiver's dependency range on the runtime is `^`), and pretending otherwise would
  * install a version that does not exist the first time they diverge.
  */
-export const RECEIVER_VERSION = "0.2.0";
+export const RECEIVER_VERSION = "0.2.1";
 
 /** The two npm package names, spelled once. Literals of this module -- see npmInstallArgsFor's argument. */
 const RUNTIME_PKG = "@edgehero/pi-dispatch";

--- a/admin/test/setup-wizard.test.mjs
+++ b/admin/test/setup-wizard.test.mjs
@@ -803,7 +803,7 @@ test("wizard: the edge's service answer installs the PINNED receiver, then the -
   assert.equal(attached.length, 2, "the npm install and the unit install — nothing else");
   assert.equal(attached[0].argv0, "npm", "posix npm, per npmSpawnOptions");
   assert.deepEqual(attached[0].args, mod.npmInstallArgsFor(RECEIVER_PKG, mod.RECEIVER_VERSION));
-  assert.ok(attached[0].args.includes(`${RECEIVER_PKG}@0.2.0`), "the pinned name@version token, spelled out");
+  assert.ok(attached[0].args.includes(`${RECEIVER_PKG}@0.2.1`), "the pinned name@version token, spelled out");
   assert.equal(attached[0].cwd, dir, "installed into the deployment dir, by cwd");
   assert.deepEqual(
     JSON.parse(readFileSync(join(dir, "package.json"), "utf8")),
@@ -817,7 +817,7 @@ test("wizard: the edge's service answer installs the PINNED receiver, then the -
   assert.equal(attached[1].cwd, dir);
 
   const c = seen.confirm.find((x) => /receiver/i.test(x.title));
-  assert.match(c.message, new RegExp(`${RECEIVER_PKG.replace("/", "\\/")}@0\\.2\\.0`), "the confirm shows the exact pin");
+  assert.match(c.message, new RegExp(`${RECEIVER_PKG.replace("/", "\\/")}@0\\.2\\.1`), "the confirm shows the exact pin");
   assert.match(c.message, /service install --receiver/, "and the unit command it will run after");
   assert.ok(c.message.includes(dir), "and names the cwd");
   assert.ok(reachedFirstTrigger(seen), "the wizard continued to step 11");

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",
@@ -4236,10 +4236,10 @@
     },
     "receiver": {
       "name": "@edgehero/pi-dispatch-receiver",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@edgehero/pi-dispatch": "^0.2.0",
+        "@edgehero/pi-dispatch": "^0.3.0",
         "@octokit/webhooks": "14.2.0",
         "bullmq": "5.80.4",
         "ioredis": "5.11.1"
@@ -4253,7 +4253,7 @@
     },
     "worker": {
       "name": "@edgehero/pi-dispatch",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",

--- a/receiver/package.json
+++ b/receiver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-receiver",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Webhook receiver for pi-dispatch: the always-on edge that verifies GitHub, GitLab, Forgejo and Azure DevOps deliveries and enqueues (at most) one job per event for the worker.",
   "keywords": [
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@octokit/webhooks": "14.2.0",
-    "@edgehero/pi-dispatch": "^0.2.0",
+    "@edgehero/pi-dispatch": "^0.3.0",
     "bullmq": "5.80.4",
     "ioredis": "5.11.1"
   }

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Self-hosted job harness for the pi coding agent: a BullMQ worker that drains the queue, mints scoped forge tokens, and runs one container per job — plus the pi-dispatch CLI (init, up, doctor, service).",
   "keywords": [


### PR DESCRIPTION
Ships the issue #54 trigger/flow graph across all three packages. Merging this fires the npm publishes (release.yml is version-gated per package) and the ghcr image retags off the root version.

- **worker 0.3.0**: run records persist `triggerIndex`/`triggerType` (forge run attribution, `INT-RUN-HISTORY-FILE-CONTRACT`); new export subpaths `./open-browser` and `./materialize`; `aiTriggerAllows` exported from `./flow-gate`; chain-cap defaults exported from `./config`; `defaultGraphDir`.
- **receiver 0.2.1**: no source change; republished so its `@edgehero/pi-dispatch` range (`^0.3.0`) matches the worker on the registry, per the publish sync tests.
- **admin 0.7.0**: the GRAPH dashboard view (`g`), `/dispatch graph`, and `/dispatch graph html` with `--no-open`/`--full-paths`; the graph read-model and edge-honesty fold; loops grouped inside their skill; record-derived forge scope labels; the ASCII overlay gap closed; the review-hardening fixes.

`RUNTIME_VERSION`/`RECEIVER_VERSION` and the wizard tests' two spelled-out pin literals move with the versions per the anti-drift discipline. The lock is hand-patched for versions only (the npm-minor normalization noise filtered per the recorded gotcha).

Upgrade actions for existing deployments: update the console with `pi install npm:@edgehero/pi-dispatch-admin` and let bare `/dispatch`'s skew notice walk the runtime through `/dispatch setup`. No service unit or env changes; the new record fields are additive and old records read fine.

Suite in the CI posture: 2175 pass, 0 skipped; admin bundle builds.