### PR TITLE
release: v0.11.0 (admin 0.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ did and what it spent, and shuts the container down. A durable queue absorbs bur
 checked before a single token is spent, and a live admin panel shows everything and can turn the whole
 thing off.
 
-![The /dispatch dashboard overlay, theme-colored: live queue state, day/week/month spend meters plus a daily token counter, the unified triggers pane (cron, label, comment, pull_request; selectable and editable), scheduled pause windows, and the interactive runs list, in one framed TUI](docs/images/dispatch-dashboard.svg?v=0.12.0)
+![The /dispatch dashboard overlay, theme-colored: live queue state, day/week/month spend meters plus a daily token counter, the unified triggers pane (cron, label, comment, pull_request; selectable and editable), scheduled pause windows, and the interactive runs list, in one framed TUI](docs/images/dispatch-dashboard.svg?v=0.11.0)
 
 ![Transcript of /dispatch status, runs, and triggers: queue counts, the run-history table with per-job token and cost accounting, and the unified {on,run} triggers list](docs/images/dispatch-commands.svg?v=0.5.0)
 
@@ -57,7 +57,7 @@ trigger and flow costs, whether a subscription pays off, drawn as charts beside 
 single file your browser opens from disk, budget dials included, because the caps are the one lever
 that actually changes what all of this costs:
 
-![The insights page: KPI tiles, the budget dials, a plan verdict card, the daily and cumulative spend charts, per-flow trend panels, the four breakdowns with plan-covered buckets drawn as chips instead of dollar bars, and the trigger/flow topology with spend badged onto the triggers that earned it](docs/images/insights-view.png?v=0.12.0)
+![The insights page: KPI tiles, the budget dials, a plan verdict card, the daily and cumulative spend charts, per-flow trend panels, the four breakdowns with plan-covered buckets drawn as chips instead of dollar bars, and the trigger/flow topology with spend badged onto the triggers that earned it](docs/images/insights-view.png?v=0.11.0)
 
 ## Quickstart
 
@@ -414,7 +414,7 @@ orphan skills and dangling triggers flagged, each cron's next fire or overdue st
 onto the triggers that earned it ([`docs/graph.md`](docs/graph.md) explains every edge;
 [`docs/insights.md`](docs/insights.md) the page, shown [above](#when-to-use-it)).
 
-![The topology pane of the insights page: cron and forge triggers wired to their flows, an observed chain edge carrying its run count and recency, a potential mention, a skill with its prose loop grouped inside it, cron re-arm loops with their schedules, an orphan skill dimmed, the forge group naming the repos its runs hit, and the legend stating the chain caps and honesty counters](docs/images/graph-view.png?v=0.12.0)
+![The topology pane of the insights page: cron and forge triggers wired to their flows, an observed chain edge carrying its run count and recency, a potential mention, a skill with its prose loop grouped inside it, cron re-arm loops with their schedules, an orphan skill dimmed, the forge group naming the repos its runs hit, and the legend stating the chain caps and honesty counters](docs/images/graph-view.png?v=0.11.0)
 
 ```bash
 pi install npm:@edgehero/pi-dispatch-admin   # then, in pi:  /dispatch

--- a/admin/README.md
+++ b/admin/README.md
@@ -55,14 +55,14 @@ Four forges: GitHub, GitLab, Forgejo (and Gitea), Azure DevOps. **Who may fire a
 One command puts a live TUI over the whole deployment:
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/dispatch-dashboard.png?v=0.12.0" alt="The /dispatch panel: status, spend meters, triggers, runs, and settings" width="820">
+  <img src="https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/dispatch-dashboard.png?v=0.11.0" alt="The /dispatch panel: status, spend meters, triggers, runs, and settings" width="820">
 </p>
 
 - **Status and spend.** Queue and worker state, day/week/month spend meters, a daily token counter, and a run-history table with per-job tokens and cost.
 - **Insights, the one analytics page.** Press `i` on the panel (or type `/dispatch insights`) and a single self contained page opens in your browser: the budget dials (the one lever that actually changes what all of this costs), per-plan verdicts against API rates, daily, cumulative and per-flow spend charts, the four breakdowns (flow, trigger, model, repo), and the whole trigger and flow topology with spend badged onto the triggers that earned it. Every dollar carries its class: a plan-covered run never renders as $0.00, and an estimate is always marked as one. Design your agent loops as triggers and skills, see the loops you actually built, and see what each one costs, all in one place ([`docs/insights.md`](https://github.com/edgehero/pi-dispatch/blob/main/docs/insights.md)).
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/insights-view.png?v=0.12.0" alt="The insights page: KPI tiles, a plan verdict card, the daily spend chart, the four breakdowns with plan-covered buckets drawn as chips instead of dollar bars, and the topology with spend badges" width="820">
+  <img src="https://raw.githubusercontent.com/edgehero/pi-dispatch/main/docs/images/insights-view.png?v=0.11.0" alt="The insights page: KPI tiles, a plan verdict card, the daily spend chart, the four breakdowns with plan-covered buckets drawn as chips instead of dollar bars, and the topology with spend badges" width="820">
 </p>
 
 - **Triggers, editable live.** cron, label, comment and pull_request triggers with colored drill-ins showing what fires each one, what it runs, and its trust model. Added, edited and deleted without a restart. Triggers that run third-party code or a custom image are badged; opting in or out of either stays an edit to the reviewed `triggers.json`, which neither the console nor a model-callable tool will make for you.

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -8,7 +8,7 @@ informs; it changes nothing — no port, no database, no new dependency.
 
 ## Where it renders
 
-![The topology pane: triggers wired to their flows Node-RED style, an observed chain edge with its count and recency, a potential mention, cron re-arm loops, an orphan skill dimmed, and the legend](images/graph-view.png?v=0.12.0)
+![The topology pane: triggers wired to their flows Node-RED style, an observed chain edge with its count and recency, a potential mention, cron re-arm loops, an orphan skill dimmed, and the legend](images/graph-view.png?v=0.11.0)
 
 The topology is the lower half of the **insights page** ([`insights.md`](insights.md)):
 `/dispatch insights` writes one self-contained HTML file and opens your browser, and the topology

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",


### PR DESCRIPTION
Ships the insights consolidation (issues #175 and #181; PRs #176 through #180 and #182 through #184).

**admin 0.8.0**: insights is the one analytics surface. Bare `/dispatch insights` (and the panel's `i` key) writes and opens the self-contained page: the budget dials (used-vs-cap facts, states as the worker's own words, the `/dispatch set` lever named), plan verdicts against API rates, daily, cumulative and per-flow spend charts, the four breakdowns, and the trigger/flow topology with schedule tips and spend badges. `insights whatif` is the estimator. **Breaking for operators**: the COSTS and GRAPH views and the `costs`/`graph` subcommands are removed; `dispatch_costs` (the model-facing tool) is unchanged. The cost-fold correctness fixes and the byTrigger/byRepo/dailyByFlow folds ride along.

**worker 0.3.0** and **receiver 0.2.1** are unchanged since v0.10.0; their publish groups skip on the version gate. Image `?v=` tags normalized to this release's version.

Suite green in the CI posture (2192 tests, 0 skipped, live Valkey).