### PR TITLE
feat(admin): tier-aware flow resolution in the topology (#188)

### DIFF
--- a/admin/src/dashboard.ts
+++ b/admin/src/dashboard.ts
@@ -25,7 +25,7 @@ import { makeQueue } from "@edgehero/pi-dispatch/queue";
 import { STALL_KEY } from "@edgehero/pi-dispatch/scheduler-stall-guard";
 import { windowEndAt } from "@edgehero/pi-dispatch/pause-windows";
 import { listRuns, readSettingsView, mapSchedulers, readTriggers, readPauseWindows, readStagedPackages } from "./read-model.mjs";
-import { renderStatus, renderBudget, renderTriggers, renderSettingsView } from "./render.mjs";
+import { renderStatus, renderBudget, renderTriggers, renderSettingsView, commandSlashLabel } from "./render.mjs";
 import { matchesKey } from "./keys.mjs";
 import { box, meter, clip, makeLineInput } from "./panel.mjs";
 import { makeStyler, frame, RULE } from "./style.mjs";
@@ -935,7 +935,10 @@ function matchColored(t: any, styler: any): string {
 
 function targetColored(t: any, styler: any): string {
   const arrow = styler.fg("dim", "→");
-  const flow = styler.bold(styler.fg("text", t?.flow ?? "-"));
+  // A command trigger shows its `/name` in the flow position, through render.mjs's one exported
+  // vocabulary (issue #188): before this fallback the row rendered a bare "-", as if the trigger
+  // targeted nothing.
+  const flow = styler.bold(styler.fg("text", t?.flow ?? commandSlashLabel(t) ?? "-"));
   if (t?.type === "cron") {
     // A local/cron trigger runs its flow against a folder — show `local <folder>/<flow>` so the target
     // (not just the flow name) is visible; github triggers get their repo from the webhook, so none there.
@@ -1077,7 +1080,7 @@ function renderTriggerDetail(t: any, inner: number, styler: any, sched: any = nu
 
   // Header: kind badge -> flow, plus a health marker for cron (✔ healthy / ⚠ overdue) derived from the
   // scheduler's overdueMs. A trigger with no matching scheduler shows no health marker rather than a guess.
-  let header = styler.fg(KIND_COLOR[t.type] ?? "muted", t.type ?? "?") + "  " + styler.bold(styler.fg("text", `→ ${t.flow ?? "-"}`));
+  let header = styler.fg(KIND_COLOR[t.type] ?? "muted", t.type ?? "?") + "  " + styler.bold(styler.fg("text", `→ ${t.flow ?? commandSlashLabel(t) ?? "-"}`));
   if (t.type === "cron" && sched) {
     const healthy = !sched.overdueMs;
     header += "   " + (healthy ? styler.fg("success", "✔ healthy") : styler.fg("warning", `⚠ overdue ${formatDuration(sched.overdueMs)}`));
@@ -1123,6 +1126,11 @@ function renderTriggerDetail(t: any, inner: number, styler: any, sched: any = nu
     out.push(kv("target", forgeTargetLabel(t?.forge), "accent"));
     out.push(kv("model", "deployment default", "dim"));
   }
+  // A command trigger's full `/name args` line (issue #189): the list and header show the name only,
+  // and this drill-in is where the args belong -- the reviewed file staged them, the operator's own
+  // session shows them. Rendered only when armed, on both branches, because all four kinds can carry
+  // a command; a flow trigger's pane stays byte-identical.
+  if (typeof t.command === "string" && t.command.trim() !== "") out.push(kv("command", `/${t.command.trim()}`, "accent"));
   // Same shape as the model row -- a per-trigger override of a deployment default -- and rendered on BOTH
   // branches, because unlike model, all four kinds can carry an image. The dim "deployment default" is
   // deliberate rather than an omitted row: a missing row would read as "I don't know", this reads as

--- a/admin/src/graph-html.mjs
+++ b/admin/src/graph-html.mjs
@@ -116,7 +116,9 @@ const WIRE_POTENTIAL = "#8b949e";
 
 // One glyph per node kind for the 30px icon column; characters, not images, because images would
 // need data: URIs and a font would need @font-face, both of which the file:// posture forbids.
-const GLYPH = Object.freeze({
+// Exported for the kind-parity test: this module cannot use the `from` clause, so a test is the
+// anti-drift wire that keeps every GRAPH_NODE_KINDS entry drawable (the GRAPH_HTML_KINDS pattern).
+export const GLYPH = Object.freeze({
   cron: "◷",
   label: "◈",
   comment: "❝",
@@ -124,7 +126,10 @@ const GLYPH = Object.freeze({
   skill: "ƒ",
   "skill-missing": "!",
   "skill-unverified": "?",
+  "skill-not-at-head": "⋯",
   injected: "+",
+  overlay: "◎",
+  staged: "▣",
 });
 
 // The 5-entity escape, byte-for-byte the worker's buildFormPage helper: every string interpolated
@@ -208,6 +213,14 @@ function normalizeModel(model) {
       .map((d) => clip(d, 120))
       .sort()
       .slice(0, 8),
+    // The two tier-honesty counters (issue #188), the injectedUnreachable rule applied to the
+    // deployment-wide tiers: a tier the ladder silently skipped would read as "checked".
+    overlayUnreachable: m.meta?.overlayUnreachable === true,
+    stagedUnenumerable: (Array.isArray(m.meta?.stagedUnenumerable) ? m.meta.stagedUnenumerable : [])
+      .filter((d) => typeof d === "string")
+      .map((d) => clip(d, 80))
+      .sort()
+      .slice(0, 8),
   };
 
   const folders = [];
@@ -243,6 +256,15 @@ function normalizeModel(model) {
       onType: typeof n.onType === "string" ? n.onType : null,
       pattern: typeof n.pattern === "string" ? n.pattern : null,
       flow: typeof n.flow === "string" ? n.flow : null,
+      // A command trigger's slash command (issue #189's node fact, #188's rendering): the tip is the
+      // detail surface, so the full command rides, clipped like every other string on this page.
+      command: typeof n.command === "string" ? clip(n.command, 80) : null,
+      // The staged tier node's owning package, and the softened state's evidence: which tiers this
+      // session could not check. Both clipped/sorted/capped so a hostile model cannot inflate a tip.
+      package: typeof n.package === "string" ? clip(n.package, 80) : null,
+      tiersUnknown: Array.isArray(n.tiersUnknown)
+        ? [...new Set(n.tiersUnknown.filter((t) => typeof t === "string").map((t) => clip(t, 40)))].sort().slice(0, 4)
+        : [],
       replicas: intOr(n.replicas, null),
       folderKey: typeof n.folderKey === "string" ? n.folderKey : null,
       runs: intOr(n.runs, 0),
@@ -350,6 +372,8 @@ function layoutNormalized(norm) {
     placedByOrig.set(n.id, p);
     let g = n.folderKey === null ? null : (groupIndexByKey.get(n.folderKey) ?? null);
     if (!g && n.kind === "injected") g = groupIndexByKey.get("~injected") ?? addGroup("~injected", "injected skills (run.skillsDir)", "local", null, null);
+    if (!g && n.kind === "overlay") g = groupIndexByKey.get("~overlay") ?? addGroup("~overlay", "overlay skills (global pi dir)", "local", null, null);
+    if (!g && n.kind === "staged") g = groupIndexByKey.get("~staged") ?? addGroup("~staged", "staged package skills", "local", null, null);
     if (!g) g = groupIndexByKey.get(n.folderKey ?? "~ungrouped") ?? addGroup(n.folderKey ?? "~ungrouped", "ungrouped", "local", null, null);
     g.members.push(p);
     p.groupId = g.id;
@@ -758,13 +782,27 @@ function buildTip(n, flags, groupLabel, nowMs) {
   if (n.kind === "trigger") {
     lines.push(`trigger · ${n.onType ?? "?"} · ${n.label ?? ""}`.trim());
     if (n.flow !== null) lines.push(`flow: ${n.flow}${n.replicas !== null ? ` ×${n.replicas}` : ""}`);
+    // flow's mutually-exclusive sibling (issue #189): a command trigger dispatches a registered
+    // extension command, so the tip shows the whole /name-and-args line the reviewed file staged.
+    else if (n.command !== null) lines.push(`command: /${n.command}${n.replicas !== null ? ` ×${n.replicas}` : ""}`);
   } else if (n.kind === "injected") {
     lines.push(`injected skill · ${n.name ?? "?"}`);
     lines.push("trigger-reachable via run.skillsDir, never AI-reachable");
+  } else if (n.kind === "overlay") {
+    lines.push(`overlay skill · ${n.name ?? "?"}`);
+    lines.push("deployment overlay skills/, trigger-reachable, never AI-reachable");
+  } else if (n.kind === "staged") {
+    lines.push(`staged skill · ${n.name ?? "?"}${n.package !== null ? ` · package ${n.package}` : ""}`);
+    lines.push("staged pi package, trigger-reachable, never AI-reachable");
   } else if (n.kind === "skill-missing") {
     lines.push(`skill · ${n.name ?? "?"} · missing at HEAD`);
   } else if (n.kind === "skill-unverified") {
     lines.push(`skill · ${n.name ?? "?"} · unverified (repo not readable from this host)`);
+  } else if (n.kind === "skill-not-at-head") {
+    // The softened state (issue #188): absent at HEAD is known TRUE, but a tier this session cannot
+    // check may still hold the name, so neither missing styling nor a dangling flag would be honest.
+    lines.push(`skill · ${n.name ?? "?"} · not committed at HEAD`);
+    if (n.tiersUnknown.length > 0) lines.push(`not checkable from this session: ${n.tiersUnknown.join(", ")}`);
   } else {
     lines.push(`skill · ${n.name ?? "?"}${n.isSub ? " · sub-skill (never a flow)" : ""}`);
   }
@@ -823,6 +861,10 @@ function nodeState(n, flagNames) {
     return { stroke: DANGER, dash: "10,4", faded: false };
   }
   if (n.kind === "skill-unverified") return { stroke: PAGE_DIM, dash: "10,4", faded: false };
+  // Amber, deliberately between red and dim (issue #188): the repo read HAPPENED and came back
+  // absent, but an unchecked tier may hold the name -- a third epistemic state, styled as one.
+  // Safe below the red arm: the dangling flags ride TRIGGER nodes, never this kind.
+  if (n.kind === "skill-not-at-head") return { stroke: PAGE_AMBER, dash: "10,4", faded: false };
   if (flagNames.has("orphan")) return { stroke: CHIP_STROKE, dash: "8,3", faded: true };
   return { stroke: CHIP_STROKE, dash: null, faded: false };
 }
@@ -959,7 +1001,8 @@ export function legendHtml(norm) {
   row(legendSwatch(`<circle cx="8" cy="6" r="5" fill="${BADGE_ORANGE}"/>`), "unread / injected ai-trigger / PR spend-loop risk");
   row(legendSwatch(`<circle cx="8" cy="6" r="4" fill="none" stroke="${BADGE_GREEN}" stroke-width="2"/>`), "chainable: ai-trigger allow");
   row(legendSwatch(`<rect x="1" y="1" width="14" height="10" rx="2" fill="none" stroke="${CHIP_STROKE}" stroke-dasharray="8,3"/>`), "orphan: no trigger, no ai-trigger, no mention");
-  row(legendSwatch(`<rect x="1" y="1" width="14" height="10" rx="2" fill="none" stroke="${DANGER}" stroke-dasharray="10,4"/>`), "dangling: flow absent or name invalid");
+  row(legendSwatch(`<rect x="1" y="1" width="14" height="10" rx="2" fill="none" stroke="${DANGER}" stroke-dasharray="10,4"/>`), "dangling: absent in every checkable tier or name invalid");
+  row(legendSwatch(`<rect x="1" y="1" width="14" height="10" rx="2" fill="none" stroke="${PAGE_AMBER}" stroke-dasharray="10,4"/>`), "not at HEAD: some skill tiers not checkable from this session");
   row(legendSwatch(`<rect x="1" y="1" width="14" height="10" rx="2" fill="none" stroke="${PAGE_DIM}" stroke-dasharray="10,4"/>`), "unverified: repo not readable from this host");
   rows.push(`<div class="caps">${escapeHtml(capsLineText(norm.caps))}</div>`);
   const honesty = [];
@@ -972,6 +1015,8 @@ export function legendHtml(norm) {
   const refused = norm.meta.chainRefusals.reduce((a, r) => a + r.count, 0);
   if (refused > 0) honesty.push(`${refused} chain requests refused (caps or gate)`);
   if (norm.meta.injectedUnreachable.length > 0) honesty.push(`injected skills dir unreadable: ${norm.meta.injectedUnreachable.join(", ")}`);
+  if (norm.meta.overlayUnreachable) honesty.push("overlay skills dir unreadable (global pi dir)");
+  if (norm.meta.stagedUnenumerable.length > 0) honesty.push(`staged packages not enumerable (manifest patterns): ${norm.meta.stagedUnenumerable.join(", ")}`);
   for (const line of honesty) rows.push(`<div class="honesty">${escapeHtml(line)}</div>`);
   return `<div id="legend">${rows.join("")}</div>`;
 }

--- a/admin/src/graph-model.mjs
+++ b/admin/src/graph-model.mjs
@@ -131,7 +131,7 @@ export function findLoopHints(text) {
 // minting a new one without a renderer arm should go red in a unit test, not render as nothing.
 export const GRAPH_EDGE_KINDS = Object.freeze(["config", "observed", "potential", "cron-rearm"]);
 export const GRAPH_FLAGS = Object.freeze([
-  "no-skill", // config edge target absent at HEAD in an ENUMERATED folder (readFlowGate's precise token)
+  "no-skill", // config edge target absent in EVERY checkable applicable tier (readFlowGate's precise token, now with the full ladder behind it)
   "charset-invalid", // run.flow fails SKILL_NAME_RE: can never materialise, a distinct defect from no-skill
   "orphan", // no trigger, no ai-trigger, no incoming mention: dead by every path the system has
   "ai-reachable-no-trigger", // no trigger but ai-trigger: allow -- deliberately chain/dispatch_run-reachable
@@ -139,6 +139,26 @@ export const GRAPH_FLAGS = Object.freeze([
   "unread", // SKILL.md unreadable/oversized at enumeration: facts unknown, gate read as closed
   "pr-spend-loop-risk", // pull_request on opened/synchronize: the OQ-020 cross-actor spend-loop signature
 ]);
+// The node kinds, closed and pinned like the two vocabularies above since issue #188 grew them: a
+// renderer meets every one of these or a new producer goes red in a unit test. The edge and flag sets
+// are BYTE-UNCHANGED by that issue -- REQ-TOPOLOGY-GRAPH (h)'s "the closed vocabularies stay closed"
+// holds literally; resolution honesty lives in kinds and node facts, never in a new flag.
+export const GRAPH_NODE_KINDS = Object.freeze([
+  "trigger",
+  "skill", // committed at HEAD in an enumerated folder
+  "skill-missing", // absent in every checkable applicable tier: the one red, dangling state
+  "skill-unverified", // the folder itself was never readable (forge/remote): a read that never happened
+  "skill-not-at-head", // absent at HEAD, but some lower tier was not checkable from this session
+  "injected", // run.skillsDir working-tree skill: trigger-reachable, never AI-reachable
+  "overlay", // deployment overlay skills/: trigger-reachable, never AI-reachable
+  "staged", // a staged pi package's skill: trigger-reachable, never AI-reachable
+]);
+
+// The ladder's tier names, one vocabulary for `tiersUnknown` and the no-skill detail text; doctor's
+// per-trigger flow lines spell the same tiers so an operator can cross-read the two surfaces.
+const TIER_INJECTED = "injected run.skillsDir";
+const TIER_OVERLAY = "overlay skills/";
+const TIER_STAGED = "staged packages";
 
 /**
  * Assemble the graph model every consumer renders from. Pure fold over the read-model's outputs --
@@ -160,11 +180,17 @@ export const GRAPH_FLAGS = Object.freeze([
  * Total function: absent or malformed inputs degrade to an empty-but-well-formed model, never a
  * throw (the read-model's viewer doctrine, one layer up).
  */
-export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSkills, foldersTruncated, forgeRepos, cronStats, runJoin, chainEdges, caps, nowMs, triggerCosts } = {}) {
+export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSkills, overlaySkills, stagedSkills, foldersTruncated, forgeRepos, cronStats, runJoin, chainEdges, caps, nowMs, triggerCosts } = {}) {
   const triggerList = Array.isArray(triggers?.triggers) ? triggers.triggers : [];
   const schedulerList = Array.isArray(schedulers) ? schedulers : [];
   const folders = folderSkills && typeof folderSkills === "object" ? folderSkills : {};
   const injected = injectedSkills && typeof injectedSkills === "object" ? injectedSkills : {};
+  // The two deployment-wide skill tiers (issue #188). Null OR malformed reads as "tier not checkable
+  // from this session" -- the deployment pointer cannot carry PI_GLOBAL_PI_DIR, so a wizard-launched
+  // console legitimately sees nothing -- and only a well-formed result can ever produce a known miss:
+  // degrading junk to an empty-but-known shape here would re-mint the false red this issue removes.
+  const overlay = overlaySkills && typeof overlaySkills === "object" && Array.isArray(overlaySkills.skills) ? overlaySkills : null;
+  const staged = stagedSkills && typeof stagedSkills === "object" && Array.isArray(stagedSkills.skills) ? stagedSkills : null;
   const statsById = cronStats?.byId && typeof cronStats.byId === "object" ? cronStats.byId : {};
   const statsByIndex = runJoin?.byIndex && typeof runJoin.byIndex === "object" ? runJoin.byIndex : {};
   const observed = Array.isArray(chainEdges?.edges) ? chainEdges.edges : [];
@@ -194,7 +220,7 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
         // collectGraphInputs' cap flag rides its spread into this input (review finding: this was
         // hardcoded false, so the cap-reached banner could never fire on any surface).
         folders: foldersTruncated === true,
-        skills: Object.values(folders).some((f) => f?.truncated === true),
+        skills: Object.values(folders).some((f) => f?.truncated === true) || overlay?.truncated === true || staged?.truncated === true,
         edges: chainEdges?.truncated === true,
       },
       droppedObservedEdges: 0,
@@ -204,6 +230,11 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
         .filter(([, r]) => typeof r?.unreachable === "string")
         .map(([dir]) => dir)
         .sort(),
+      // The two tier-honesty counters (issue #188): an overlay whose skills/ failed to read, and the
+      // staged packages whose pattern manifests defeat enumeration. Both feed the softened state
+      // below AND a banner, because a tier the ladder silently skipped would read as "checked".
+      overlayUnreachable: overlay?.unreachable === "unreadable",
+      stagedUnenumerable: (Array.isArray(staged?.unenumerable) ? staged.unenumerable : []).filter((p) => typeof p === "string").sort(),
     },
   };
 
@@ -284,6 +315,32 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
       }
     }
   }
+  // The two deployment-wide tiers render like the injected dirs (issue #188): every enumerated skill
+  // gets a node, capped upstream, bucketed by the page into its own tier group, orphan-exempt by
+  // kind. Neither joins skillNode -- that map answers "committed at HEAD in THIS folder", and a tier
+  // node resolves a config edge only through the precedence ladder below.
+  const overlayNodeId = new Map(); // name -> node id
+  if (overlay) {
+    for (const skill of overlay.skills) {
+      if (typeof skill?.name !== "string" || skill.name === "" || overlayNodeId.has(skill.name)) continue;
+      const id = `overlay:${skill.name}`;
+      overlayNodeId.set(skill.name, id);
+      model.nodes.push({ id, kind: "overlay", name: skill.name });
+    }
+  }
+  const stagedNodeId = new Map(); // name -> FIRST matching node id: manifest order is loader order
+  if (staged) {
+    const seenStagedIds = new Set();
+    for (const skill of staged.skills) {
+      if (typeof skill?.name !== "string" || skill.name === "" || typeof skill?.dir !== "string" || skill.dir === "") continue;
+      const id = `staged:${skill.dir}:${skill.name}`;
+      if (!seenStagedIds.has(id)) {
+        seenStagedIds.add(id);
+        model.nodes.push({ id, kind: "staged", name: skill.name, package: typeof skill.package === "string" && skill.package !== "" ? skill.package : skill.dir });
+      }
+      if (!stagedNodeId.has(skill.name)) stagedNodeId.set(skill.name, id);
+    }
+  }
 
   // A config edge may point at a flow the enumeration did not find; the target then exists as a
   // `skill-missing` node so the edge has a visible end. Created lazily, once per (group, name).
@@ -295,6 +352,22 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
     skillNode.set(key, node);
     model.nodes.push(node);
     group.skillIds.push(node.id);
+    return node;
+  };
+
+  // missingNode's softened sibling (issue #188): the flow is known absent at HEAD, but at least one
+  // lower tier was not checkable from this session, so neither "missing" styling nor a dangling flag
+  // would be honest. Shares missingNode's id space; where a red and a softened claimant land on one
+  // (group, name) -- per-trigger tier knowledge differs by skillsDir and run.packages -- the softened
+  // kind wins in EITHER arrival order, because red asserts "definitively nowhere" and the softened
+  // claimant's unknown tiers refute exactly that. The red claimant loses nothing: its no-skill flag
+  // rides its own TRIGGER node and survives the shared target.
+  const notAtHeadNode = (group, name, tiers) => {
+    const node = missingNode(group, name);
+    if (node.kind === "skill-missing") node.kind = "skill-not-at-head";
+    if (node.kind === "skill-not-at-head") {
+      node.tiersUnknown = [...new Set([...(Array.isArray(node.tiersUnknown) ? node.tiersUnknown : []), ...tiers])].sort();
+    }
     return node;
   };
 
@@ -386,11 +459,61 @@ export function buildGraphModel({ triggers, schedulers, folderSkills, injectedSk
           existing.isFlow = true;
           model.edges.push({ from: id, to: existing.id, kind: "config" });
         } else {
-          // Enumeration SUCCEEDED and the path is absent: this is readFlowGate's precise
-          // "no-skill", the one token that means dangling (deny would prove nothing).
-          const target = missingNode(group, t.flow);
-          model.edges.push({ from: id, to: target.id, kind: "config" });
-          model.flags.push({ nodeId: id, flag: "no-skill", detail: `.pi/skills/${t.flow}/SKILL.md absent at HEAD` });
+          // Absent at HEAD -- but the repo is only the top of the loader's four tiers (issue #188).
+          // Probe the rest in precedence order, per trigger: injected run.skillsDir, overlay
+          // skills/, staged packages. Each probe answers hit, miss, or unknown, and a tier node is
+          // claimed only when every higher applicable tier is a KNOWN miss: a config edge asserts
+          // node identity ("the job loads THIS file"), so a hit below an unknown tier stays soft.
+          // Doctor probes past an unknown on purpose -- its check answers the existential "does the
+          // name resolve anywhere", which a lower hit satisfies regardless of which tier shadows it;
+          // an identity claim may not, because the wrong node is a wrong tick
+          // (DES-FLOW-RESOLUTION-TWO-ADVISORY-LAYERS's one forbidden direction).
+          const probes = [];
+          if (typeof t.skillsDir === "string" && t.skillsDir !== "") {
+            // Applicable only when THIS trigger injects a dir; an unreadable or truncated listing
+            // proves nothing about the name (the miss may sit past the cap).
+            const r = injected[t.skillsDir];
+            if (!r || typeof r.unreachable === "string") probes.push({ tier: TIER_INJECTED, state: "unknown" });
+            else if ((Array.isArray(r.skills) ? r.skills : []).some((s) => s?.name === t.flow)) probes.push({ tier: TIER_INJECTED, state: "hit", nodeId: `injected:${t.skillsDir}:${t.flow}` });
+            else probes.push({ tier: TIER_INJECTED, state: r.truncated === true ? "unknown" : "miss" });
+          }
+          if (overlay === null || typeof overlay.unreachable === "string") probes.push({ tier: TIER_OVERLAY, state: "unknown" });
+          else if (overlayNodeId.has(t.flow)) probes.push({ tier: TIER_OVERLAY, state: "hit", nodeId: overlayNodeId.get(t.flow) });
+          else probes.push({ tier: TIER_OVERLAY, state: overlay.truncated === true ? "unknown" : "miss" });
+          if (t.packages === false) {
+            // Withheld by the trigger's own config is a KNOWN miss: the job would not load the tier
+            // either. Named in the detail text so a red on a packages:false trigger says why the
+            // staged tier could not have saved it.
+            probes.push({ tier: `${TIER_STAGED} (withheld: run.packages false)`, state: "miss" });
+          } else if (staged === null) probes.push({ tier: TIER_STAGED, state: "unknown" });
+          else if (stagedNodeId.has(t.flow)) probes.push({ tier: TIER_STAGED, state: "hit", nodeId: stagedNodeId.get(t.flow) });
+          else probes.push({ tier: TIER_STAGED, state: staged.unenumerable.length > 0 || staged.truncated === true ? "unknown" : "miss" });
+
+          let target = null;
+          let blocked = false;
+          for (const probe of probes) {
+            if (probe.state === "hit" && !blocked) {
+              target = probe.nodeId;
+              break;
+            }
+            if (probe.state === "unknown") blocked = true;
+          }
+          if (target !== null) {
+            // Resolved in a lower tier: the edge lands on the tier node that already renders its own
+            // "never AI-reachable" truth, and NO flag is minted -- the flow runs fine.
+            model.edges.push({ from: id, to: target, kind: "config" });
+          } else if (probes.some((p) => p.state === "unknown")) {
+            const soft = notAtHeadNode(group, t.flow, probes.filter((p) => p.state === "unknown").map((p) => p.tier));
+            model.edges.push({ from: id, to: soft.id, kind: "config" });
+          } else {
+            // Every applicable tier checked and missed: readFlowGate's precise "no-skill", the one
+            // token that means dangling (deny would prove nothing), now with the whole ladder
+            // behind it -- the detail names the tiers so the claim is auditable.
+            const target2 = missingNode(group, t.flow);
+            model.edges.push({ from: id, to: target2.id, kind: "config" });
+            const alsoChecked = probes.length > 0 ? `; also checked: ${probes.map((p) => p.tier).join(", ")}` : "";
+            model.flags.push({ nodeId: id, flag: "no-skill", detail: `.pi/skills/${t.flow}/SKILL.md absent at HEAD${alsoChecked}` });
+          }
         }
       } else if (group) {
         // Forge repo (not local) or unreachable folder: the edge still draws -- the config fact is

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -1060,7 +1060,7 @@ async function assembleGraph(paths: any): Promise<any> {
   return buildGraphModel({
     triggers,
     schedulers: Array.isArray(schedulers) ? schedulers : [],
-    ...collectGraphInputs({ triggers: triggerList }),
+    ...collectGraphInputs({ triggers: triggerList, globalPiDir: paths.globalPiDir }),
     cronStats: cronRunStats({ records: recs, schedulerIds: triggerList.filter((t) => t.type === "cron" && typeof t.id === "string").map((t) => t.id) }),
     runJoin: joinRunsToTriggers({ records: recs, triggerCount: triggers?.count, triggerTypes: Object.fromEntries(triggerList.map((t: any) => [t.index, t.type])) }),
     chainEdges: observedChainEdges({ records: recs }),

--- a/admin/src/read-model.mjs
+++ b/admin/src/read-model.mjs
@@ -31,7 +31,7 @@ import { parseConnection, makeRedisClient } from "@edgehero/pi-dispatch/connecti
 import { makeQueue, enqueueLocalJob } from "@edgehero/pi-dispatch/queue";
 import { readFlowGate, aiTriggerAllows, SKILL_NAME_RE } from "@edgehero/pi-dispatch/flow-gate";
 import { gitDirty } from "@edgehero/pi-dispatch/git-dirty";
-import { readStageManifest } from "@edgehero/pi-dispatch/packages";
+import { readStageManifest, readStagedSkills } from "@edgehero/pi-dispatch/packages";
 // The skill enumeration reuses the worker's OWN listing parsers (issue #54), the same anti-drift rule
 // as parseTriggers/readOverlay above: selectEntries keeps only regular blobs at allowed paths, and
 // keepOnlyDeclaredSkills drops a subtree that declares no SKILL.md -- re-deriving either here is how
@@ -864,6 +864,7 @@ export const GRAPH_LIMITS = Object.freeze({
   maxEdges: 200, // distinct observed chain edges kept; beyond this the graph says "truncated"
   windowDays: 30, // run-record window the graph folds; matches the default PI_LOG_RETENTION_DAYS
   maxReposListed: 5, // repos named per forge group, from record targets; a scope label, not an inventory
+  maxStagedSkills: 64, // staged-package skills kept for display; one stage read per graph build
 });
 
 /**
@@ -1183,14 +1184,110 @@ export function readInjectedSkills({ skillsDir, fs = nodeFs } = {}) {
 }
 
 /**
- * The one I/O aggregation for a graph build: enumerate every distinct cron folder and injected
- * skills dir the display triggers name, deduped and capped. Lives here so the dashboard seam and the
- * `/dispatch graph` command share one folder-dedupe/caps implementation; callers bring their own
- * records/schedulers reads. Forge triggers contribute no folder -- their repo is not on this host,
- * which is exactly what the graph's "skills unverifiable from the admin host" folder line says.
+ * Enumerate the deployment overlay's `skills/` (REQ-GLOBAL-PI-OVERLAY) for display: a working-tree
+ * readdir like readInjectedSkills, because the overlay is operator-authored host state with no git
+ * history. Existence-only on purpose, no frontmatter read and no `ai-trigger` fact: an overlay skill
+ * is never AI-reachable regardless of what its frontmatter claims (DES-AI-TRIGGER-FLOW-GATE), and the
+ * flag vocabulary is closed, so a body read could add nothing the tip's "never AI-reachable" does not
+ * already say. The unbadged overlay `ai-trigger: allow` no-op is a recorded residual, not an oversight.
+ *
+ * ENOENT on the readdir is KNOWN-EMPTY, not unreachable: an overlay carrying only models.json or
+ * prompts/ is a legal deployment, and calling it unreadable would soften every dangling flow into
+ * "tier not checkable" for deployments that simply stage no overlay skills. Every other failure is
+ * "unreadable", which the resolution ladder treats as an unknown tier: a read that failed proves
+ * nothing (the readFolderSkills doctrine, one tier over).
  */
-export function collectGraphInputs({ triggers, readFolder = readFolderSkills, readInjected = readInjectedSkills } = {}) {
-  const out = { folderSkills: {}, injectedSkills: {}, foldersTruncated: false };
+export function readOverlaySkills({ globalPiDir, fs = nodeFs } = {}) {
+  if (typeof globalPiDir !== "string" || globalPiDir === "") return { skills: [], truncated: false, unreachable: null };
+  const dir = join(globalPiDir, "skills");
+  let names;
+  try {
+    names = fs.readdirSync(dir);
+  } catch (err) {
+    if (err?.code === "ENOENT") return { skills: [], truncated: false, unreachable: null };
+    return { skills: [], truncated: false, unreachable: "unreadable" };
+  }
+  const valid = names.filter((n) => SKILL_NAME_RE.test(n)).sort();
+  const truncated = valid.length > GRAPH_LIMITS.maxSkillsPerFolder;
+  const skills = [];
+  for (const name of valid.slice(0, GRAPH_LIMITS.maxSkillsPerFolder)) {
+    let present = false;
+    try {
+      present = fs.existsSync(join(dir, name, "SKILL.md"));
+    } catch {
+      present = false; // an unstattable entry is not a skill the loader would take either
+    }
+    if (present) skills.push({ name });
+  }
+  return { skills, truncated, unreachable: null };
+}
+
+/**
+ * Enumerate the staged pi packages' skills for display, through the worker's OWN readStagedSkills
+ * (worker/src/packages.mjs): manifest-vs-convention semantics at the pin, glob/override packages
+ * reported as unenumerable rather than guessed at, dir-basename naming (a frontmatter rename can
+ * only turn a would-be resolution into a softened one, never invent one). Same anti-drift rule as
+ * readStagedPackages above, and the same wrapper doctrine: that reader never throws by contract, and
+ * the try/catch here additionally covers the injected fs callbacks.
+ *
+ * Manifest order is PRESERVED, no re-sort: resolution takes the first name match, the same package
+ * doctor's staged probe names, and display determinism comes from the page normalizer's id sort,
+ * never from this list.
+ */
+export function readStagedSkillsList({ globalPiDir, fs = nodeFs, readStaged = readStagedSkills } = {}) {
+  const empty = { skills: [], unenumerable: [], truncated: false };
+  if (typeof globalPiDir !== "string" || globalPiDir === "") return empty;
+  let result;
+  try {
+    result = readStaged({
+      globalPiDir,
+      readFile: (path) => fs.readFileSync(path, "utf8"),
+      fileExists: (path) => fs.existsSync(path),
+      readDir: (path, opts) => fs.readdirSync(path, opts),
+    });
+  } catch {
+    return empty;
+  }
+  const seen = new Set();
+  const skills = [];
+  for (const s of Array.isArray(result?.skills) ? result.skills : []) {
+    if (typeof s?.name !== "string" || !SKILL_NAME_RE.test(s.name)) continue;
+    if (typeof s.dir !== "string" || s.dir === "") continue;
+    const key = `${s.dir} ${s.name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    skills.push({ name: s.name, package: typeof s.package === "string" && s.package !== "" ? s.package : s.dir, dir: s.dir });
+  }
+  return {
+    skills: skills.slice(0, GRAPH_LIMITS.maxStagedSkills),
+    unenumerable: (Array.isArray(result?.unenumerable) ? result.unenumerable : []).filter((p) => typeof p === "string").sort(),
+    truncated: skills.length > GRAPH_LIMITS.maxStagedSkills,
+  };
+}
+
+/**
+ * The one I/O aggregation for a graph build: enumerate every distinct cron folder and injected
+ * skills dir the display triggers name, deduped and capped, plus the two deployment-wide skill tiers
+ * (overlay `skills/` and staged packages) when this session can see the global pi dir at all. Lives
+ * here so the dashboard seam and the `/dispatch graph` command share one folder-dedupe/caps
+ * implementation; callers bring their own records/schedulers reads. Forge triggers contribute no
+ * folder -- their repo is not on this host, which is exactly what the graph's "skills unverifiable
+ * from the admin host" folder line says.
+ *
+ * `overlaySkills`/`stagedSkills` are null (not empty) when `globalPiDir` is unset: the deployment
+ * pointer's env allowlist deliberately excludes PI_GLOBAL_PI_DIR, so a wizard-launched session sees
+ * null even when the worker service has a real overlay. Null means "tier not checkable from this
+ * session", never "tier empty", and the model softens rather than flagging.
+ */
+export function collectGraphInputs({
+  triggers,
+  globalPiDir = null,
+  readFolder = readFolderSkills,
+  readInjected = readInjectedSkills,
+  readOverlay = readOverlaySkills,
+  readStaged = readStagedSkillsList,
+} = {}) {
+  const out = { folderSkills: {}, injectedSkills: {}, overlaySkills: null, stagedSkills: null, foldersTruncated: false };
   if (!Array.isArray(triggers)) return out;
   const folders = [];
   const injectedDirs = [];
@@ -1204,6 +1301,10 @@ export function collectGraphInputs({ triggers, readFolder = readFolderSkills, re
   }
   for (const dir of injectedDirs.slice(0, GRAPH_LIMITS.maxFoldersScanned)) {
     out.injectedSkills[dir] = readInjected({ skillsDir: dir });
+  }
+  if (typeof globalPiDir === "string" && globalPiDir !== "") {
+    out.overlaySkills = readOverlay({ globalPiDir });
+    out.stagedSkills = readStaged({ globalPiDir });
   }
   return out;
 }

--- a/admin/src/render.mjs
+++ b/admin/src/render.mjs
@@ -167,12 +167,7 @@ export function renderTriggers({ schedulers, triggers } = {}) {
  * suffix is empty and appended last.
  */
 function triggerLine(t) {
-  // A command trigger (issue #189, `run.command`) shows `/name` in the flow position: the shared parser
-  // makes flow and command mutually exclusive, so the column never has to hold both, and the slash marks
-  // "dispatches a registered extension command" apart from a flow at a glance. The NAME only (the first
-  // space-delimited token) so the line stays skimmable, the [skills basename] doctrine restated; the args
-  // belong in the detail view.
-  const flow = t?.flow ?? (typeof t?.command === "string" && t.command.trim() !== "" ? `/${t.command.trim().split(/\s+/)[0]}` : "-");
+  const flow = t?.flow ?? commandSlashLabel(t) ?? "-";
   const forge = t?.forge && t.forge !== "github" ? `  [${t.forge}]` : "";
   const pkgs = t?.packages === true ? "  [packages]" : "";
   const img = t?.image ? `  [image ${t.image}]` : "";
@@ -208,6 +203,19 @@ function triggerLine(t) {
     default:
       return "(unknown trigger)";
   }
+}
+
+/**
+ * The `/name` display token for a command trigger (issue #189, `run.command`), or null when the entry
+ * carries no command. It renders in the flow position: the shared parser makes flow and command mutually
+ * exclusive, so the column never has to hold both, and the slash marks "dispatches a registered extension
+ * command" apart from a flow at a glance. The NAME only (the first space-delimited token, pi's own
+ * dispatch grammar) so the line stays skimmable, the [skills basename] doctrine restated; the args belong
+ * in the detail view. Exported as the one vocabulary (issue #188): the list line here, the TUI's target
+ * column and the drill-in header must not drift on what a command trigger is called.
+ */
+export function commandSlashLabel(t) {
+  return typeof t?.command === "string" && t.command.trim() !== "" ? `/${t.command.trim().split(/\s+/)[0]}` : null;
 }
 
 function ruleClauses(rule) {

--- a/admin/test/dashboard.test.mjs
+++ b/admin/test/dashboard.test.mjs
@@ -768,6 +768,16 @@ async function renderTrigger(trigger) {
   return { list, detail: stripAnsi(comp.render(100).join("\n")) };
 }
 
+test("a command trigger's target and drill-in show /name, and the full staged line lives in the detail", async () => {
+  // Before this, both surfaces rendered a bare "-" for a command trigger, as if it targeted nothing
+  // (issue #188's display half). The /name comes from render.mjs's one exported vocabulary.
+  const { list, detail } = await renderTrigger({ type: "comment", forge: "github", phrase: "@pi deploy", flow: null, command: "deploy prod --now", packages: false, image: null, skillsDir: null, instructions: false, resume: false, replicas: null });
+  assert.ok(list.includes("/deploy"), "the target column shows the slash name, not '-'");
+  assert.equal(list.includes("deploy prod --now"), false, "the args stay out of the list row");
+  assert.ok(detail.includes("→ /deploy"), "the drill-in header names the command the way it names a flow");
+  assert.ok(detail.includes("/deploy prod --now"), "the full staged line belongs in the detail, the operator's own session");
+});
+
 test("a trigger's row names its forge ONCE -- the target says it, so no badge repeats it", async () => {
   // The badge existed because the target read `-> github` for every forge, so a gitlab row contradicted its
   // own badge. Fixing the target removed the badge's REASON to exist, not merely its wrongness. render.mjs

--- a/admin/test/graph-html.test.mjs
+++ b/admin/test/graph-html.test.mjs
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
-import { buildGraphHtml, layoutGraph, GRAPH_HTML_KINDS } from "../src/graph-html.mjs";
-import { buildGraphModel, GRAPH_EDGE_KINDS } from "../src/graph-model.mjs";
+import { buildGraphHtml, layoutGraph, GRAPH_HTML_KINDS, GLYPH } from "../src/graph-html.mjs";
+import { buildGraphModel, GRAPH_EDGE_KINDS, GRAPH_NODE_KINDS } from "../src/graph-model.mjs";
 
 const NOW = 1770000000000;
 
@@ -34,6 +34,11 @@ const CANNED = () => ({
     },
   },
   injectedSkills: { "/inj": { skills: [{ name: "tidy", aiTrigger: true }], truncated: false, unreachable: null } },
+  // Known-empty tier reads (issue #188), mirroring graph-model.test.mjs: a session that can see the
+  // global pi dir and finds both tiers empty keeps `deleted-flow` a KNOWN miss, so the red dangling
+  // pins below stay meaningful. Absent keys would soften it to the amber not-at-head state.
+  overlaySkills: { skills: [], truncated: false, unreachable: null },
+  stagedSkills: { skills: [], unenumerable: [], truncated: false },
   forgeRepos: { github: ["acme/website", "acme/api"] },
   cronStats: { byId: { nightly: { runs: 41, lastOutcome: "completed", lastEndedAt: "2026-08-11T00:00:00.000Z" }, gone: { runs: 0, lastOutcome: null, lastEndedAt: null } } },
   runJoin: { byIndex: { 1: { runs: 12, lastOutcome: "completed", lastEndedAt: "2026-08-11T01:00:00.000Z" } }, unattributed: 2 },
@@ -391,6 +396,111 @@ test("the page script letterbox-maps the cursor, survives a pan without wiping s
   assert.equal((script.match(/GRAPH\.nodes\[/g) ?? []).length, 1, "exactly one raw indexed read of GRAPH.nodes: the one inside the guard");
 
   new Function(script); // parse check: a syntax break in the emitted script goes red here, not in a browser
+});
+
+// ---- 10c. tier rendering (issue #188) ----
+
+// A tier-bearing deployment: the CANNED base plus one trigger resolving in each non-repo tier, and
+// the tier reads that let them resolve.
+const TIERED = () => {
+  const inputs = CANNED();
+  inputs.overlaySkills = { skills: [{ name: "global-flow" }], truncated: false, unreachable: null };
+  inputs.stagedSkills = { skills: [{ name: "pkg-flow", package: "@acme/wf", dir: "wf" }], unenumerable: [], truncated: false };
+  inputs.triggers.triggers.push(
+    { type: "cron", index: 3, id: "inj", pattern: "0 7 * * *", folder: "/srv/site", flow: "tidy", model: null, packages: true, image: null, skillsDir: "/inj", instructions: false, resume: false },
+    { type: "cron", index: 4, id: "glob", pattern: "0 8 * * *", folder: "/srv/site", flow: "global-flow", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false },
+    { type: "cron", index: 5, id: "pkg", pattern: "0 9 * * *", folder: "/srv/site", flow: "pkg-flow", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false },
+  );
+  return inputs;
+};
+
+test("every GRAPH_NODE_KINDS entry except trigger has its own glyph -- the kind-parity anti-drift wire", () => {
+  // graph-html cannot use the `from` clause on graph-model, so this test is where a new node kind
+  // without a drawing arm goes red (the GRAPH_HTML_KINDS pattern, applied to kinds).
+  for (const kind of GRAPH_NODE_KINDS) {
+    if (kind === "trigger") continue; // triggers glyph by onType, pinned by the GLYPH keys below
+    assert.ok(typeof GLYPH[kind] === "string" && GLYPH[kind] !== "", `no glyph for node kind ${kind}`);
+  }
+  for (const onType of ["cron", "label", "comment", "pull_request"]) {
+    assert.ok(typeof GLYPH[onType] === "string", `no glyph for trigger onType ${onType}`);
+  }
+});
+
+test("tier nodes render in their own groups, tips name the tier and stay never-AI-reachable", () => {
+  const out = buildGraphHtml(buildGraphModel(TIERED()), { now: NOW });
+  assert.ok(out.includes("overlay skills (global pi dir)"), "the overlay group renders");
+  assert.ok(out.includes("staged package skills"), "the staged group renders");
+  assert.ok(out.includes("deployment overlay skills/, trigger-reachable, never AI-reachable"), "the overlay tip keeps the reachability half");
+  assert.ok(out.includes("staged pi package, trigger-reachable, never AI-reachable"), "the staged tip too");
+  assert.ok(out.includes("package @acme/wf"), "the staged tip names the owning package");
+  assert.ok(out.includes(">◎</text>") && out.includes(">▣</text>"), "the tier glyphs render in the icon column");
+  // The resolved triggers are NOT dangling: the only red chip is CANNED's own deleted-flow.
+  assert.equal((out.match(/stroke="#f85149" stroke-width="1" stroke-dasharray="10,4"/g) ?? []).length, 2, "deleted-flow's node and its trigger chip stay the only red pair");
+});
+
+test("acceptance (i) end to end: an injected-resolved flow wires trigger to the injected node, unflagged", () => {
+  const layout = layoutGraph(buildGraphModel(TIERED()));
+  const trigger = layout.nodes.find((n) => n.node.id === "trigger:3");
+  const injectedChip = layout.nodes.find((n) => n.node.id === "injected:/inj:tidy");
+  assert.ok(trigger && injectedChip, "both endpoints place");
+  const wire = layout.wires.find((w) => w.kind === "config" && w.from === trigger.id);
+  assert.equal(wire.to, injectedChip.id, "the config edge lands on the injected node that already existed");
+  assert.ok(!layout.nodes.some((n) => n.node.id === "skill:folder:/srv/site:tidy"), "and no red twin is minted");
+});
+
+test("the softened not-at-head state renders amber-dashed with its tiers in the tip; red needs every tier checked", () => {
+  const blind = CANNED();
+  // A session without PI_GLOBAL_PI_DIR (the deployment pointer cannot carry it): both
+  // deployment-wide tiers read as unknown, so deleted-flow softens instead of flagging.
+  delete blind.overlaySkills;
+  delete blind.stagedSkills;
+  const out = buildGraphHtml(buildGraphModel(blind), { now: NOW });
+  assert.ok(out.includes('stroke="#d29922" stroke-width="1" stroke-dasharray="10,4"'), "the amber chip treatment renders");
+  assert.equal((out.match(/stroke="#f85149" stroke-width="1" stroke-dasharray="10,4"/g) ?? []).length, 0, "no chip wears the red missing claim");
+  assert.ok(out.includes("not committed at HEAD"), "the tip states the one thing the session KNOWS");
+  assert.ok(out.includes("not checkable from this session: overlay skills/, staged packages"), "and names what it could not check");
+  assert.ok(out.includes(">⋯</text>"), "the softened glyph renders");
+
+  // The twin: with the tier reads wired and empty (CANNED), the same flow is a checked miss -- red.
+  const checked = cannedHtml();
+  assert.equal((checked.match(/stroke="#f85149" stroke-width="1" stroke-dasharray="10,4"/g) ?? []).length, 2, "deleted-flow's node and its trigger chip carry the red");
+  assert.ok(!checked.includes("not committed at HEAD"), "no softened tip when every tier was checkable");
+});
+
+test("the legend states the tier-aware vocabulary and the tier honesty banners", () => {
+  const out = cannedHtml();
+  assert.ok(out.includes("dangling: absent in every checkable tier or name invalid"), "the dangling row now claims the whole ladder");
+  assert.ok(out.includes("not at HEAD: some skill tiers not checkable from this session"), "the softened state has its legend row");
+
+  const troubled = buildGraphModel(TIERED());
+  troubled.meta.overlayUnreachable = true;
+  troubled.meta.stagedUnenumerable = ["@glob/pkg"];
+  const page = buildGraphHtml(troubled, { now: NOW });
+  assert.ok(page.includes("overlay skills dir unreadable (global pi dir)"), "an unreadable overlay banners");
+  assert.ok(page.includes("staged packages not enumerable (manifest patterns): @glob/pkg"), "pattern manifests banner instead of being guessed at");
+});
+
+test("a command trigger's tip shows the slash command; junk tiersUnknown is filtered at the allowlist", () => {
+  const inputs = CANNED();
+  inputs.triggers.triggers.push({ type: "comment", index: 3, phrase: "@pi deploy", flow: null, command: "deploy prod", packages: true, image: null, skillsDir: null, instructions: false, resume: false, replicas: null, forge: "github" });
+  const out = buildGraphHtml(buildGraphModel(inputs), { now: NOW });
+  assert.ok(out.includes("command: /deploy prod"), "the tip is the detail surface, so the whole staged line shows");
+
+  const soft = buildGraphModel((() => { const b = CANNED(); delete b.overlaySkills; delete b.stagedSkills; return b; })());
+  const target = soft.nodes.find((n) => n.kind === "skill-not-at-head");
+  target.tiersUnknown = [42, null, "CANARY-TIER-x9"];
+  const page = buildGraphHtml(soft, { now: NOW });
+  assert.ok(page.includes("not checkable from this session: CANARY-TIER-x9"), "string entries survive the allowlist; the junk beside them does not");
+});
+
+test("a permuted tier-bearing model does not move a byte", () => {
+  const model = buildGraphModel(TIERED());
+  const permuted = buildGraphModel(TIERED());
+  permuted.nodes.reverse();
+  permuted.edges.reverse();
+  permuted.flags.reverse();
+  permuted.folders.reverse();
+  assert.equal(buildGraphHtml(permuted, { now: NOW }), buildGraphHtml(model, { now: NOW }));
 });
 
 // ---- 11. degrades ----

--- a/admin/test/graph-model.test.mjs
+++ b/admin/test/graph-model.test.mjs
@@ -72,9 +72,9 @@ test("findSiblingMentions is total: bad inputs yield [], and a self-shaped name 
 
 // ---- buildGraphModel (the assembler; DES-GRAPH-EDGE-DERIVATION's honesty rules live here) ----
 
-import { buildGraphModel, GRAPH_EDGE_KINDS, GRAPH_FLAGS } from "../src/graph-model.mjs";
+import { buildGraphModel, GRAPH_EDGE_KINDS, GRAPH_FLAGS, GRAPH_NODE_KINDS } from "../src/graph-model.mjs";
 
-test("the edge and flag vocabularies are the LITERAL closed sets, frozen", () => {
+test("the edge, flag and node-kind vocabularies are the LITERAL closed sets, frozen", () => {
   // Every consumer switches on these strings; a producer minting a new one without a renderer arm
   // must go red HERE, not render as nothing. Change these on purpose and say why in the commit body.
   assert.deepEqual([...GRAPH_EDGE_KINDS], ["config", "observed", "potential", "cron-rearm"]);
@@ -82,7 +82,13 @@ test("the edge and flag vocabularies are the LITERAL closed sets, frozen", () =>
     [...GRAPH_FLAGS],
     ["no-skill", "charset-invalid", "orphan", "ai-reachable-no-trigger", "injected-ai-trigger", "unread", "pr-spend-loop-risk"],
   );
-  assert.ok(Object.isFrozen(GRAPH_EDGE_KINDS) && Object.isFrozen(GRAPH_FLAGS));
+  // Issue #188 grew the KINDS (tier nodes, the softened state) and closed the set; the edge and flag
+  // vocabularies above are byte-unchanged by it, which is what keeps REQ-TOPOLOGY-GRAPH (h) literally true.
+  assert.deepEqual(
+    [...GRAPH_NODE_KINDS],
+    ["trigger", "skill", "skill-missing", "skill-unverified", "skill-not-at-head", "injected", "overlay", "staged"],
+  );
+  assert.ok(Object.isFrozen(GRAPH_EDGE_KINDS) && Object.isFrozen(GRAPH_FLAGS) && Object.isFrozen(GRAPH_NODE_KINDS));
 });
 
 // One canned deployment the assembler tests share: a local folder with a healthy chain pair, an
@@ -111,6 +117,11 @@ const CANNED = () => ({
     },
   },
   injectedSkills: { "/inj": { skills: [{ name: "tidy", aiTrigger: true }], truncated: false, unreachable: null } },
+  // Known-empty tier reads (issue #188): the session can see the global pi dir and both tiers hold
+  // nothing, so a miss is a KNOWN miss and `deleted-flow` stays red. Null here would mean "tier not
+  // checkable" and soften every dangling assertion below.
+  overlaySkills: { skills: [], truncated: false, unreachable: null },
+  stagedSkills: { skills: [], unenumerable: [], truncated: false },
   cronStats: { byId: { nightly: { runs: 41, lastOutcome: "completed", lastEndedAt: "2026-08-11T00:00:00.000Z" }, gone: { runs: 0, lastOutcome: null, lastEndedAt: null } } },
   runJoin: { byIndex: { 1: { runs: 12, lastOutcome: "completed", lastEndedAt: "2026-08-11T01:00:00.000Z" } }, unattributed: 2 },
   chainEdges: { edges: [{ parentFlow: "build-report", childFlow: "notify", target: "local:site", count: 3, lastEndedAt: "2026-08-10T00:00:00.000Z" }], refusals: { "build-report": 1 }, truncated: false },
@@ -346,4 +357,174 @@ test("skill nodes carry their loops, and forge groups carry their record-derived
   assert.deepEqual(m.nodes.find((n) => n.id === "skill:folder:/srv/site:build-report").loops, [{ hint: "until the report renders right" }]);
   assert.deepEqual(m.folders.find((f) => f.key === "forge:github").repos, ["acme/website"], "the group says which repos it is ABOUT");
   assert.deepEqual(buildGraphModel(CANNED()).folders.find((f) => f.key === "forge:github").repos, [], "no records, no claim");
+});
+
+// ---- tier-aware config-edge resolution (issue #188: repo > injected > overlay > staged) ----
+
+test("a cron flow that resolves only in its injected run.skillsDir lands its edge on the injected node, unflagged", () => {
+  const inputs = CANNED();
+  inputs.triggers.triggers.push({ type: "cron", index: 3, id: "inj", pattern: "0 7 * * *", folder: "/srv/site", flow: "tidy", model: null, packages: true, image: null, skillsDir: "/inj", instructions: false, resume: false });
+  const m = buildGraphModel(inputs);
+  const edge = m.edges.find((e) => e.kind === "config" && e.from === "trigger:3");
+  assert.equal(edge.to, "injected:/inj:tidy", "the true node already exists; the edge lands on it instead of minting a red twin");
+  assert.ok(!m.nodes.some((n) => n.id === "skill:folder:/srv/site:tidy"), "no second, dangling node is minted for the same name");
+  assert.deepEqual(m.flags.filter((f) => f.nodeId === "trigger:3"), [], "a flow that runs fine carries no dangling flag");
+});
+
+test("repo wins: a flow present at HEAD AND in the injected dir resolves to the committed skill node", () => {
+  const inputs = CANNED();
+  inputs.injectedSkills["/inj"].skills.push({ name: "build-report", aiTrigger: false });
+  inputs.triggers.triggers[0].skillsDir = "/inj";
+  const m = buildGraphModel(inputs);
+  const edge = m.edges.find((e) => e.kind === "config" && e.from === "trigger:0");
+  assert.equal(edge.to, "skill:folder:/srv/site:build-report", "loader precedence is repo > injected; the edge says what the job actually loads");
+});
+
+test("a flow that resolves only in the overlay lands on its overlay node; every overlay skill enumerates", () => {
+  const inputs = CANNED();
+  inputs.overlaySkills = { skills: [{ name: "deleted-flow" }, { name: "unrelated" }], truncated: false, unreachable: null };
+  const m = buildGraphModel(inputs);
+  const edge = m.edges.find((e) => e.kind === "config" && e.from === "trigger:2");
+  assert.equal(edge.to, "overlay:deleted-flow");
+  assert.deepEqual(m.flags.filter((f) => f.nodeId === "trigger:2"), [], "resolved in a legal tier: not dangling");
+  assert.ok(m.nodes.some((n) => n.id === "overlay:unrelated" && n.kind === "overlay"), "unreferenced overlay skills still enumerate, the injected-group precedent");
+});
+
+test("a flow that resolves only in a staged package lands on the FIRST manifest-order package's node", () => {
+  const inputs = CANNED();
+  inputs.stagedSkills = {
+    skills: [
+      { name: "deleted-flow", package: "@a/one", dir: "one" },
+      { name: "deleted-flow", package: "@b/two", dir: "two" },
+    ],
+    unenumerable: [],
+    truncated: false,
+  };
+  const m = buildGraphModel(inputs);
+  const edge = m.edges.find((e) => e.kind === "config" && e.from === "trigger:2");
+  assert.equal(edge.to, "staged:one:deleted-flow", "manifest order is loader order; the attribution matches doctor's staged probe");
+  assert.equal(m.nodes.find((n) => n.id === "staged:one:deleted-flow").package, "@a/one");
+  assert.ok(m.nodes.some((n) => n.id === "staged:two:deleted-flow" && n.kind === "staged"), "the shadowed twin still enumerates as its own node");
+  assert.deepEqual(m.flags.filter((f) => f.nodeId === "trigger:2"), []);
+});
+
+test("run.packages: false withholds the staged tier as a KNOWN miss, and the red detail says so", () => {
+  const inputs = CANNED();
+  inputs.stagedSkills = { skills: [{ name: "deleted-flow", package: "@a/one", dir: "one" }], unenumerable: [], truncated: false };
+  inputs.triggers.triggers[2].packages = false;
+  const m = buildGraphModel(inputs);
+  const flag = m.flags.find((f) => f.flag === "no-skill" && f.nodeId === "trigger:2");
+  assert.ok(flag, "the job would not load the tier either: withheld is a known miss, so red stays honest");
+  assert.ok(flag.detail.includes("withheld: run.packages false"), "the detail says why the staged tier could not have saved it");
+  assert.equal(m.edges.find((e) => e.kind === "config" && e.from === "trigger:2").to, "skill:folder:/srv/site:deleted-flow");
+});
+
+test("tiers this session cannot check soften the claim: skill-not-at-head, no flag, tiers named", () => {
+  const inputs = CANNED();
+  // The deployment pointer cannot carry PI_GLOBAL_PI_DIR, so a wizard-launched session reads both
+  // deployment-wide tiers as null -- unknown, never empty.
+  delete inputs.overlaySkills;
+  delete inputs.stagedSkills;
+  const m = buildGraphModel(inputs);
+  const node = m.nodes.find((n) => n.id === "skill:folder:/srv/site:deleted-flow");
+  assert.equal(node.kind, "skill-not-at-head", "absent at HEAD is true; the missing styling is the lie");
+  assert.deepEqual(node.tiersUnknown, ["overlay skills/", "staged packages"]);
+  assert.deepEqual(m.flags.filter((f) => f.flag === "no-skill"), [], "no dangling flag can honestly attach when a tier went unchecked");
+  assert.equal(m.edges.find((e) => e.kind === "config" && e.from === "trigger:2").to, node.id, "the config edge still draws, ALWAYS");
+});
+
+test("a pattern-manifest package makes a staged miss unknowable: softened, not red", () => {
+  const inputs = CANNED();
+  inputs.stagedSkills = { skills: [], unenumerable: ["@glob/pkg"], truncated: false };
+  const m = buildGraphModel(inputs);
+  const node = m.nodes.find((n) => n.id === "skill:folder:/srv/site:deleted-flow");
+  assert.equal(node.kind, "skill-not-at-head");
+  assert.deepEqual(node.tiersUnknown, ["staged packages"], "only the tier that could not be checked is named");
+  assert.deepEqual(m.meta.stagedUnenumerable, ["@glob/pkg"]);
+});
+
+test("stop-at-unknown: a hit below an unknown higher tier stays soft -- the edge claims identity, not existence", () => {
+  const inputs = CANNED();
+  inputs.injectedSkills["/broken"] = { skills: [], truncated: false, unreachable: "unreadable" };
+  inputs.overlaySkills = { skills: [{ name: "deleted-flow" }], truncated: false, unreachable: null };
+  inputs.triggers.triggers[2].skillsDir = "/broken";
+  const m = buildGraphModel(inputs);
+  const node = m.nodes.find((n) => n.id === "skill:folder:/srv/site:deleted-flow");
+  assert.equal(node.kind, "skill-not-at-head", "the unreadable injected dir may shadow the overlay hit; claiming the overlay node would be the wrong tick");
+  assert.equal(m.edges.find((e) => e.kind === "config" && e.from === "trigger:2").to, node.id);
+  assert.deepEqual(node.tiersUnknown, ["injected run.skillsDir"], "the tier that blocked the claim is the one named");
+});
+
+test("a truncated injected listing makes its miss unknowable: the name may sit past the cap", () => {
+  const inputs = CANNED();
+  inputs.injectedSkills["/inj"].truncated = true;
+  inputs.triggers.triggers[2].skillsDir = "/inj";
+  const m = buildGraphModel(inputs);
+  const node = m.nodes.find((n) => n.id === "skill:folder:/srv/site:deleted-flow");
+  assert.equal(node.kind, "skill-not-at-head");
+  assert.deepEqual(node.tiersUnknown, ["injected run.skillsDir"]);
+});
+
+test("red and softened claimants share one node: softened kind wins in either arrival order, the red trigger keeps its flag", () => {
+  const red = { type: "cron", index: 3, id: "red", pattern: "0 8 * * *", folder: "/srv/site", flow: "shared-gone", model: null, packages: true, image: null, skillsDir: null, instructions: false, resume: false };
+  const soft = { type: "cron", index: 4, id: "soft", pattern: "0 9 * * *", folder: "/srv/site", flow: "shared-gone", model: null, packages: true, image: null, skillsDir: "/broken", instructions: false, resume: false };
+  for (const pair of [[red, soft], [soft, red]]) {
+    const inputs = CANNED();
+    inputs.injectedSkills["/broken"] = { skills: [], truncated: false, unreachable: "unreadable" };
+    inputs.triggers.triggers.push(...pair);
+    const m = buildGraphModel(inputs);
+    const node = m.nodes.find((n) => n.name === "shared-gone");
+    assert.equal(node.kind, "skill-not-at-head", "red asserts definitively-nowhere, which the softened claimant's unknown tier refutes");
+    assert.deepEqual(node.tiersUnknown, ["injected run.skillsDir"]);
+    const noSkill = m.flags.filter((f) => f.flag === "no-skill").map((f) => f.nodeId);
+    assert.ok(noSkill.includes("trigger:3"), "the red claimant's flag rides its own trigger node and survives the shared target");
+    assert.ok(!noSkill.includes("trigger:4"), "the softened claimant is not dangling");
+  }
+});
+
+test("a forge trigger's flow matching an overlay name still renders unverified: the remote repo may shadow it", () => {
+  const inputs = CANNED();
+  inputs.overlaySkills = { skills: [{ name: "triage" }], truncated: false, unreachable: null };
+  const m = buildGraphModel(inputs);
+  const node = m.nodes.find((n) => n.id === "skill:forge:github:triage");
+  assert.equal(node.kind, "skill-unverified", "dim-with-no-claim stays the honest forge state; the repo tier outranks every checkable one");
+  assert.equal(m.edges.find((e) => e.kind === "config" && e.from === "trigger:1").to, node.id);
+});
+
+test("charset-invalid short-circuits the ladder: no tier probe can launder an unmaterialisable name", () => {
+  const inputs = CANNED();
+  inputs.triggers.triggers.push({ type: "cron", index: 3, id: "bad", pattern: "0 5 * * *", folder: "/srv/site", flow: "Tidy/../up", model: null, packages: true, image: null, skillsDir: "/inj", instructions: false, resume: false });
+  const m = buildGraphModel(inputs);
+  assert.ok(m.flags.some((f) => f.flag === "charset-invalid" && f.nodeId === "trigger:3"));
+  assert.ok(!m.nodes.some((n) => n.kind === "skill-not-at-head"), "no softened node for a name that can never materialise");
+});
+
+test("potential edges stay repo-only: a mention of an overlay-resolved name draws nothing", () => {
+  const inputs = CANNED();
+  inputs.overlaySkills = { skills: [{ name: "global-helper" }], truncated: false, unreachable: null };
+  inputs.folderSkills["/srv/site"].skills[0].mentions.push({ name: "global-helper", strong: true });
+  const m = buildGraphModel(inputs);
+  assert.equal(m.edges.filter((e) => e.kind === "potential").length, 1, "only the committed sibling mention draws; the chain gate could never fire an overlay flow");
+});
+
+test("meta carries the tier honesty counters, and tier caps join the skills-truncation bit", () => {
+  const inputs = CANNED();
+  inputs.overlaySkills = { skills: [], truncated: false, unreachable: "unreadable" };
+  inputs.stagedSkills = { skills: [], unenumerable: ["@b/two", "@a/one"], truncated: true };
+  const m = buildGraphModel(inputs);
+  assert.equal(m.meta.overlayUnreachable, true);
+  assert.deepEqual(m.meta.stagedUnenumerable, ["@a/one", "@b/two"], "sorted for determinism");
+  assert.equal(m.meta.truncated.skills, true);
+  const base = buildGraphModel(CANNED());
+  assert.equal(base.meta.overlayUnreachable, false);
+  assert.deepEqual(base.meta.stagedUnenumerable, []);
+});
+
+test("junk tier inputs degrade to unknown-tier behaviour, never a throw", () => {
+  const inputs = CANNED();
+  inputs.overlaySkills = "x";
+  inputs.stagedSkills = 42;
+  const m = buildGraphModel(inputs);
+  const node = m.nodes.find((n) => n.id === "skill:folder:/srv/site:deleted-flow");
+  assert.equal(node.kind, "skill-not-at-head", "a malformed read proves nothing; only a well-formed result can produce a known miss");
 });

--- a/admin/test/insights-html.test.mjs
+++ b/admin/test/insights-html.test.mjs
@@ -35,6 +35,10 @@ const CANNED = () => ({
     },
   },
   injectedSkills: { "/inj": { skills: [{ name: "tidy", aiTrigger: true }], truncated: false, unreachable: null } },
+  // Known-empty tier reads (issue #188), mirroring the two graph suites: deleted-flow stays a KNOWN
+  // miss (red), so the topology pane's pins keep their meaning.
+  overlaySkills: { skills: [], truncated: false, unreachable: null },
+  stagedSkills: { skills: [], unenumerable: [], truncated: false },
   forgeRepos: { github: ["acme/website", "acme/api"] },
   cronStats: { byId: { nightly: { runs: 41, lastOutcome: "completed", lastEndedAt: "2026-08-11T00:00:00.000Z" }, gone: { runs: 0, lastOutcome: null, lastEndedAt: null } } },
   runJoin: { byIndex: { 1: { runs: 12, lastOutcome: "completed", lastEndedAt: "2026-08-11T01:00:00.000Z" } }, unattributed: 2 },

--- a/admin/test/read-model.test.mjs
+++ b/admin/test/read-model.test.mjs
@@ -34,6 +34,8 @@ import {
   observedChainEdges,
   readFolderSkills,
   readInjectedSkills,
+  readOverlaySkills,
+  readStagedSkillsList,
   collectGraphInputs,
   forgeRepoTargets,
 } from "../src/read-model.mjs";
@@ -1264,7 +1266,7 @@ test("GRAPH_LIMITS is the LITERAL reviewed numbers, frozen", () => {
   // the numbers on purpose and say why in the commit body.
   assert.deepEqual(
     { ...GRAPH_LIMITS },
-    { maxFoldersScanned: 16, maxSkillsPerFolder: 64, maxSkillBytes: 65536, maxMentionScanBytes: 32768, maxEdges: 200, windowDays: 30, maxReposListed: 5 },
+    { maxFoldersScanned: 16, maxSkillsPerFolder: 64, maxSkillBytes: 65536, maxMentionScanBytes: 32768, maxEdges: 200, windowDays: 30, maxReposListed: 5, maxStagedSkills: 64 },
   );
   assert.ok(Object.isFrozen(GRAPH_LIMITS));
 });
@@ -1631,9 +1633,119 @@ test("collectGraphInputs dedupes folders and skills dirs, caps folders, and says
 });
 
 test("collectGraphInputs degrades on bad input", () => {
-  assert.deepEqual(collectGraphInputs({}), { folderSkills: {}, injectedSkills: {}, foldersTruncated: false });
-  assert.deepEqual(collectGraphInputs(), { folderSkills: {}, injectedSkills: {}, foldersTruncated: false });
-  assert.deepEqual(collectGraphInputs({ triggers: "nope" }), { folderSkills: {}, injectedSkills: {}, foldersTruncated: false });
+  const empty = { folderSkills: {}, injectedSkills: {}, overlaySkills: null, stagedSkills: null, foldersTruncated: false };
+  assert.deepEqual(collectGraphInputs({}), empty);
+  assert.deepEqual(collectGraphInputs(), empty);
+  assert.deepEqual(collectGraphInputs({ triggers: "nope" }), empty);
+});
+
+test("collectGraphInputs reads the two deployment-wide tiers once, and only when globalPiDir is visible (issue #188)", () => {
+  const calls = [];
+  const readOverlay = ({ globalPiDir }) => { calls.push(["overlay", globalPiDir]); return { skills: [{ name: "g" }], truncated: false, unreachable: null }; };
+  const readStaged = ({ globalPiDir }) => { calls.push(["staged", globalPiDir]); return { skills: [], unenumerable: [], truncated: false }; };
+  const triggers = [
+    { type: "cron", folder: "/f0", skillsDir: null },
+    { type: "cron", folder: "/f1", skillsDir: null },
+  ];
+  const readFolder = () => ({ head: "h", skills: [], truncated: false, unreachable: null });
+
+  const out = collectGraphInputs({ triggers, globalPiDir: "/gpd", readFolder, readOverlay, readStaged });
+  assert.deepEqual(calls, [["overlay", "/gpd"], ["staged", "/gpd"]], "one read per tier per build, however many triggers");
+  assert.deepEqual(out.overlaySkills, { skills: [{ name: "g" }], truncated: false, unreachable: null });
+  assert.deepEqual(out.stagedSkills, { skills: [], unenumerable: [], truncated: false });
+
+  // Null globalPiDir (the deployment pointer cannot carry PI_GLOBAL_PI_DIR): the tier keys stay
+  // null, meaning "not checkable from this session", NEVER an empty-but-known shape.
+  const blind = collectGraphInputs({ triggers, readFolder, readOverlay, readStaged });
+  assert.equal(blind.overlaySkills, null);
+  assert.equal(blind.stagedSkills, null);
+  const blank = collectGraphInputs({ triggers, globalPiDir: "", readFolder, readOverlay, readStaged });
+  assert.equal(blank.overlaySkills, null, "empty string reads as unset, the resolvePaths || null rule");
+});
+
+test("readOverlaySkills lists the overlay's skills/: charset-filtered, SKILL.md required, existence-only", () => {
+  const dirs = { "/gpd/skills": ["tidy", "plain", "Bad.Name", "empty"] };
+  const present = new Set(["/gpd/skills/tidy/SKILL.md", "/gpd/skills/plain/SKILL.md"]);
+  const fs = {
+    readdirSync: (dir) => dirs[dir] ?? (() => { throw new Error("unrouted"); })(),
+    existsSync: (p) => present.has(p),
+  };
+  const out = readOverlaySkills({ globalPiDir: "/gpd", fs });
+  assert.deepEqual(out, {
+    skills: [{ name: "plain" }, { name: "tidy" }],
+    truncated: false,
+    unreachable: null,
+  }, "Bad.Name fails the charset, empty has no SKILL.md; no frontmatter is read on purpose");
+});
+
+test("readOverlaySkills: ENOENT is a KNOWN-EMPTY overlay, every other failure is unreadable", () => {
+  const enoent = () => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }); };
+  assert.deepEqual(
+    readOverlaySkills({ globalPiDir: "/gpd", fs: { readdirSync: enoent, existsSync: () => false } }),
+    { skills: [], truncated: false, unreachable: null },
+    "an overlay carrying only models.json is a legal deployment, not an unknown tier",
+  );
+  assert.deepEqual(
+    readOverlaySkills({ globalPiDir: "/gpd", fs: { readdirSync: () => { throw new Error("EACCES"); }, existsSync: () => false } }),
+    { skills: [], truncated: false, unreachable: "unreadable" },
+    "a failed read proves nothing: the ladder must treat this tier as unknown",
+  );
+  assert.deepEqual(readOverlaySkills({}), { skills: [], truncated: false, unreachable: null });
+  assert.deepEqual(readOverlaySkills({ globalPiDir: "" }), { skills: [], truncated: false, unreachable: null });
+});
+
+test("readOverlaySkills caps the listing and says so", () => {
+  const names = Array.from({ length: GRAPH_LIMITS.maxSkillsPerFolder + 1 }, (_, i) => `s${String(i).padStart(3, "0")}`);
+  const fs = { readdirSync: () => names, existsSync: () => true };
+  const out = readOverlaySkills({ globalPiDir: "/gpd", fs });
+  assert.equal(out.skills.length, GRAPH_LIMITS.maxSkillsPerFolder);
+  assert.equal(out.truncated, true, "a truncated listing's miss must read as unknown, so the cap is stated");
+});
+
+test("readStagedSkillsList adapts the worker reader's seams and preserves manifest order", () => {
+  const seen = [];
+  const readStaged = ({ globalPiDir, readFile, fileExists, readDir }) => {
+    // The worker seams must be REAL functions adapted from fs -- the Dirent contract included.
+    assert.equal(globalPiDir, "/gpd");
+    assert.equal(typeof readFile, "function");
+    assert.equal(typeof fileExists, "function");
+    assert.equal(typeof readDir, "function");
+    seen.push("called");
+    return {
+      skills: [
+        { name: "zeta", package: "@a/one", dir: "one" },
+        { name: "alpha", package: "@b/two", dir: "two" },
+        { name: "zeta", package: "@b/two", dir: "two" },
+        { name: "Bad.Name", package: "@b/two", dir: "two" },
+        { name: "dup", package: "@a/one", dir: "one" },
+        { name: "dup", package: "@a/one", dir: "one" },
+      ],
+      unenumerable: ["@z/glob", "@a/glob"],
+    };
+  };
+  const out = readStagedSkillsList({ globalPiDir: "/gpd", readStaged });
+  assert.deepEqual(seen, ["called"]);
+  assert.deepEqual(out.skills, [
+    { name: "zeta", package: "@a/one", dir: "one" },
+    { name: "alpha", package: "@b/two", dir: "two" },
+    { name: "zeta", package: "@b/two", dir: "two" },
+    { name: "dup", package: "@a/one", dir: "one" },
+  ], "manifest order is loader order -- resolution takes the first name match, so this list must not re-sort; per-dir dupes and charset failures drop");
+  assert.deepEqual(out.unenumerable, ["@a/glob", "@z/glob"], "unenumerable is display-only, so it sorts");
+  assert.equal(out.truncated, false);
+});
+
+test("readStagedSkillsList degrades: unset dir, throwing seams, junk shapes, and the cap", () => {
+  const empty = { skills: [], unenumerable: [], truncated: false };
+  assert.deepEqual(readStagedSkillsList({}), empty);
+  assert.deepEqual(readStagedSkillsList({ globalPiDir: "" }), empty);
+  assert.deepEqual(readStagedSkillsList({ globalPiDir: "/gpd", readStaged: () => { throw new Error("boom"); } }), empty);
+  assert.deepEqual(readStagedSkillsList({ globalPiDir: "/gpd", readStaged: () => "junk" }), empty);
+
+  const many = Array.from({ length: GRAPH_LIMITS.maxStagedSkills + 1 }, (_, i) => ({ name: `s${String(i).padStart(3, "0")}`, package: "@a/one", dir: "one" }));
+  const out = readStagedSkillsList({ globalPiDir: "/gpd", readStaged: () => ({ skills: many, unenumerable: [] }) });
+  assert.equal(out.skills.length, GRAPH_LIMITS.maxStagedSkills);
+  assert.equal(out.truncated, true);
 });
 
 test("forgeRepoTargets lists each forge's repos from record targets, capped and sorted", () => {

--- a/admin/test/render.test.mjs
+++ b/admin/test/render.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { renderStatus, renderRuns, renderBudget, renderTriggers, renderSettingsView, renderWhatIf } from "../src/render.mjs";
+import { renderStatus, renderRuns, renderBudget, renderTriggers, renderSettingsView, renderWhatIf, commandSlashLabel } from "../src/render.mjs";
 
 test("render.mjs has no path to raw .log content", () => {
   const src = readFileSync(fileURLToPath(new URL("../src/render.mjs", import.meta.url)), "utf8");
@@ -163,6 +163,16 @@ test("renderTriggers shows a command trigger as /name in the flow position; flow
   // Neither flow nor command (a degraded display record) keeps the "-" placeholder.
   const neither = renderTriggers({ schedulers: [], triggers: { triggers: [{ ...command, command: null }] } });
   assert.match(neither, /comment {2}"@pi deploy" → -$/m);
+});
+
+test("commandSlashLabel is the one /name vocabulary every surface shares (issue #188)", () => {
+  // Exported so the list line here, the TUI's target column and the drill-in header cannot drift on
+  // what a command trigger is called: three renderings, one token rule.
+  assert.equal(commandSlashLabel({ command: "deploy prod --now" }), "/deploy");
+  assert.equal(commandSlashLabel({ command: "  wf  run " }), "/wf", "surrounding whitespace never reaches the token");
+  assert.equal(commandSlashLabel({ command: "" }), null);
+  assert.equal(commandSlashLabel({ flow: "fix" }), null, "a flow trigger has no slash label");
+  assert.equal(commandSlashLabel(null), null);
 });
 
 test("renderTriggers marks a packages-loading trigger and leaves a declining one unchanged", () => {

--- a/docs/global-pi-overlay.md
+++ b/docs/global-pi-overlay.md
@@ -247,7 +247,10 @@ file.
 `.pi/skills` at HEAD, an injected `run.skillsDir`, the overlay's `skills/`, or a staged package -- and warns
 (never fails) when it resolves in no tier this host can see: such a job runs without the flow it names, logs
 `flow_not_loaded` in the container, and still exits 0. A flow that resolves only in a staged package is a
-plain checkmark naming the package.
+plain checkmark naming the package. The insights topology tells the same story visually
+([`graph.md`](graph.md)): overlay and staged-package skills render as their own node groups when the
+session can see `PI_GLOBAL_PI_DIR`, and a trigger whose flow lives in one gets its edge drawn there
+instead of a false "missing" claim.
 
 `doctor` also compares your **host** against the overlay, and all four of these are warnings rather than
 failures, because running a narrower set on a deployment than on your laptop is a legitimate choice:

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -79,7 +79,8 @@ count under `runs unattributed`, and never land on whatever entry now occupies t
 
 | badge | meaning |
 |---|---|
-| `[no-skill: flow absent at HEAD]` | the trigger names a flow that does not exist in the folder's committed `.pi/skills/` |
+| `[no-skill]`, red dashed | the flow is absent in **every tier the session could check** — the folder's committed `.pi/skills/` at HEAD, the trigger's own `run.skillsDir`, the overlay `skills/`, the staged packages — and the detail names the tiers checked |
+| `[not at HEAD]`, amber dashed | absent at HEAD, but at least one tier was **not checkable from this session** (no `PI_GLOBAL_PI_DIR` in this session's env, an unreadable listing, a pattern-manifest package); the tip names what went unchecked |
 | `[invalid flow name: can never materialise]` | the flow name fails the skill charset; no commit can ever satisfy it |
 | `[chainable]` | the skill's `SKILL.md` carries `ai-trigger: allow` at HEAD |
 | `[AI-reachable, no trigger]` | no trigger names it, but chaining and `dispatch_run` can reach it; not an orphan |
@@ -88,14 +89,34 @@ count under `runs unattributed`, and never land on whatever entry now occupies t
 | `[SKILL.md unread]` | the enumeration could not read it; the gate is reported closed, not guessed |
 | `[spend-loop risk]` | a `pull_request` trigger on `opened`/`synchronize`: a flow that pushes can loop with another bot (`OQ-020`) |
 | injected skills section | `run.skillsDir` skills are trigger-reachable and never AI-reachable; an injected `ai-trigger: allow` is a silent no-op and says so (`OQ-022`) |
+| overlay / staged package sections | the deployment overlay's `skills/` and each staged package's skills, when the session can see `PI_GLOBAL_PI_DIR`; same trigger-reachable, never-AI-reachable truth as injected |
+
+## Where a flow resolves
+
+`run.flow` is resolved by the container's loader across four tiers — the serviced repo's committed
+`.pi/skills` at HEAD, the trigger's injected `run.skillsDir`, the overlay `skills/`, the staged
+packages, in that precedence order — and the graph resolves each config edge the same way, per
+trigger. A flow living below the repo lands its edge on the tier node that holds it (no flag; the
+flow runs fine), which is why an injected-only or overlay-only flow no longer renders as a red
+missing node. A tier node is claimed only when every tier above it was checked and missed: an edge
+asserts *which file the job loads*, and where a higher tier is unknowable the claim softens to
+`[not at HEAD]` instead of guessing. `doctor` answers the same question more deeply, per trigger and
+per tier, on the worker host; the runner's `flow_not_loaded` log line is the exact in-container
+answer both surfaces approximate.
 
 ## Honesty at the edges of the data
 
-The enumeration reads the git **object store at HEAD**, the same read the worker trusts, never the
-working tree. A folder that cannot be read renders `unverified` and produces **no** dangling flags: a
-read that never happened proves nothing. Forge repos are not on the admin host at all, so their flows
-render under `skills unverifiable from the admin host`. Every cap and truncation states itself: a
-folder scan stopped at its cap says the unlisted folders are unscanned, not empty.
+The repo enumeration reads the git **object store at HEAD**, the same read the worker trusts, never
+the working tree; the injected, overlay and staged tiers are host-side directory reads, labelled by
+their sections. A folder that cannot be read renders `unverified` and produces **no** dangling flags:
+a read that never happened proves nothing — the same rule that softens a dangling claim to
+`[not at HEAD]` when a tier is unreadable, truncated, or simply not visible from the session
+(a wizard-launched console has no `PI_GLOBAL_PI_DIR`; export it to the session if you want the graph
+to see the overlay and staged tiers). Forge repos are not on the admin host at all, so their flows
+render under `skills unverifiable from the admin host` even when an overlay or staged skill shares
+the name: the remote repo outranks every tier this host can read. Every cap and truncation states
+itself: a folder scan stopped at its cap says the unlisted folders are unscanned, not empty, an
+unreadable overlay or a pattern-manifest package banners in the legend.
 
 The display is advisory. The chain gate's truth is read at each run's own pinned commit, before the
 agent runs; the graph shows what the *next* run would see.

--- a/docs/insights.md
+++ b/docs/insights.md
@@ -73,5 +73,10 @@ always printed first. `scp` the file to your desktop and open it there.
   control re-reads the file so an open tab follows your re-runs.
 - Everything the [`costs.md`](costs.md) honest-limits section says holds here too: totals are
   floors, pre-ledger runs are counted rather than guessed at, and history is never re-priced.
+- The topology's tier visibility depends on this session's environment: the overlay and
+  staged-package skill tiers enumerate only when `PI_GLOBAL_PI_DIR` is set for the session running
+  `/dispatch insights` (the deployment pointer deliberately cannot carry it), and a flow the visible
+  tiers miss renders the amber `[not at HEAD]` state rather than a red claim — see
+  [`graph.md`](graph.md).
 - The what-if is the `/dispatch insights whatif <provider/model> --flow <flow>` command: an
   estimate wants the full priced catalog, and tab completion offers it.

--- a/specs/design.md
+++ b/specs/design.md
@@ -925,7 +925,15 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   already-scanned run records into the per-trigger and flow→flow joins (`cronRunStats`,
   `joinRunsToTriggers`, `observedChainEdges`) — all never-throw, degrading per folder, bounded by the
   literal-pinned `GRAPH_LIMITS`, and all inside `read-model.mjs`, so the dashboard's fs ban and the
-  `.log` placement boundary are untouched. The enumeration is **display-advisory**: the chain gate's
+  `.log` placement boundary are untouched. Issue #188 grew the same surface by the two deployment-wide
+  tiers, in the same posture: `readOverlaySkills` (a working-tree readdir of the overlay `skills/`,
+  existence-only — no frontmatter read, because the flag vocabulary is closed and "never AI-reachable"
+  already rides the tip; ENOENT is a legal models-only overlay, so it reads known-empty, while any
+  other failure reads unknown) and `readStagedSkillsList` (the worker's own `readStagedSkills` behind
+  the `readStagedPackages` wrapper doctrine, manifest order preserved because it is the loader's
+  shadowing order), both null — "not checkable from this session", never "empty" — when
+  `PI_GLOBAL_PI_DIR` is not visible, one read each per graph build, capped by the same literal-pinned
+  `GRAPH_LIMITS`. The enumeration is **display-advisory**: the chain gate's
   truth stays `readFlowGate` at a pre-agent sha (`DES-AI-TRIGGER-FLOW-GATE`), and no graph badge is a
   gate decision.
 - **Why**:
@@ -1113,9 +1121,15 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   (`buildGraphModel`, `admin/src/graph-model.mjs`) over the read-model's outputs, and every edge it
   emits is labelled by its **evidence class**, drawn from a closed, test-pinned vocabulary:
   - **`config`** — trigger → flow, from the live triggers file. Every trigger naming a `run.flow`
-    gets exactly one, **always** — dangling, unverifiable and charset-invalid included; a target the
-    enumeration did not find exists as a `skill-missing` (enumerated folder) or `skill-unverified`
-    (forge repo / unreachable folder) node so the edge has a visible end.
+    gets exactly one, **always** — dangling, unverifiable and charset-invalid included. Resolution is
+    **tier-aware** (issue #188): the repo enumeration first, then — for a cron trigger whose folder
+    read succeeded — the trigger's injected `run.skillsDir`, the overlay `skills/` and the staged
+    packages, in the loader's own precedence order, so a flow legally living below the repo lands its
+    edge on the `injected`/`overlay`/`staged` node that tier enumerates instead of a red twin. A
+    target no checkable tier holds exists as a `skill-missing` (every applicable tier checked and
+    missed), `skill-not-at-head` (absent at HEAD, some tier not checkable from this session — amber,
+    `tiersUnknown` named in the tip) or `skill-unverified` (forge repo / unreachable folder) node so
+    the edge has a visible end.
   - **`observed`** — flow → flow, from run records only (`parentJobId` joins), folded per flow pair
     with its **count and last occurrence**. An observed edge exists because a run actually spawned
     another, never because one could. Same-target only; an edge that cannot be hung on exactly one
@@ -1132,10 +1146,20 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   trigger's flow** (a forge job gets no `/outbox` mount), and **no chain edge ever crosses
   folders** (the child folder is forced to the parent's own) — the harness makes both
   unrepresentable, so the graph never renders either. Dangling is precise: `no-skill` flags only
-  where enumeration **succeeded** and the path is absent at HEAD (the gate's own token); an
+  where **every applicable tier was checked and missed** (issue #188 widened the gate's own token
+  from one enumeration to the whole ladder, and the detail names the tiers checked — a trigger's
+  `run.packages: false` withholds the staged tier as a known miss, worded as such); an
   unreachable or remote folder renders **unverified**, never dangling, and a `run.flow` failing
   `SKILL_NAME_RE` is its own `charset-invalid` flag — the gate would answer `deny` for it, and
-  deny proves nothing about existence. Orphanhood is three distinct facts, not one: `orphan` (no
+  deny proves nothing about existence. The ladder **stops at an unknown tier**, deliberately
+  diverging from doctor: doctor answers the existential "does the name resolve anywhere", which a
+  hit below an unknown tier satisfies regardless of what shadows it, so doctor probes past unknowns
+  (`DES-FLOW-RESOLUTION-TWO-ADVISORY-LAYERS`); a config edge asserts node **identity** — "the job
+  loads THIS file" — and claiming a lower-tier node under an unknown higher tier is exactly the
+  wrong tick that spec forbids. An unknown tier (a session without `PI_GLOBAL_PI_DIR` — the
+  deployment pointer deliberately cannot carry it — an unreadable listing, a truncated one whose
+  miss may sit past the cap, a pattern-manifest package) therefore softens the claim to
+  `skill-not-at-head`, never resolves and never flags. Orphanhood is three distinct facts, not one: `orphan` (no
   trigger, no `ai-trigger`, no incoming mention), `ai-reachable-no-trigger` (deliberately
   chain/dispatch_run-reachable), and `injected-ai-trigger` (the `OQ-022` silent no-op, badged
   loudly). Sub-skills are never orphan candidates — the gate's path template has no room for them.
@@ -1162,7 +1186,16 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
     operator to delete a trigger whose skill exists.
   - *Resolving ambiguous observed-edge targets by first match* — pins real history onto the wrong
     folder's skills; dropped-and-counted is honest, guessed is not.
+  - *Claiming a lower-tier node under an unknown higher tier* (issue #188) — doctor's existential ✓
+    survives an unknown above a hit; an identity edge does not, because the unknown tier may shadow
+    the hit at load time and the edge would point at content the job never runs. Softened, not
+    resolved.
+  - *A new flag or edge kind for tier resolution* (issue #188) — `REQ-TOPOLOGY-GRAPH` (h) promises
+    the closed vocabularies stay closed, and resolution honesty fits in node kinds and node facts;
+    the kinds themselves became the third closed pinned set instead of staying an informal literal
+    scatter.
 - **Traces to**: `DES-ADMIN-VIA-PI-EXTENSION`, `DES-JOB-OUTBOX-CHAINING`, `DES-AI-TRIGGER-FLOW-GATE`,
+  `DES-FLOW-RESOLUTION-TWO-ADVISORY-LAYERS`, `REQ-GLOBAL-PI-OVERLAY`, `REQ-PER-TRIGGER-SKILLS`,
   `OQ-008`, `OQ-009`, `OQ-022`, `INT-RUN-HISTORY-FILE-CONTRACT`; implemented in
   `admin/src/graph-model.mjs` (`buildGraphModel`) over `admin/src/read-model.mjs`'s graph readers.
 
@@ -1331,7 +1364,10 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   burn the reserved budget slot per refusal, paying for zero work on every delivery of a misconfigured
   trigger). The check sits at the pre-spend moment anyway, so flipping report to refusal is a one-line
   change plus a row here. The residual is stated: an advisory line at 03:00 helps only an operator who
-  reads logs; doctor's per-trigger lines are the layer that reaches them earlier.
+  reads logs; doctor's per-trigger lines are the layer that reaches them earlier, and (issue #188) the
+  topology renders the same host-side approximation as a third advisory surface — with one deliberate
+  divergence recorded on `DES-GRAPH-EDGE-DERIVATION`: doctor's ✓ is existential and probes past an
+  unknown tier, while a config edge claims node identity and therefore stops at one.
 - **Rejected**: failing worker/receiver **boot** on an unresolved flow (`parseTriggers` is pure and
   fs-free by `DES-TRIGGERS-UNIFIED-FILE`, the receiver may run on a host with no repo, and overlay and
   package tiers make "absent at HEAD" a legal steady state); carrying the flow in `event.json` (an
@@ -2088,6 +2124,7 @@ a tunnel.
 
 | Date | Change |
 |---|---|
+| 2026-08-13 | Issue #188 (topology: tier-aware config-edge resolution). **DES-GRAPH-EDGE-DERIVATION AMENDED**: the config bullet's edge-end fallback set grows the tier nodes and the amber `skill-not-at-head` state; the dangling doctrine is rewritten around the per-trigger precedence ladder (repo > injected > overlay > staged) with `no-skill` demanding every applicable tier checked-and-missed; the stop-at-unknown rule is recorded WITH its doctor divergence (existential ✓ probes past an unknown, identity edge stops at one) as the load-bearing why; Rejected grows *claiming a lower-tier node under an unknown higher tier* and *a new flag or edge kind for tier resolution* (the closed vocabularies stay closed; node kinds became the third closed pinned set instead). **DES-ADMIN-VIA-PI-EXTENSION AMENDED**: the graph data surface gains `readOverlaySkills` (existence-only, ENOENT = legal models-only overlay = known-empty, other failures = unknown) and `readStagedSkillsList` (the worker's own reader behind the `readStagedPackages` wrapper doctrine, manifest order preserved as loader shadowing order), both null-means-not-checkable when `PI_GLOBAL_PI_DIR` is invisible (the deployment pointer deliberately cannot supply it), same never-throw/`GRAPH_LIMITS`/display-advisory posture. **DES-FLOW-RESOLUTION-TWO-ADVISORY-LAYERS AMENDED** (one sentence): the topology joins doctor as the residual's third advisory surface, divergence cross-referenced. **DES-AI-TRIGGER-FLOW-GATE UNCHANGED, checked** -- AI-reachability stays committed-repo-only; tier nodes carry no `aiTrigger` and no chainable badge, and `potential`-edge eligibility still reads only the repo enumeration. |
 | 2026-08-13 | Issue #189 (closing pass: package prompt templates, OQ-019 deferral (b)). **DES-COMMAND-ENTRY-POINT AMENDED**: the template half of the /name fall-through hazard recorded and closed -- `getCommand()` forecloses the unregistered case, `promptsOverride` forecloses a package template shadowing a protected one, so both halves of what /name runs are pinned to reviewed content. **DES-OPERATOR-GLOBAL-OVERLAY UNCHANGED, checked** -- the overlay's trust class and mount are untouched; it gained a resource kind through the existing mount. **DES-FLOW-RESOLUTION-TWO-ADVISORY-LAYERS UNCHANGED, checked** -- skills-tier resolution is untouched by the prompts work. |
 | 2026-08-13 | Issue #189 (Gap 2, producer half: `run.command` in the triggers file). **DES-COMMAND-ENTRY-POINT AMENDED** with the producer-half decisions: legal on ALL FOUR trigger kinds (`run.skillsDir`'s capability-of-the-deployment reasoning — a webhook trigger runs what a cron trigger runs), exactly one of `flow`/`command` enforced at parse by the shared validator; forge command prompts are the same bare `/<command> [args]` — the envelope bypassed whole, delivery context handler-read from `event.json`, `CONST-ISSUE-TEXT-IS-DATA` held and arguably strengthened since nothing payload-authored renders into a command prompt; the `cmd:`-prefixed dedup slot so a command rule never coalesces with a same-named flow rule; the `commands` capability gate now enforced worker-side pre-spend (`job-image-commands-unsupported`, the label's second direction); the comment trailing-word override INERT on a command rule; and `DES-TRIGGER-INSTRUCTION-IN-THE-ENVELOPE`'s byte-for-byte objection answered head-on — command prompts are NEW prompts, every existing flow trigger's `prompt.md` stays byte-identical. **DES-AI-TRIGGER-FLOW-GATE AMENDED**: the command clause joins the injected-skills paragraph's neighborhood — never AI-reachable, and BUILT at the two producers rather than falling out, because no committed artifact exists for the gate to read (`chain-command-refused` before the charset check, no opt-in; `dispatch_run` structurally incapable plus a readable slash-leading-flow refusal; `OQ-022`'s allowlist closing shape unchanged in spirit, with the inversion stated on that row). **DES-JOB-OUTBOX-CHAINING AMENDED**: the explicit refusal token joins the validation ladder; commands may chain OUT, nothing chains INTO a command — ignoring the key under unknown-keys would enqueue a flow the agent did not request. **DES-TRIGGER-INSTRUCTION-IN-THE-ENVELOPE AMENDED**: command jobs have no envelope, and `run.instructions` is refused beside `run.command` rather than left inert — the cron refusal's accepted-where-it-does-nothing hazard, arriving through a bypassed envelope; the entry's byte-for-byte reasoning survives because no existing prompt changes. **DES-TRIGGERS-UNIFIED-FILE UNCHANGED, checked** — the shared validator gains a field, and the one-validator doctrine is exactly what makes the mutual exclusion fail both services identically; no engine merges, and the on × run matrix is untouched. |
 | 2026-08-13 | Issue #189 (Gap 2, runner half). **NEW `DES-COMMAND-ENTRY-POINT`**: a trigger may dispatch a registered pi extension command; the runner's protocol ships first (env-authoritative `/command` prompt because pi's grammar fires only on a whole-text slash and a worker mismatch must not misclassify a flow job; pre-prompt `getCommand()` verification because an unregistered `/name` is not an error to pi and rides into a paid model call; handler throws observed via `extensionRunner.onError`, the pin's only channel, and classified retryable `command-error` by explicit user choice with the accepted cost stated; the fire-and-forget residual stated as pi's own contract; the `commands` image capability as the two-direction rollout gate, `replicas` pattern). The old docs premise ("nobody to type it inside a job") is recorded as contradicted by the pinned `session.prompt()` contract, proven by a keyless real-session pinned-contract test. **DES-FLOW-RESOLUTION-TWO-ADVISORY-LAYERS UNCHANGED, checked** — flows keep their advisory posture; a command's registration check is a REFUSAL because unlike a flow there is no hint-style steady state in which an unregistered command is legitimate. **DES-PER-TRIGGER-JOB-IMAGE UNCHANGED, checked** — the capability label mechanism is reused, not changed. **DES-TRIGGER-INSTRUCTION-IN-THE-ENVELOPE UNCHANGED, checked** — envelope semantics move with the producer half. |

--- a/specs/open-questions.md
+++ b/specs/open-questions.md
@@ -737,7 +737,10 @@ adversarial passes did.
 - **Status**: ACCEPTED, and it is the fail-CLOSED direction, so the risk of leaving it is nil. What it
   costs is an operator surprise rather than a hole, and the surprise has a sharp edge: an injected
   `SKILL.md` carrying `ai-trigger: allow` is never read, so the operator writes the opt-in and nothing
-  honours it. `doctor` warns when it finds one, which is the only thing that would have told them.
+  honours it. Three surfaces now say so: `doctor` warns when it finds one (originally the only thing
+  that would have told them), the topology badges the skill `injected-ai-trigger` (issue #54), and
+  since issue #188 the config edge of a trigger naming an injected-only flow lands on the injected
+  node itself — whose tip carries "never AI-reachable" — instead of a false red `no-skill`.
 - **The sibling asymmetry, with the inversion stated** (issue #189): `run.command` triggers are ALSO
   trigger-reachable and never AI-reachable — a chain request carrying a `command` key refuses outright
   (`chain-command-refused`, before the charset check) and `dispatch_run` cannot express one — but where
@@ -798,10 +801,55 @@ adversarial passes did.
 
 ---
 
+## OQ-025 — the topology's tier resolution carries the host-side approximation's residuals
+
+- **Question**: Issue #188 made config-edge resolution tier-aware (`REQ-TOPOLOGY-GRAPH` (a2)): the
+  graph now probes injected, overlay and staged tiers where this session can read them, softens to
+  `skill-not-at-head` where it cannot, and reserves red `no-skill` for every-tier-checked misses. The
+  probes are host-side approximations of what the loader will do in a container. Which residuals were
+  accepted, and what would move each?
+- **Status**: ACCEPTED, itemised, all display-only — the runner's `flow_not_loaded` line
+  (`DES-FLOW-RESOLUTION-TWO-ADVISORY-LAYERS`) is exact where every entry below approximates, so each
+  residual is bounded by a later, authoritative layer:
+  (1) **dir-basename naming**: every non-repo probe names a skill by its directory, and pi names it
+  `frontmatter.name || parentDirName` at the pin — a frontmatter rename can turn a would-be tier hit
+  into a softened or red claim, never mint a false hit (the one direction that matters). Closing it
+  means parsing frontmatter in three readers for a rename nobody has shipped; the runner line already
+  catches the real thing.
+  (2) **pointer blindness**: `POINTER_ENV_ALLOWLIST` deliberately excludes `PI_GLOBAL_PI_DIR`, so a
+  wizard-launched console softens every overlay/staged question — including on a deployment that has
+  no overlay at all, whose genuinely deleted flows now render amber rather than red. Deliberate: the
+  session cannot distinguish the two nulls, and a false red on a wizard+overlay deployment is the bug
+  class #188 exists to kill. Widening the allowlist is the close, and it is a reviewed policy edit
+  (the pointer is wizard-written; adding a path var lets it aim the console's fs reads), not a bug fix
+  to slip in.
+  (3) **overlay/staged `ai-trigger: allow` is unbadged**: the readers are existence-only, so the
+  OQ-022-shaped silent no-op in those two tiers gets no orange badge — the tier tips carry the
+  categorical "never AI-reachable" instead, which is the user-facing truth. A badge would need either
+  frontmatter parsing plus a reused flag whose name says "injected", or a new flag the closed
+  vocabulary forbids. Doctor stays the deeper surface.
+  (4) **forge flows in non-repo tiers stay unverified**: a forge trigger's repo is unreadable from
+  this host and outranks every readable tier, so even an overlay hit renders dim-unverified — the
+  issue's own NOT-proposed list, restated here as accepted.
+  (5) **malformed stage manifest reads as nothing-staged**: `readStageManifest` yields null for
+  absent and malformed alike, and the display treats both as an empty tier, while the worker's job
+  path keeps last-known-good on a torn read — a transient window where the graph is redder than the
+  jobs. Bounded by the manifest being operator-written and the window being one re-stage.
+  (6) **repo-tier truncation predates**: a folder listing over `maxSkillsPerFolder` can still red a
+  flow past the cap — the pre-#188 behaviour, banner-covered ("skill enumeration truncated"), while
+  the three NEW tiers' truncated listings read as unknown and soften. Aligning the repo tier is a
+  one-line change waiting on anyone actually running 64+ top-level skills in one folder.
+- **What would reopen it**: a real deployment hitting (2) hard enough that operators ask for the
+  pointer to carry the overlay path — that is the allowlist review, not a topology change.
+- **Raised by**: issue #188.
+
+---
+
 ## Revision History
 
 | Date | Change |
 |---|---|
+| 2026-08-13 | Issue #188 (topology tier resolution). Added **OQ-025** (ACCEPTED, itemised): the six display-side residuals of probing skill tiers from the host — dir-basename naming (false soft possible, false hit impossible), deployment-pointer blindness to `PI_GLOBAL_PI_DIR` (wizard sessions soften rather than lie red; widening the allowlist is a reviewed policy edit, deliberately not done here), overlay/staged `ai-trigger: allow` unbadged (existence-only readers; the closed flag vocabulary stays closed and the tier tips carry the categorical truth), forge flows in non-repo tiers staying unverified (the remote repo outranks every readable tier), malformed stage manifest reading as nothing-staged where the job path keeps last-known-good, and the pre-existing repo-tier truncation false-red (banner-covered; the three new tiers soften on truncation instead). Each bounded by the runner's exact `flow_not_loaded` layer. **OQ-022 AMENDED** (prose correction): doctor's warn is no longer "the only thing that would have told them" — the topology badges `injected-ai-trigger` since issue #54, and since #188 the config edge itself lands on the injected node with its never-AI-reachable tip. **OQ-008 UNCHANGED, checked** — the graph still re-reads the live triggers file per build; tier reads added no cache. **OQ-009 UNCHANGED, checked** — tier nodes join config edges only; no chain edge gained a source or crossed a folder. |
 | 2026-08-13 | Issue #189 (closing pass). **OQ-019 AMENDED**: deferral (b) partially closed -- in-container prompt templates get the skills treatment (overlay channel, enforced precedence, per-root counting; commands counted post-session), themes stay count-only with the no-failure-mode-to-prevent reason stated, and the host-side ENABLEMENT mirror half of (b) still stands on OQ-018's argument. **OQ-018 UNCHANGED, checked** -- no new pi internal is mirrored; the enforcement rides declared loader seams. **OQ-022 UNCHANGED, checked**. |
 | 2026-08-13 | Issue #189 (Gap 2, producer half: `run.command`). **OQ-022 AMENDED**: the command asymmetry joins the row as the built-not-fallen-out sibling — a `run.command` trigger is trigger-reachable and never AI-reachable, refused at both model-reachable producers (`chain-command-refused` before the charset check; `dispatch_run` structurally incapable, its params `{folder, flow, task}` and a slash-leading flow refusing with a readable message) rather than falling out of an object-store miss, because a command has no committed artifact a gate could read: its dispatch line is BUILT from the reviewed `triggers.json`, so default-deny cannot be a frontmatter read and must be a refusal. The row's closing shape ("an explicit allowlist in the reviewed `triggers.json`") is unchanged in spirit and now covers both asymmetries. **OQ-008 UNCHANGED, checked** — command triggers reach the file through the same operator-typed, `parseTriggers`-validated, live-reloaded write path its resolution rests on, and no LLM tool gained a write (`dispatch_trigger_add`/`_edit` carry no `command` parameter). **OQ-019 UNCHANGED, checked, and its (b) stays open** — extension enablement mirroring is untouched by commands: a package the operator disabled registers no command, which now surfaces as the runner's pre-spend `command-unregistered` refusal instead of a job silently modelling the line as prose, so the row's cost/benefit call is if anything cheaper to leave; the skills/prompts/themes half remains deferred on its own terms. **OQ-009 UNCHANGED, checked** — a forge command job gets no `/outbox`, exactly as no forge job does; commands changed what a parent may BE, never who may chain. |
 | 2026-08-12 | Issue #181. **OQ-024 RESCOPED** from the graph export to the insights export: `graph html` is gone (REQ-GRAPH-HTML-EXPORT superseded into REQ-INSIGHTS-HTML-EXPORT) and the bare `/dispatch insights` is now the one command carrying the browser spawn; the question, the WATCH posture, the bounds (`--no-open`, the SSH/display skip, the printed URL as the contract) and what-would-close-it are all unchanged — only the surface name moved. |

--- a/specs/requirements.md
+++ b/specs/requirements.md
@@ -721,11 +721,25 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
 - **Statement**: The harness shall make the trigger/flow **topology** visible: the topology pane of the
   insights artifact (`REQ-INSIGHTS-HTML-EXPORT`, the one analytics surface) renders one assembled model
   (`DES-GRAPH-EDGE-DERIVATION`) of every trigger, every
-  enumerated skill, and every edge between them, grouped by folder. The surface informs; it changes
+  enumerated skill, and every edge between them, grouped by folder — and, since issue #188, the three
+  non-repo skill tiers the loader legally resolves from (`REQ-PER-TRIGGER-SKILLS`,
+  `REQ-GLOBAL-PI-OVERLAY`): injected `run.skillsDir` skills, the overlay's `skills/` and the staged
+  packages' skills each render as their own tier-labelled group where this session can enumerate them.
+  The surface informs; it changes
   nothing — no port, no database, no new dependency, all fs/redis access in the read-model. The
   **honesty rules are requirements, not conventions**:
   (a) every trigger naming a `run.flow` renders its config edge — dangling, unverifiable and
   charset-invalid included;
+  (a2) config-edge **resolution is tier-aware** (issue #188), probing the loader's precedence order
+  repo > injected > overlay > staged per trigger: a flow absent at HEAD but present in a lower tier
+  lands its edge on that tier's node with **no flag** (the flow runs fine; the tier node's tip carries
+  the never-AI-reachable half), a tier node is claimed only when every higher applicable tier is a
+  **known** miss (a config edge asserts node identity, and a wrong tick is the one direction an
+  advisory may not err in), a flow missing from every checkable tier while some applicable tier is
+  not checkable from this session renders the **`skill-not-at-head`** state — amber, naming the
+  unchecked tiers, never the red missing claim — and the red `no-skill` flag fires **only** when
+  every applicable tier was checked and missed, its detail naming the tiers checked (a trigger's own
+  `run.packages: false` withholds the staged tier as a known miss and the detail says so);
   (b) a cron trigger's run count and last outcome are **exact** over the stated window (the jobId
   join), and a forge trigger's come **only** from the persisted `triggerIndex` **and**
   `triggerType`, both of which must agree with the entry now at that index — a record whose index is
@@ -754,7 +768,11 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   honestly) and its **overdue** state from the scheduler's `overdueMs`, and a trigger carries the
   window's **typed spend** badge (`foldTriggerCosts`, keyed by the node id), rendered only through
   the shared cost formatter so a plan-covered trigger never reads `$0.00`; spend and schedule are
-  node **facts**: no new edge kind, no new flag, the closed vocabularies stay closed.
+  node **facts**: no new edge kind, no new flag, the closed vocabularies stay closed. Issue #188
+  honours that sentence literally: the edge and flag vocabularies are byte-unchanged by tier
+  resolution — what grew is the **node kinds** (`overlay`, `staged`, `skill-not-at-head`), which now
+  form their own closed, test-pinned set (`GRAPH_NODE_KINDS`) with a glyph-parity pin so a kind
+  without a renderer arm goes red in a unit test.
 - **Scope**: Display only, from the operator's session. The graph triggers nothing, writes nothing,
   and is deliberately **not** a model-callable tool: the enumeration spawns git per folder, and the
   topology is for the operator's eyes (`DES-CLI-SURFACE`'s ungated operator-typed tier).
@@ -764,6 +782,7 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   history (`REQ-COST-ANALYTICS`'s estimate-never-mislabeled-as-truth discipline, applied to
   topology).
 - **Traces to**: `DES-GRAPH-EDGE-DERIVATION`, `DES-ADMIN-VIA-PI-EXTENSION`,
+  `DES-FLOW-RESOLUTION-TWO-ADVISORY-LAYERS`, `REQ-PER-TRIGGER-SKILLS`, `REQ-GLOBAL-PI-OVERLAY`,
   `INT-RUN-HISTORY-FILE-CONTRACT`, `OQ-008`, `OQ-009`, `OQ-022`
 - **Acceptance**: Given a triggers file with a cron trigger whose folder enumeration succeeds and a
   label trigger, when the insights artifact renders, then the cron trigger shows exact run counts
@@ -771,9 +790,21 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   edges render;
   given a record whose `triggerIndex` exceeds the current file, then it counts as unattributed and
   attributes to no row; given a folder whose skills include one no trigger names, with no
-  `ai-trigger` and no mention, then it flags `orphan`; given a trigger whose flow is absent at HEAD
-  in an enumerated folder, then it flags `no-skill`, and given the folder is unreachable instead,
-  then it renders unverified with no dangling flag; given any output, then the caps line
+  `ai-trigger` and no mention, then it flags `orphan`; given a cron trigger whose flow is absent at
+  HEAD in an enumerated folder **and absent from every checkable applicable tier**, then it flags
+  `no-skill` with the checked tiers in the detail, and given the folder is unreachable instead,
+  then it renders unverified with no dangling flag;
+  given a cron trigger whose flow exists only in its `run.skillsDir`, then the config edge lands on
+  the existing `injected:<dir>:<name>` node, no `no-skill` flag is minted, no second node appears
+  for the name, and the tip still says never AI-reachable; given a flow that resolves only in the
+  overlay `skills/` or only in a staged package, then the edge lands on that tier's node likewise,
+  a staged resolution naming the first manifest-order package (the loader's own shadowing order);
+  given a session whose `PI_GLOBAL_PI_DIR` is not visible (the deployment pointer cannot carry it),
+  an unreadable tier listing, a truncated one, or a pattern-manifest package, then a flow missing
+  from the checkable tiers renders `skill-not-at-head` naming the unchecked tiers, never the red
+  missing claim; given a forge trigger whose flow matches an overlay or staged name, then it still
+  renders unverified — the remote repo outranks every tier this host can read;
+  given any output, then the caps line
   (`chain depth`, `per job`, `same folder only`, window) is present; given an observed chain edge,
   then its line carries `observed x<count>`, and no potential line carries a count.
 
@@ -969,7 +1000,10 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   refused **pre-spend** with `skills-dir-missing`, no token is minted and no budget slot is consumed.
   Given a directory that is empty or over a cap, the job is refused in prepare, before the budget, with
   the cap named. Given a flow that exists ONLY in an injected directory, a chain request or a
-  `dispatch_run` for it is refused, and `doctor` warns that an injected `ai-trigger: allow` is never read.
+  `dispatch_run` for it is refused, `doctor` warns that an injected `ai-trigger: allow` is never read,
+  and (issue #188) the topology lands the trigger's config edge on the injected skill's own node with
+  no dangling flag — the never-AI-reachable badge stays, the false `no-skill` goes
+  (`REQ-TOPOLOGY-GRAPH` (a2)).
   Given a job whose `run.flow` names a skill that NO loaded tier materialised — repo, injected, overlay
   or staged package — the runner emits one `flow_not_loaded` line (flow name and a loaded-skill count,
   never task content) before any session exists, so the silent-exit-0 shape is a failing test rather
@@ -1067,7 +1101,12 @@ and nothing about the box itself (`INT-CONTAINER-RUNTIME-CONTRACT`).
   package, because staged-only resolution is legal steady state, and a package whose `pi` manifest uses
   glob or override patterns is reported as not enumerable rather than guessed at (`readStagedSkills`
   mirrors pi's own manifest-vs-convention rule at the pin, including that a `pi` manifest without a
-  `skills` key contributes nothing).
+  `skills` key contributes nothing). The topology is the same story's display half (issue #188,
+  `REQ-TOPOLOGY-GRAPH` (a2)): where `PI_GLOBAL_PI_DIR` is visible to the console session, the overlay's
+  `skills/` and the staged packages' skills enumerate as their own tier-labelled node groups (the staged
+  reader shared with doctor, manifest order preserved because it is the loader's shadowing order), and
+  where it is not — the deployment pointer deliberately cannot carry `PI_GLOBAL_PI_DIR` — a dangling
+  claim softens to `skill-not-at-head` naming the unchecked tiers, never a false red.
 - **A third skill tier sits between the overlay and the repo** (`REQ-PER-TRIGGER-SKILLS`, issue #60).
   "Repo wins on conflict" is unchanged and now reads in full as **repo > injected > overlay**: a trigger's
   own `run.skillsDir` refines this deployment-wide overlay, because "for THIS trigger" is the narrower
@@ -1365,6 +1404,7 @@ wait-list working as designed, not a failure — see `README.md`.
 
 | Date | Change |
 |---|---|
+| 2026-08-13 | Issue #188 (topology: flows resolved from injected, overlay or staged-package skills rendered as missing). **REQ-TOPOLOGY-GRAPH AMENDED**: the statement gains the three non-repo tier groups and new honesty clause (a2) — config-edge resolution is tier-aware in loader precedence order (repo > injected > overlay > staged, per trigger); a lower-tier resolution lands the edge on the tier node with NO flag; a tier node is claimed only when every higher applicable tier is a KNOWN miss (a config edge asserts node identity, and a wrong tick is the one forbidden direction); unknown tiers soften a dangling claim to the new amber `skill-not-at-head` state naming what this session could not check (the deployment pointer deliberately cannot carry `PI_GLOBAL_PI_DIR`, so wizard-launched sessions soften rather than lie red); red `no-skill` fires only when every applicable tier was checked and missed, its detail naming the tiers, with `run.packages: false` a known withheld miss. Clause (h)'s "the closed vocabularies stay closed" survives LITERALLY: edges and flags are byte-unchanged; node kinds grew (`overlay`, `staged`, `skill-not-at-head`) and became their own closed pinned set (`GRAPH_NODE_KINDS`) with a glyph-parity pin. Acceptance rows reworded/added accordingly, including forge-unchanged (a remote repo outranks every host-readable tier, so forge flows stay unverified). **REQ-PER-TRIGGER-SKILLS AMENDED** (one acceptance clause): an injected-only flow's config edge lands on the injected node, unflagged, badge kept. **REQ-GLOBAL-PI-OVERLAY AMENDED** (one Why clause): the topology is doctor's display half — tier groups where `PI_GLOBAL_PI_DIR` is visible (staged reader shared with doctor, manifest order preserved as loader shadowing order), softened claims where it is not. **REQ-DEPLOYMENT-BOOTSTRAP UNCHANGED, checked** — no doctor change; display only. **REQ-AI-TRIGGERED-RUNS UNCHANGED, checked** — tier nodes carry no `aiTrigger`/chainable claim, and `potential`-edge eligibility stays committed-repo-only. |
 | 2026-08-13 | Issue #189 (closing pass: package prompt templates, OQ-019 deferral (b)). **REQ-GLOBAL-PI-OVERLAY AMENDED**: the overlay gains its `prompts/` channel (templates were the one resource kind with none), and "repo wins on conflict" is now stated as ENFORCED for prompt templates through `promptsOverride`, mirroring the skills enforcement, because pi merges package prompt paths first and path order alone cannot carry the promise. Themes stay count-only with the reason recorded on OQ-019. **REQ-PER-TRIGGER-SKILLS UNCHANGED, checked** -- injected skills are a skills-only tier; no prompt analog was added or implied. **REQ-DEPLOYMENT-BOOTSTRAP UNCHANGED, checked** -- no doctor change in this pass. |
 | 2026-08-13 | Issue #189 (Gap 2, producer half: `run.command`, the second trigger entry point). **REQ-AI-TRIGGERED-RUNS AMENDED**: commands are never AI-triggerable and there is no opt-in — the statement gains the outbox `command`-key refusal (`chain-command-refused`, ordered before the charset check) and `dispatch_run`'s structural incapability (`{folder, flow, task}` params; a slash-leading flow refuses with a readable message naming the distinction rather than falling through to `no-skill`); acceptance pins both as free, nothing-enqueued, no-budget-touched refusals. **REQ-CRON-SCHEDULED-JOBS AMENDED**: acceptance gains the entry-point clauses it is the end-to-end home for — a `run.command` trigger loads in BOTH services (the shared validator) and its emitted job dispatches headlessly with the prompt exactly `/<command> [args]`; both-or-neither of `flow`/`command` is a parse-time `piDispatchConfig` error in both services; an unregistered command refuses `command-unregistered` (exit 2, pre-work, never retried) before any model call. **REQ-TRIGGER-AUTHOR-GATE AMENDED**: the comment `<phrase> <flow>` trailing-word override is INERT on a command rule — trailing text neither retargets nor suppresses the command, riding only as `event.json` data — and the known-flows set is built from flow-carrying rules only, so a command name is never summonable by comment; acceptance pins the collaborator `@pi review` case running the rule's own command. **REQ-DEPLOYMENT-BOOTSTRAP UNCHANGED, checked** — doctor REPORTS command triggers (a count plus one in-container-verifiability advisory line) and fixes nothing; the closed fix tiers are untouched. |
 | 2026-08-13 | Issue #189 (Gap 1, doctor half: per-trigger flow-tier resolution lines). **REQ-PER-TRIGGER-SKILLS AMENDED**: acceptance gains the doctor clause — one line per distinct (flow, folder, skillsDir, packages) question naming the resolving tier, probed in loader precedence order (repo at HEAD via the gate's own ls-tree read but HEAD-resolved and degrading to unknown, injected dir, overlay `skills/`, staged packages), ⚠ never ✗ and never a fixAction when none resolves, tiers-checked vs not-checkable named, charset failures their own ⚠, comment triggers checked on the default flow only, zero triggers zero lines. **REQ-GLOBAL-PI-OVERLAY AMENDED**: the overlay `skills/` and staged-package tiers join doctor's obligations; staged-only resolution is a plain ✓ naming the package; `readStagedSkills` (worker/src/packages.mjs, never-throws, shared with issue #188's topology) mirrors pi's manifest-vs-convention rule at the pin including the manifest-without-skills-key null case, and pattern manifests read as not-enumerable rather than guessed. **REQ-DEPLOYMENT-BOOTSTRAP UNCHANGED, checked** — the new checks are warn-tier and carry no `fixAction`, so the tier ladder it defines is untouched. |


### PR DESCRIPTION
Closes #188.

## What

**Tier-aware config-edge resolution.** `run.flow` legally resolves in four tiers (repo `.pi/skills` at HEAD > injected `run.skillsDir` > overlay `skills/` > staged packages), but the topology consulted only the repo enumeration, so a flow living in any non-repo tier drew its edge to a red `skill-missing` node flagged `no-skill` ("absent at HEAD") — a false alarm for a flow that runs fine. In the sharpest case the true `injected:<dir>:<name>` node already existed in the same model, edge-less, while a red twin was minted beside it.

The config edge now resolves per trigger in the loader's own precedence order:

- A lower-tier hit lands the edge on that tier's node, **unflagged**; the tip keeps the trigger-reachable, never-AI-reachable truth. Overlay and staged skills enumerate as their own tier-labelled groups where the session can see `PI_GLOBAL_PI_DIR` (new `readOverlaySkills`; the worker's own `readStagedSkills` behind `readStagedSkillsList`, manifest order preserved because it is the loader's shadowing order).
- A tier node is claimed only when every higher applicable tier is a **known** miss. Doctor's existential ✓ probes past an unknown tier; a config edge asserts node identity and stops at one — the divergence is recorded on `DES-GRAPH-EDGE-DERIVATION`.
- Where a tier is not checkable (no `PI_GLOBAL_PI_DIR` in the session — the deployment pointer deliberately cannot carry it — an unreadable or truncated listing, a pattern-manifest package), a dangling claim softens to the new amber `skill-not-at-head` state naming the unchecked tiers, never the red missing claim.
- Red `no-skill` now requires **every applicable tier checked and missed**, its detail names the tiers, and `run.packages: false` reads as the known withheld miss it is.
- Forge triggers keep `skill-unverified`: the remote repo outranks every host-readable tier.

The closed edge and flag vocabularies are **byte-unchanged** (REQ-TOPOLOGY-GRAPH (h) holds literally); node kinds grew (`overlay`, `staged`, `skill-not-at-head`) and became the third closed pinned set (`GRAPH_NODE_KINDS`) with a glyph-parity pin.

**The `run.command` display half** (the #189 handoff): the graph tip gains `command: /name args`, and the TUI list target and trigger drill-in show `/name` instead of a bare dash, all through one exported vocabulary (`commandSlashLabel`); the drill-in carries the full staged line.

## Specs and docs (same PR, revision rows)

REQ-TOPOLOGY-GRAPH **AMENDED** (statement, new clause (a2), acceptance rows). REQ-PER-TRIGGER-SKILLS **AMENDED** (injected-only acceptance clause). REQ-GLOBAL-PI-OVERLAY **AMENDED** (topology as doctor's display half). DES-GRAPH-EDGE-DERIVATION **AMENDED** (ladder, stop-at-unknown, two Rejected rows). DES-ADMIN-VIA-PI-EXTENSION **AMENDED** (two new readers, same never-throw/GRAPH_LIMITS/display-advisory posture). DES-FLOW-RESOLUTION-TWO-ADVISORY-LAYERS **AMENDED** (third advisory surface). OQ-022 **AMENDED** (prose correction), **OQ-025 NEW** (six accepted display residuals, incl. the pointer-allowlist blindness — widening it is deliberately not done here). DES-AI-TRIGGER-FLOW-GATE **UNCHANGED, checked**: AI-reachability stays committed-repo-only; tier nodes carry no `aiTrigger`, no chainable badge, and potential-edge eligibility still reads only the repo enumeration. REQ-DEPLOYMENT-BOOTSTRAP **UNCHANGED, checked**. `docs/graph.md` (badge table, new resolution section, honesty section), `docs/insights.md`, `docs/global-pi-overlay.md` updated.

## Verification

- Full suite in CI posture (`PI_DISPATCH_REQUIRE_{LOADER,WORKER,RECEIVER}_TESTS=1`, live Valkey): **2327 tests, 0 failed, 0 skipped** (was 2297).
- `node admin/build.mjs` proves `readStagedSkills` resolves through `@edgehero/pi-dispatch/packages` and inlines.
- End-to-end fixture: a real git repo, injected dir, overlay and staged package driven through the real `collectGraphInputs` → `buildGraphModel` → `buildGraphHtml`; all four tiers resolve, the nowhere-flow stays red with the tiers named, and the same model built without `PI_GLOBAL_PI_DIR` softens to amber naming the unseeable tiers.