### PR TITLE
README: bound the per-job token per auth source, not unconditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ flowchart LR
   end
   R -->|"enqueueGitHubJob (jobId = gh-&lt;delivery&gt;)"| Q[("Valkey + BullMQ<br/>pi-jobs, AOF, 31d+ retention")]
   subgraph HOST["worker/ (host process)"]
-    W["mint scoped token, refuse an unprotected branch,<br/>hardened clone at the default-branch SHA, run container"]
+    W["mint the job's token, refuse an unprotected branch,<br/>hardened clone at the default-branch SHA, run container"]
   end
   Q --> W
   W -->|"docker run --rm"| C["job container: the agent commits,<br/>pushes --force-with-lease, gh pr create, comments"]
@@ -501,9 +501,12 @@ flowchart LR
   step. PR triggers (label, comment, auto on open/update, or a submitted review) gate the auto path on the
   PR author being a collaborator, so a fork PR from a stranger never auto-fires, and gate a review on the
   **reviewer** instead, so a collaborator reviewing that same fork PR does.
-- The per-job token is repo-scoped and short-lived, and honestly: it *can* merge, because GitHub gates
-  push and merge behind the same scope. **Branch protection on your default branch is the real
-  control**, and the worker refuses an unprotected repo before any spend.
+- What bounds the per-job token depends on which auth source you run. The App mints one scoped to a
+  single repository, expiring in an hour; the default `gh` source forwards your own login into every
+  token-carrying job, full-scope and non-expiring, which is what `pi-dispatch doctor` warns about. Under
+  every source it *can* merge, because GitHub gates push and merge behind the same scope. **Branch
+  protection on your default branch is the real control**, and the worker refuses an unprotected repo
+  before any spend.
 - The checkout is always the base repo at its default-branch SHA, never a PR branch. Landing a commit on
   your default branch is enough to run code in a job container; issue and comment text never is. It
   stays data.
@@ -511,8 +514,8 @@ flowchart LR
 **Credentials in one click**: `pi-dispatch setup github` runs GitHub's App Manifest flow against your own
 loopback. One browser click mints the App id, private key and webhook secret; every `.env` line is shown
 before one consent, the key lands with mode 0600, and no secret is ever printed. The App is the
-strongest auth source (per-repo one-hour tokens); `gh` and fine-grained PATs also work
-(`GITHUB_AUTH_SOURCE`).
+strongest auth source (per-repo one-hour tokens); a fine-grained PAT carries an expiry you set, and
+`gh` carries neither (`GITHUB_AUTH_SOURCE`).
 
 **Three ways to run the trigger edge**, pick one (or let `/dispatch setup` walk you through the choice,
 which is what it offers right after the credentials step):


### PR DESCRIPTION
Closes #197.

`README.md` asserted *"The per-job token is repo-scoped and short-lived"* with no condition attached. That is the **App** path's property. The shipped default is `gh` (`worker/src/config.mjs:218`), which hands out `gh auth token` verbatim on every mint (`worker/src/get-token.mjs:69-80`), described in that module's own words at `:209-211` as *"the operator's whole `gh` login: full-scope and NON-EXPIRING"*.

## What changed

Three edits, `README.md` only:

- **The bullet** names the source each bound holds for. The App mints one scoped to a single repository, expiring in an hour; the default `gh` source forwards your own login into every token-carrying job. The branch-protection point is kept intact, because it is true under every source.
- **The ranking** under *Credentials in one click* said `gh` and fine-grained PATs "also work". It now says what `gh` costs: a fine-grained PAT carries an expiry you set, and `gh` carries neither.
- **The GitHub automation diagram** said `mint scoped token`, which asserts the same unconditional property in three words. It now says `mint the job's token`.

## Cross-checked, UNCHANGED

Every other surface already told the truth, which is what made this a defect rather than a permissible simplification:

- `SECURITY.md:382-386` (*"With `GITHUB_AUTH_SOURCE=gh` (the default), your entire gh login reaches every token-carrying job"*)
- `worker/src/doctor.mjs` warns on exactly this and names the scopes on every run
- `worker/src/get-token.mjs:221-226` refuses `gh` outright for a `run.resume` job
- `specs/interfaces.md:910-915` (*"Per-job token *scoping* ... is the App path's property, not `gh`'s"*)

No spec entry changes: `CONST-TOKEN-SCOPED-PER-JOB` and `INT-CONTAINER-RUNTIME-CONTRACT` are UNCHANGED, checked.

## Explicitly not in this PR

- **The default itself.** Changing it is a separate decision with its own migration cost, and `pi-dispatch setup github` already moves an operator to `app` in one browser click.
- **`SECURITY.md:285-291`.** Its egress row leans on *"the token's short expiry and narrow scope"* in the same way the README bullet did. That row was rewritten last week for #199 and is #198's declared out-of-scope area, so it is flagged here rather than edited.

## Checks

Full suite green before commit: 2327 tests, 0 fail, 16 skipped. README dash rule re-audited whole-file: 0 em dash, 0 en dash, 0 spaced hyphen.