### PR TITLE
README: say which credentials live inside a job container, and what bounds each

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,26 @@ default and is yours to bound: [`docs/sandbox.md`](docs/sandbox.md) carries a re
 with the failure modes measured. Recorded tokens and cost are process-wide (subagent sessions included),
 and the per-job token budget is enforced against that same total.
 
+### What is inside the container while a job runs
+
+Two credentials go in as environment values, and the agent can read both. The runner is the container's
+entrypoint and starts the agent session in its own process, so `process.env` is the agent's own
+environment. The guardrails tell it never to print or transmit them, and that is prompt text, not
+enforcement.
+
+- **The provider key**, under whichever variable name your provider uses. It cannot be scoped, because
+  the agent cannot function without it, so it is bounded by a **provider-side spend limit** instead of by
+  scope. Set one. A host holding both `ANTHROPIC_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` sends both.
+- **The forge token**, under that forge's own variable names, bounded by whichever auth source you
+  configured: a per-repo one-hour token on the GitHub App path, your whole login under the default `gh`
+  (`GITHUB_AUTH_SOURCE`). On the other forges it is the token you minted, for as long as you leave it
+  valid.
+- **Anything you list in `PI_FORWARD_ENV`**, the one channel for a variable the allowlist does not
+  already carry (a custom provider's key, say). Same exposure.
+
+The bound is on the blast radius, not on the leak. [`SECURITY.md`](SECURITY.md) states the whole of it,
+including the case this design does not defend.
+
 ## Reuse your existing pi setup
 
 Give every job your host pi setup (custom models, global skills, a persona), layered under each repo's


### PR DESCRIPTION
Closes #198.

External review of v1.0.0, verbatim: *"I did read through the README and I am unclear if there is any solution is in use for secrets. Looks like secrets are exposed to running agents."*

The reader is right on the facts. Two credentials reach a job container as environment values (`worker/src/env-allowlist.mjs`, emitted at `worker/src/docker-run.mjs:89-92`), and the runner is the container entrypoint that starts the agent session in that same process, so `process.env` is the agent's own environment. `guardrails/HARD_RULES.md:43-45` asks it not to exfiltrate them, which is prompt text, not enforcement.

`SECURITY.md:285-291` states all of this already. The README never did: every secrets mention in it was setup-time hygiene (mode 0600 on the App key, the overlay refusing a literal key, the sandbox running with no credentials). All true, and none of it answers the question the reader asked.

## What changed

One new `###` subsection under **What runs, and what protects you**, where the isolation diagram already sets the topic:

- **The provider key**, and its bound stated as what it is. Per `constitution.md:604-609` it cannot be scoped because the agent cannot function without it, so it is bounded by a provider-side spend limit instead of by scope. The subsection also notes that a host holding both `ANTHROPIC_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` sends both (`env-allowlist.mjs:47-50` returns every present name).
- **The forge token**, bounded by whichever auth source is configured, in the wording #197 just landed, plus one clause for the other forges: the token you minted, for as long as you leave it valid.
- **`PI_FORWARD_ENV`**, named as the same exposure by operator choice, since it is the only channel for a variable the allowlist does not already carry.

It links `SECURITY.md` rather than restating it, and closes by saying the bound is on the blast radius and not on the leak. If it read as reassurance it would be worse than the silence it replaced.

## Cross-checked, UNCHANGED

- `SECURITY.md:285-291` already says this plainly, and the issue explicitly asks for no edit there.
- `CONST-TOKEN-SCOPED-PER-JOB` and `INT-CONTAINER-RUNTIME-CONTRACT`: UNCHANGED, checked. No spec entry changes.

## Explicitly not in this PR

Removing the credentials from the container (the agent cannot function without the provider key and cannot push without the forge token), the egress proxy (`OQ-004`, tracked in #202), and any softening of `SECURITY.md`.

## Checks

Full suite green before commit: 2327 tests, 0 fail, 16 skipped. README dash rule re-audited whole-file: 0 em dash, 0 en dash, 0 spaced hyphen.