### PR TITLE
Ignore the App private key, and warn when it sits in a repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,17 @@ jobs/
 sessions/
 current.jsonl
 
+# The GitHub App private key. `pi-dispatch setup github` writes github-app-<slug>.pem into the
+# deployment folder itself (worker/src/github-app-setup.mjs) at mode 0600, and when that folder is a
+# checkout of this repo the key lands right here -- where 0600 stops meaning anything the moment
+# `git add -A` stages it. Broad rather than github-app-*.pem on purpose: an operator who renamed the
+# key, or brought their own, made the same mistake and deserves the same net. This is deliberately NOT
+# the `*.jsonl` case argued against above: nothing matching *.pem is tracked, the tests that need a key
+# mint one into a temp dir, and if a fixture ever needs to ship, the `!name.example.json` convention
+# used throughout this file un-ignores it in one line. `pi-dispatch doctor` covers a key kept outside
+# this repo, warning when it sits in a work tree that does not ignore it.
+*.pem
+
 # Node
 node_modules/
 dist/

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -221,9 +221,9 @@ other key still works. On those platforms, either let the manager own the whole 
 `GITHUB_APP_PRIVATE_KEY_PATH` names a file, and the config loader refuses at startup when that file does
 not exist. No amount of environment injection satisfies it. Either render the PEM to disk from your
 manager (Recipe B's template shape, mode `0600`) or leave it where `pi-dispatch setup github` put it:
-`github-app-<slug>.pem` in the deployment folder, written `0600`. If that folder is a checkout of this
-repository, note that `.gitignore` covers `.env` and not `*.pem`, so keep the key somewhere your `git
-add` cannot reach it.
+`github-app-<slug>.pem` in the deployment folder, written `0600`. Mode `0600` protects it from other
+users on the host and not at all from a commit, so this repository's `.gitignore` covers `*.pem`, and
+`pi-dispatch doctor` warns when the key sits in any git work tree that does not ignore it.
 
 ## What doctor says when there is no file
 

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -46,7 +46,7 @@
  */
 import { chmodSync, closeSync, existsSync, lstatSync, mkdirSync, mkdtempSync, openSync, readdirSync, readFileSync, readSync, rmSync, statSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn as nodeSpawn } from "node:child_process";
 import { defaultSandboxDir, globalExtensionsEnabled } from "./config.mjs";
@@ -688,6 +688,26 @@ export async function collectChecks(env, seams) {
 				}
 			} catch {
 				checks.push({ ok: false, warn: true, label: `the App private key at ${keyPath} exists but is not readable by this user`, fix: setupFix });
+			}
+			// Mode 0600 protects the key from other users on this host; it does nothing once the file is in
+			// a commit. `setup github` writes the key into the DEPLOYMENT FOLDER, and a deployment folder is
+			// very often a checkout -- so the last thing between an App signing key and a public repository
+			// can be one `git add -A`. This repo's own .gitignore covers *.pem; the operator's may not, and
+			// a key they renamed or brought themselves is the same accident.
+			//
+			// Exit 1 is the ONLY case that warns: git says "this is a work tree, and that path is not
+			// ignored". 0 means covered, 128 means no work tree at all, and null means git could not be
+			// launched. Every one of those is silence, because a check nobody can silence must never cry
+			// wolf -- the cost of a missed warning here is one operator reading the doc, and the cost of a
+			// false one is every operator learning to scroll past doctor.
+			const ignoreCode = await runCmd(spawn, "git", [...GIT_READ_FLAGS, "-C", dirname(keyPath), "check-ignore", "-q", keyPath]);
+			if (ignoreCode === 1) {
+				checks.push({
+					ok: false,
+					warn: true,
+					label: `the App private key at ${keyPath} is inside a git work tree that does not ignore it`,
+					fix: `move it outside that repo, or ignore it there (\`*.pem\`) -- one \`git add -A\` commits the App's signing key, which can mint a token for every repository the App is installed on, and mode 0600 does not survive a commit`,
+				});
 			}
 		}
 	}

--- a/worker/test/doctor.test.mjs
+++ b/worker/test/doctor.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { chmodSync, existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { PassThrough } from "node:stream";
 import { collectChecks, defaultPromptFn, githubProtectionPreflight, runDoctor } from "../src/doctor.mjs";
 
@@ -611,6 +611,51 @@ test("doctor: a file that does not start with -----BEGIN warns, and its contents
 	assert.equal(code, 0);
 	assert.match(text(), /⚠ the file at GITHUB_APP_PRIVATE_KEY_PATH does not look like a PEM \(first line is not "-----BEGIN \.\.\."\)/);
 	assert.doesNotMatch(text(), new RegExp(KEY_BODY), "not even a malformed key's contents may reach output");
+});
+
+// The key file's mode protects it from other users on this host and does nothing at all once the file is
+// in a commit (issue #211). `setup github` writes it into the DEPLOYMENT folder, which is very often a
+// checkout, so doctor asks git. `fakeSpawn` matches by prefix and nothing else in these fixtures shells
+// out to git, so keying the plan on "git " is unambiguous here.
+
+test("doctor: a key inside a git work tree that does not ignore it warns, with the path and no contents", async () => {
+	const keyPath = appKeyFile();
+	const { out, text } = capture();
+	const deps = { ...appDeps(out), spawn: fakeSpawn({ ...green, "git ": 1 }) };
+	const code = await runDoctor(appEnv({ GITHUB_APP_ID: "4242", GITHUB_APP_INSTALLATION_ID: "987654", GITHUB_APP_PRIVATE_KEY_PATH: keyPath }), deps);
+	assert.equal(code, 0, "a committable key is a warning, not a failure -- doctor never fails on hygiene");
+	assert.match(text(), new RegExp(`⚠ the App private key at ${keyPath.replace(/[.\\/]/g, "\\$&")} is inside a git work tree that does not ignore it`));
+	assert.match(text(), /git add -A/, "the fix says what would actually happen");
+	assert.doesNotMatch(text(), new RegExp(KEY_BODY));
+});
+
+test("doctor: check-ignore asks about the key path, from the key's own directory", async () => {
+	const keyPath = appKeyFile();
+	const calls = [];
+	const { out } = capture();
+	const deps = { ...appDeps(out), spawn: fakeSpawn({ ...green, "git ": 1 }, calls) };
+	await runDoctor(appEnv({ GITHUB_APP_ID: "4242", GITHUB_APP_INSTALLATION_ID: "987654", GITHUB_APP_PRIVATE_KEY_PATH: keyPath }), deps);
+	const git = calls.find((c) => c.cmd === "git");
+	assert.ok(git, "doctor asked git");
+	assert.equal(git.args.at(-1), keyPath, "the question is about the key file itself");
+	assert.equal(git.args.at(-2), "-q");
+	assert.equal(git.args.at(-3), "check-ignore");
+	assert.equal(git.args.at(-4), dirname(keyPath), "asked from the key's own directory, not doctor's cwd");
+});
+
+test("doctor: an ignored key, a non-repo, and a git that will not launch are all silent", async () => {
+	const keyPath = appKeyFile();
+	for (const [name, outcome] of [
+		["ignored (exit 0)", 0],
+		["not a work tree (exit 128)", 128],
+		["git missing", "enoent"],
+	]) {
+		const { out, text } = capture();
+		const deps = { ...appDeps(out), spawn: fakeSpawn({ ...green, "git ": outcome }) };
+		const code = await runDoctor(appEnv({ GITHUB_APP_ID: "4242", GITHUB_APP_INSTALLATION_ID: "987654", GITHUB_APP_PRIVATE_KEY_PATH: keyPath }), deps);
+		assert.equal(code, 0);
+		assert.doesNotMatch(text(), /does not ignore it/, `${name}: only a definite "not ignored" may warn`);
+	}
 });
 
 test("doctor: the app-auth block only fires for source app", async () => {

--- a/worker/test/github-app-setup.test.mjs
+++ b/worker/test/github-app-setup.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createVerify, generateKeyPairSync } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { buildFormPage, buildManifest, defaultAppName, mintAppJwt, runGithubAppSetup, sanitizeAppName } from "../src/github-app-setup.mjs";
 
 // A REAL RSA keypair, generated once: the conversion response carries the private half as its `pem`,
@@ -27,6 +28,17 @@ const APP = {
 };
 
 const PEM_PATH = "/deploy/github-app-pi-dispatch-testbox.pem";
+
+// The wizard writes the App's signing key into the DEPLOYMENT folder at mode 0600, and a deployment
+// folder is very often a checkout of this repo (issue #211). Mode 0600 does not survive a commit, so the
+// repo's own .gitignore has to cover what this module names. Bound here rather than left implicit,
+// because the two live in different files and only this one decides the extension.
+test("the repo ignores the key file this wizard writes", () => {
+	const gitignore = readFileSync(new URL("../../.gitignore", import.meta.url), "utf8");
+	const patterns = gitignore.split("\n").map((l) => l.trim()).filter((l) => l && !l.startsWith("#"));
+	assert.ok(patterns.includes("*.pem"), "`*.pem` must stay in .gitignore: the wizard writes github-app-<slug>.pem into the deployment folder");
+	assert.ok(PEM_PATH.endsWith(".pem"), "and the wizard must keep writing a .pem, or the pattern above stops covering it");
+});
 const ENV_PATH = "/deploy/.env";
 // A .env in the pre-setup shape: gh source, App keys scaffolded empty (like .env.example).
 const SEED_ENV = "GITHUB_AUTH_SOURCE=gh\nGITHUB_APP_ID=\nGITHUB_APP_PRIVATE_KEY_PATH=\nWEBHOOK_SECRET=\n";


### PR DESCRIPTION
Closes #211.

`pi-dispatch setup github` writes the GitHub App's signing key to `join(cwd, "github-app-<slug>.pem")` at mode 0600 (`worker/src/github-app-setup.mjs:198`, `:230`). The deployment folder is very often a checkout of this repository, and `.gitignore` covered `.env`, `logs/`, `jobs/`, `sessions/` and `current.jsonl` but not `*.pem`:

```
$ git check-ignore -v github-app-example.pem
$            # no match
```

So one `git add -A` staged a working App private key, and mode 0600 means nothing once a file is in a commit. That key mints installation tokens for every repository the App is installed on.

## What changed

**`.gitignore` gains `*.pem`**, with the reasoning recorded in the file's own style. Broad rather than `github-app-*.pem` on purpose: an operator who renamed the key or brought their own made the same mistake. It is deliberately not the `*.jsonl` case the file argues against two entries up, and the comment says why: nothing matching `*.pem` is tracked, the tests that need a key mint one into a temp dir, and the `!name.example.json` convention already in the file un-ignores a fixture in one line if one ever ships.

**`pi-dispatch doctor` asks git about the configured key path**, because the ignore line only protects deployments that are checkouts of this repo. One `check-ignore -q` from the key's own directory, reusing the existing `GIT_READ_FLAGS` + `runCmd` seam:

- exit `1` (a work tree, and this path is not ignored) → **warn**, naming the path
- exit `0`, exit `128`, and a git that will not launch → **silent**

Only the case git is certain about warns. A check nobody can silence must never cry wolf: a missed warning costs one operator a doc read, a false one teaches every operator to scroll past doctor. Warn tier with no `fixAction`, which is doctor's own never tier (it does not rewrite an operator's config, and moving a credential is not a mechanical remainder).

## Tests

- the warn case pins the path and the `git add -A` fix line, and asserts the key's contents never reach output
- the argv is pinned: asked about the key file, from the key's own directory rather than doctor's cwd
- all three silent outcomes in one loop
- **both directions mutation-checked**: neutering the condition fails the warn test, widening it to any nonzero fails the silence test
- `github-app-setup.test.mjs` gains a pin binding the wizard's filename to the ignore rule, since the two live in different files and only one of them decides the extension

## Also

`docs/secrets.md`'s trap 4 said `.gitignore` does not cover `*.pem`. That sentence is now false, so it states what is covered and names the doctor line instead.

Specs: `CONST-TOKEN-SCOPED-PER-JOB` UNCHANGED, checked (the App key never enters a job container, and nothing here touches the minted token). `REQ-DEPLOYMENT-BOOTSTRAP` UNCHANGED, checked (warn tier, no `fixAction`, so the closed fix tiers are untouched).

Full suite green before commit: 2331 tests, 0 fail, 16 skipped.