### PR TITLE
fix(test): signal the wrapper on a fact, not on a timer (#207)

### DIFF
--- a/worker/test/service.test.mjs
+++ b/worker/test/service.test.mjs
@@ -613,8 +613,27 @@ function runWrapper(dir, { args, onSpawn } = {}) {
 		child.stderr.on("data", (d) => (stderr += d));
 		child.on("error", reject);
 		child.on("close", (code) => resolvePromise({ code, stderr }));
-		onSpawn?.(child);
+		// Routed through the promise on purpose: a bare onSpawn?.(child) drops a rejection on the floor
+		// (an async callback here returns a promise nobody holds), so a throw inside it would surface as
+		// an unhandled rejection somewhere else in the run instead of failing this test.
+		Promise.resolve(onSpawn?.(child)).catch(reject);
 	});
+}
+
+/**
+ * Poll for a marker file the wrapper's stub writes, and SAY whether it appeared (issue #207). The old
+ * inline loop fell through on timeout and signalled anyway: on a loaded runner the TERM landed before
+ * the stub had installed its trap, the stub died on the default disposition, and the resulting failure
+ * was word-for-word identical to the wrapper simply not forwarding. Returning the answer lets the
+ * caller assert the two apart. The bound is generous on purpose -- it is a ceiling on a hang, never a
+ * wait in the healthy case, where the marker lands in tens of milliseconds.
+ */
+async function waitForMarker(path, timeoutMs = 30_000, stepMs = 25) {
+	for (let waited = 0; waited < timeoutMs; waited += stepMs) {
+		if (existsSync(path)) return true;
+		await new Promise((r) => setTimeout(r, stepMs));
+	}
+	return existsSync(path);
 }
 
 test("wrapper: a policy refusal (node exits 2) becomes a clean exit 0 with the refusal note — KeepAlive must not relaunch it", { skip: !POSIX }, async () => {
@@ -656,20 +675,32 @@ test("wrapper: refuses when ./.env is absent from its cwd, naming the directory 
 });
 
 test("wrapper: SIGTERM to the wrapper reaches node (trap + kill + double wait replaces the old exec)", { skip: !POSIX }, async () => {
-	// The stub records that it started, then waits; on TERM it records the delivery and exits 0. If
-	// the wrapper failed to forward, the stub would sit in sleep and the test would time out. The trap
-	// must kill the sleep too: an orphaned sleep inherits the wrapper's stdio pipes and would hold the
-	// spawn's `close` event (and this test) hostage for the full 30s.
-	const dir = wrapperDir('#!/bin/sh\n: > "$MARKER_DIR/started"\ntrap \': > "$MARKER_DIR/got-term"; kill "$sp" 2>/dev/null; exit 0\' TERM\nsleep 30 &\nsp=$!\nwait\nexit 1\n');
+	// The stub waits, and on TERM it records the delivery and exits 0. If the wrapper failed to forward,
+	// the stub would sit in sleep and the test would time out. The trap must kill the sleep too: an
+	// orphaned sleep inherits the wrapper's stdio pipes and would hold the spawn's `close` event (and
+	// this test) hostage for the full 30s.
+	//
+	// ORDER IS THE POINT (issue #207): the `started` marker is written LAST, after the sleep, after $sp
+	// and after the trap, so its existence means the stub is genuinely ready to be signalled. It used to
+	// be the first line, which made it a marker for "the stub has begun" -- a TERM racing in behind it
+	// still landed on the default disposition, and the test blamed the wrapper.
+	const dir = wrapperDir('#!/bin/sh\nsleep 30 &\nsp=$!\ntrap \': > "$MARKER_DIR/got-term"; kill "$sp" 2>/dev/null; exit 0\' TERM\n: > "$MARKER_DIR/started"\nwait\nexit 1\n');
+	let ready = false;
 	const { code } = await runWrapper(dir, {
 		onSpawn: async (child) => {
-			// Signal only after the stub is definitely running, so the wrapper's trap is in place.
-			for (let i = 0; i < 200 && !existsSync(join(dir, "started")); i++) {
-				await new Promise((r) => setTimeout(r, 25));
-			}
-			child.kill("SIGTERM");
+			// Signal only after the stub is definitely running, so the wrapper's trap is in place. When it
+			// never gets there, KILL instead of signalling: a TERM sent into a stub that has not reached
+			// its `trap` line tests nothing, and used to be reported as a forwarding failure (issue #207).
+			// SIGKILL only ends the wrapper, but the stub cannot be past its first line if `started` is
+			// missing, so there is nothing left holding the pipes.
+			ready = await waitForMarker(join(dir, "started"));
+			child.kill(ready ? "SIGTERM" : "SIGKILL");
 		},
 	});
+	assert.ok(
+		ready,
+		"the stub never wrote its `started` marker: the readiness wait timed out and the wrapper was never signalled, so this is a slow or hung stub, NOT a signal-forwarding failure",
+	);
 	assert.ok(existsSync(join(dir, "got-term")), "the stub received the forwarded TERM");
 	assert.equal(code, 0, "the wrapper reports node's post-drain exit code, not its own interrupted wait");
 });


### PR DESCRIPTION
`worker/test/service.test.mjs`'s *"wrapper: SIGTERM to the wrapper reaches node"* has failed four times on unrelated PRs (#177, #184, #205, #212), clearing on a plain rerun every time. On #212 the same commit passed in the sibling push run while failing the PR run, which is the race rather than the diff.

## Why it flaked

The readiness loop waited up to five seconds for the stub's `started` marker and **then signalled anyway**. On a loaded runner the TERM landed before the stub reached its `trap ... TERM` line, the stub died on the default disposition, `got-term` was never written, and the assertion about signal forwarding failed for a reason that had nothing to do with signal forwarding.

There was a second, smaller race hiding underneath it: the marker was the stub's **first** line, written before the trap was installed. So even a marker that appeared in time did not mean what the comment above the loop claimed (*"Signal only after the stub is definitely running, so the wrapper's trap is in place"*).

And the failure was mute. A timed-out poll and a genuinely unforwarded signal produced the identical assertion text, so every occurrence had to be diagnosed from scratch.

## The change

All of it in the test:

- **The marker is written last** in the stub, after `sleep 30 &`, after `sp=$!` and after the `trap`. Its existence now means the stub is genuinely ready to be signalled.
- **`waitForMarker()` returns whether the marker appeared** instead of falling through. The signal is sent only on `true`; on a timeout the wrapper is killed rather than signalled, and the test fails with its own message stating that this is a slow or hung stub and **not** a forwarding failure.
- **The bound rises to 30s.** It is a ceiling on a hang, never a wait in the healthy case, where the marker lands in tens of milliseconds. No test timeout is configured anywhere in the repo, so nothing can trip on it.

`runWrapper` also routes `onSpawn` through the promise. A bare `onSpawn?.(child)` dropped an async callback's rejection, so a throw inside it surfaced as an unhandled rejection elsewhere in the run instead of failing this test.

## Verification

Both mutations were run and reverted:

| mutation | expected | result |
|---|---|---|
| remove `trap ... TERM` from `deploy/worker-env-wrapper.sh` | red on the **forwarding** assertion | red at `:704`, the forwarding line |
| stub never writes `started` | red on the **readiness** assertion | red at `:700`, the readiness line |

So the test still pins the behaviour it exists for, and the two failure causes are now distinguishable at a glance.

Quiet under load: 20 sequential runs of the test and 12 concurrent full-file runs, all green. Whole suite: 2344 tests, 0 fail.

## Not in this PR

- No change to `deploy/worker-env-wrapper.sh` or to what the test asserts about it. Four failures, four passing reruns and a green result locally every time say the flake was in how the test decided when to signal.
- No retry, no skip. The test pins real behaviour: the wrapper's `exec` was deliberately removed so it can intercept exit codes, and forwarding TERM by hand is the cost of that.

`REQ-DEPLOYMENT-BOOTSTRAP` and `INT-RUNNER-EXIT-CODE-PROTOCOL` **UNCHANGED, checked**: a test-harness defect moves no behaviour, no contract and no fix tier.

Closes #207