### PR TITLE
release: v1.2.0 (worker 1.2.0, admin 1.2.0)

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -52,7 +52,7 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
  * follows in the same change.
  */
-export const RUNTIME_VERSION = "1.1.0";
+export const RUNTIME_VERSION = "1.2.0";
 
 /**
  * The `@edgehero/pi-dispatch-receiver` version the trigger-edge step installs -- pinned for exactly the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",
@@ -4253,7 +4253,7 @@
     },
     "worker": {
       "name": "@edgehero/pi-dispatch",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "description": "Self-hosted job harness for the pi coding agent: a BullMQ worker that drains the queue, mints scoped forge tokens, and runs one container per job — plus the pi-dispatch CLI (init, up, doctor, service).",
   "keywords": [


### PR DESCRIPTION
Ships the backlog on `main` since v1.1.0: the wrapper stop fix (#221) and the three resume eligibility bounds (#186). Root and `worker` go to 1.2.0, `admin` follows for one literal, `receiver` deliberately stays at 1.1.0.

### The upgrade action, which is not automatic

`PI_SESSION_MAX_CONTEXT_PCT` is measured by the **runner**, not the host. An operator who upgrades the packages and keeps yesterday's job image has armed a bound that reads nothing: the field never arrives on the exit line, the gate passes, and the lineage resumes exactly as before. Failing open there is deliberate, which is what makes the silence total. The age and chain bounds work immediately; the context one waits for a `docker pull` of the new image. The release notes lead with this.

### Why receiver does not move

`receiver/` has **zero** changed files since v1.1.0. Its `^1.0.0` range on the worker still admits 1.2.0 and stays a real caret, which `publish.test.mjs` requires, and `release.yml`'s per-package `npm view` gate makes the skip automatic rather than something to remember.

This is the asymmetry with v1.1.0, which moved all four: that release had to, because the console bundles the trigger validator and a stale one would have refused edits the loaders accept. Nothing of that kind happened here.

### Why admin does

`setup-wizard.ts`'s `RUNTIME_VERSION` is what `/dispatch setup` installs. A console published at 1.1.0 would go on installing a worker without the resume bounds while the packages carrying them sat on the registry. `RECEIVER_VERSION` stays 1.1.0 with the package it names, and the two spelled-out receiver literals in `setup-wizard.test.mjs` stay put for the same reason. The anti-drift tests make this checkable rather than hopeful.

### Verification

- Full suite in the CI posture with a live Valkey: **2529 pass, 0 fail, 1 skipped**.
- Artifact level: `node admin/build.mjs` produces a bundle carrying `"1.2.0"` for the runtime pin and `"1.1.0"` for the receiver one, with no stale 1.1.0 worker pin anywhere in it.
- `package-lock.json` is hand-edited, four version fields and nothing else. Regenerating under this host's npm minor rewrites unrelated normalization (drops the `libc` arrays, rewrites `./dist/cli.js`), which is what let earlier releases drift.

### What merging fires

`@edgehero/pi-dispatch@1.2.0` and `@edgehero/pi-dispatch-admin@1.2.0` publish; receiver skips on the version gate. Releases `v1.2.0`, `worker-v1.2.0` and `admin-v1.2.0` are cut, and the image workflows retag ghcr off the root bump. All three release bodies need `gh release edit --notes-file` afterwards, since the notes fall back to a raw commit list without `ANTHROPIC_API_KEY`.

No spec entry changes. `CONST-PI-VERSION-PINNED` UNCHANGED, checked: pi's pin is untouched and the image rebuild carries the same 0.80.7.
