### PR TITLE
release: v1.3.0 (worker 1.3.0, receiver 1.2.0, admin 1.3.0)

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -52,7 +52,7 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
  * follows in the same change.
  */
-export const RUNTIME_VERSION = "1.2.0";
+export const RUNTIME_VERSION = "1.3.0";
 
 /**
  * The `@edgehero/pi-dispatch-receiver` version the trigger-edge step installs -- pinned for exactly the
@@ -62,7 +62,7 @@ export const RUNTIME_VERSION = "1.2.0";
  * independently (the receiver's dependency range on the runtime is `^`), and pretending otherwise would
  * install a version that does not exist the first time they diverge.
  */
-export const RECEIVER_VERSION = "1.1.0";
+export const RECEIVER_VERSION = "1.2.0";
 
 /** The two npm package names, spelled once. Literals of this module -- see npmInstallArgsFor's argument. */
 const RUNTIME_PKG = "@edgehero/pi-dispatch";

--- a/admin/test/setup-wizard.test.mjs
+++ b/admin/test/setup-wizard.test.mjs
@@ -803,7 +803,7 @@ test("wizard: the edge's service answer installs the PINNED receiver, then the -
   assert.equal(attached.length, 2, "the npm install and the unit install — nothing else");
   assert.equal(attached[0].argv0, "npm", "posix npm, per npmSpawnOptions");
   assert.deepEqual(attached[0].args, mod.npmInstallArgsFor(RECEIVER_PKG, mod.RECEIVER_VERSION));
-  assert.ok(attached[0].args.includes(`${RECEIVER_PKG}@1.1.0`), "the pinned name@version token, spelled out");
+  assert.ok(attached[0].args.includes(`${RECEIVER_PKG}@1.2.0`), "the pinned name@version token, spelled out");
   assert.equal(attached[0].cwd, dir, "installed into the deployment dir, by cwd");
   assert.deepEqual(
     JSON.parse(readFileSync(join(dir, "package.json"), "utf8")),
@@ -817,7 +817,7 @@ test("wizard: the edge's service answer installs the PINNED receiver, then the -
   assert.equal(attached[1].cwd, dir);
 
   const c = seen.confirm.find((x) => /receiver/i.test(x.title));
-  assert.match(c.message, new RegExp(`${RECEIVER_PKG.replace("/", "\\/")}@1\\.1\\.0`), "the confirm shows the exact pin");
+  assert.match(c.message, new RegExp(`${RECEIVER_PKG.replace("/", "\\/")}@1\\.2\\.0`), "the confirm shows the exact pin");
   assert.match(c.message, /service install --receiver/, "and the unit command it will run after");
   assert.ok(c.message.includes(dir), "and names the cwd");
   assert.ok(reachedFirstTrigger(seen), "the wizard continued to step 11");

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -266,7 +266,7 @@ Because resolution happens before anything spends, a wrong reference costs nothi
 repository is cloned, no budget slot is reserved. You get a refusal on the issue naming the VARIABLE that
 failed, and never the reference, the resolver's path, or a byte of what it printed.
 
-### Three things worth knowing before you wire one
+### Four things worth knowing before you wire one
 
 1. **Your exit code decides whether the job retries.** This is the same question this page asks of every
    manager, and here it is load-bearing rather than advisory. Exit 2 means "that reference is wrong" and the
@@ -279,6 +279,14 @@ failed, and never the reference, the resolver's path, or a byte of what it print
    An agent handed a credential often persists it to make its next command simpler, and on a local job that
    `.env` lands in your real repository. Nothing scans for it. `pi-dispatch doctor` warns when a local
    trigger binds secrets; keep those folders out of anything you push.
+4. **All three packages must be new enough to carry the field, and they move together.** `run.secrets`
+   ships in `@edgehero/pi-dispatch` 1.3.0, `@edgehero/pi-dispatch-admin` 1.3.0 and
+   `@edgehero/pi-dispatch-receiver` 1.2.0; that is the floor. The skew that matters is a stale receiver:
+   it matches the rule, enqueues the job WITHOUT the secrets, and the worker sees an unarmed job -- the
+   container then runs with the variable unset on a clean exit, which is exactly the silent no-op this
+   feature is built to refuse. A stale admin fails the other way, visibly, refusing every trigger write
+   while the file holds a `run.secrets` entry. Upgrade the receiver in the same `npm install` as the
+   worker, before you bind the first secret.
 
 ### From the panel
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",
@@ -4236,10 +4236,10 @@
     },
     "receiver": {
       "name": "@edgehero/pi-dispatch-receiver",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@edgehero/pi-dispatch": "^1.0.0",
+        "@edgehero/pi-dispatch": "^1.3.0",
         "@octokit/webhooks": "14.2.0",
         "bullmq": "5.80.4",
         "ioredis": "5.11.1"
@@ -4253,7 +4253,7 @@
     },
     "worker": {
       "name": "@edgehero/pi-dispatch",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",

--- a/receiver/package.json
+++ b/receiver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-receiver",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "description": "Webhook receiver for pi-dispatch: the always-on edge that verifies GitHub, GitLab, Forgejo and Azure DevOps deliveries and enqueues (at most) one job per event for the worker.",
   "keywords": [
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@octokit/webhooks": "14.2.0",
-    "@edgehero/pi-dispatch": "^1.0.0",
+    "@edgehero/pi-dispatch": "^1.3.0",
     "bullmq": "5.80.4",
     "ioredis": "5.11.1"
   }

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "description": "Self-hosted job harness for the pi coding agent: a BullMQ worker that drains the queue, mints scoped forge tokens, and runs one container per job — plus the pi-dispatch CLI (init, up, doctor, service).",
   "keywords": [

--- a/worker/src/run-container.mjs
+++ b/worker/src/run-container.mjs
@@ -7,7 +7,7 @@ import { InfraRetry } from "./processor.mjs";
 
 /**
  * The real `runContainer` the processor injects. Launches one job container and returns
- * `{ code, aborted, turns, tokens, session, usage }`, where `aborted` records whether the WORKER initiated the stop (docker stop on
+ * `{ code, aborted, turns, tokens, session, usage, context }`, where `aborted` records whether the WORKER initiated the stop (docker stop on
  * the 30-min timeout or graceful shutdown), which the processor classifies as POLICY (no retry) per
  * INT-RUNNER-EXIT-CODE-PROTOCOL. The numeric `code` alone cannot say this: a worker SIGKILL and a
  * kernel OOM both surface as 137, so the abort FLAG -- not the code -- is the discriminator.


### PR DESCRIPTION
Ships run.secrets (#225) to npm and closes #232: main and the registry carried different contents under identical version numbers, and the mixed deployments that allows fail in two directions, one of them silently.

The silent direction is the receiver. A published 1.1.0 receiver parses a secret-bearing trigger, matches the rule, and enqueues the job **without** `run.secrets`, so the worker sees an unarmed job, the pre-spend gate never runs, and the container starts with the variable unset on a clean exit 0. The whole feature is built to fail closed and loud, and that skew defeats it. The loud direction is the admin: its bundled validator refuses every trigger write while the file holds a `run.secrets` entry, and its older overlay validator silently drops a declared `secretProfiles` table.

What moves, and why all three move (unlike v1.2.0, where receiver/ had a zero diff and stayed put; this time `receiver/src` changed in 67ef47d):

- worker and admin 1.2.0 to 1.3.0, receiver 1.1.0 to 1.2.0, root 1.3.0. Lockfile hand-edited (five version fields plus the receiver range); `npm ci --dry-run` validates it clean.
- The receiver's range on `@edgehero/pi-dispatch` tightens from `^1.0.0` to `^1.3.0`: it validates triggers with the worker package's own `parseTriggers`, and an older parser does not know the field. Same shape as the receiver 0.2.1 release.
- `RUNTIME_VERSION` and `RECEIVER_VERSION` move in `setup-wizard.ts`, together with the two spelled-out pins in `setup-wizard.test.mjs`, so `/dispatch setup` stops installing the receiver that drops the field.
- The version floor is recorded where an operator will read it: a fourth entry under docs/secrets.md's "things worth knowing before you wire one".
- The #232 rider rides along: `run-container.mjs`'s docblock return shape gains `context`, which the implementation returns and the processor destructures. #225 corrected the processor-side twin and missed this one.

Specs are UNCHANGED, checked: a version bump changes no behaviour, and REQ-TRIGGER-SECRETS plus OQ-027/OQ-028 already record the feature this release publishes.

Merging this to main fires release.yml for all three packages (each gated on its version being absent from the registry) and repo-release.yml for the v1.3.0 tag. Release notes for all four will be edited after the cut, leading with the receiver.

Verification: full suite in the CI posture (`PI_DISPATCH_REQUIRE_*_TESTS=1` plus a live Valkey): 2608 tests, 0 fail, 1 skipped (the systemd-analyze platform skip on macOS, which CI's Linux runs).
