### PR TITLE
release: v1.4.0 (worker 1.4.0, receiver 1.3.0, admin 1.4.0)

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -52,7 +52,7 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
  * follows in the same change.
  */
-export const RUNTIME_VERSION = "1.3.0";
+export const RUNTIME_VERSION = "1.4.0";
 
 /**
  * The `@edgehero/pi-dispatch-receiver` version the trigger-edge step installs -- pinned for exactly the
@@ -62,7 +62,7 @@ export const RUNTIME_VERSION = "1.3.0";
  * independently (the receiver's dependency range on the runtime is `^`), and pretending otherwise would
  * install a version that does not exist the first time they diverge.
  */
-export const RECEIVER_VERSION = "1.2.0";
+export const RECEIVER_VERSION = "1.3.0";
 
 /** The two npm package names, spelled once. Literals of this module -- see npmInstallArgsFor's argument. */
 const RUNTIME_PKG = "@edgehero/pi-dispatch";

--- a/admin/test/setup-wizard.test.mjs
+++ b/admin/test/setup-wizard.test.mjs
@@ -803,7 +803,7 @@ test("wizard: the edge's service answer installs the PINNED receiver, then the -
   assert.equal(attached.length, 2, "the npm install and the unit install — nothing else");
   assert.equal(attached[0].argv0, "npm", "posix npm, per npmSpawnOptions");
   assert.deepEqual(attached[0].args, mod.npmInstallArgsFor(RECEIVER_PKG, mod.RECEIVER_VERSION));
-  assert.ok(attached[0].args.includes(`${RECEIVER_PKG}@1.2.0`), "the pinned name@version token, spelled out");
+  assert.ok(attached[0].args.includes(`${RECEIVER_PKG}@1.3.0`), "the pinned name@version token, spelled out");
   assert.equal(attached[0].cwd, dir, "installed into the deployment dir, by cwd");
   assert.deepEqual(
     JSON.parse(readFileSync(join(dir, "package.json"), "utf8")),
@@ -817,7 +817,7 @@ test("wizard: the edge's service answer installs the PINNED receiver, then the -
   assert.equal(attached[1].cwd, dir);
 
   const c = seen.confirm.find((x) => /receiver/i.test(x.title));
-  assert.match(c.message, new RegExp(`${RECEIVER_PKG.replace("/", "\\/")}@1\\.2\\.0`), "the confirm shows the exact pin");
+  assert.match(c.message, new RegExp(`${RECEIVER_PKG.replace("/", "\\/")}@1\\.3\\.0`), "the confirm shows the exact pin");
   assert.match(c.message, /service install --receiver/, "and the unit command it will run after");
   assert.ok(c.message.includes(dir), "and names the cwd");
   assert.ok(reachedFirstTrigger(seen), "the wizard continued to step 11");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",
@@ -4236,10 +4236,10 @@
     },
     "receiver": {
       "name": "@edgehero/pi-dispatch-receiver",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@edgehero/pi-dispatch": "^1.3.0",
+        "@edgehero/pi-dispatch": "^1.4.0",
         "@octokit/webhooks": "14.2.0",
         "bullmq": "5.80.4",
         "ioredis": "5.11.1"
@@ -4253,7 +4253,7 @@
     },
     "worker": {
       "name": "@edgehero/pi-dispatch",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",

--- a/receiver/package.json
+++ b/receiver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-receiver",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "description": "Webhook receiver for pi-dispatch: the always-on edge that verifies GitHub, GitLab, Forgejo and Azure DevOps deliveries and enqueues (at most) one job per event for the worker.",
   "keywords": [
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@octokit/webhooks": "14.2.0",
-    "@edgehero/pi-dispatch": "^1.3.0",
+    "@edgehero/pi-dispatch": "^1.4.0",
     "bullmq": "5.80.4",
     "ioredis": "5.11.1"
   }

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "description": "Self-hosted job harness for the pi coding agent: a BullMQ worker that drains the queue, mints scoped forge tokens, and runs one container per job — plus the pi-dispatch CLI (init, up, doctor, service).",
   "keywords": [


### PR DESCRIPTION
Version bumps and pins only; the #231 slices and the #222/#224 fixes are already on main. Merging FIRES the npm publish (worker 1.4.0, receiver 1.3.0, admin 1.4.0) and retags the ghcr images off the root bump.

Release-note actions after the tags land: rewrite all four release bodies via gh release edit --notes-file (lead with what the version adds; name the upgrade actions: `npm install` alone updates service deployments since the plist points into the installed package, and one-shot users should set PI_TRIGGERS_FILE to one absolute path in both services; note the run.flow charset narrowing).