### PR TITLE
feat(worker): scoped-limits file, parser and shared contract (#242)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,8 @@ PI_JOB_IMAGE=pi-job:latest          # the DEFAULT job image. Any trigger may nam
                                     # Unset = cron disabled for the worker; the receiver falls back to ./triggers.json in the folder it starts from (what `pi-dispatch init` scaffolds)
                                     # and refuses to start when neither exists (it holds the label/comment/pull_request trigger config)
 # PI_PAUSE_WINDOWS_FILE=            # ABSOLUTE path to pause-windows.json — "quiet hours" per folder/repo (pause runs between certain times/days/dates, auto-resume). Unset = feature off. See docs/pause-windows.md
+# PI_SCOPED_LIMITS_FILE=            # ABSOLUTE path to scoped-limits.json — per repo/folder job-count caps (day/week/month, refused pre-spend as scope-cap) and max concurrent jobs per scope (excess deferred, never dropped).
+                                    # Unset = no scoped caps or concurrency; the one-job-per-folder mutex for local jobs is always on and needs no file. See docs/scoped-limits.md
 # PI_SUBSCRIPTIONS_FILE=            # path to subscriptions.json — operator-declared subscription plan prices (the admin defaults to ./subscriptions.json in its working directory). Read by the ADMIN EXTENSION only, never at job time.
                                     # Subscription-backed providers bill 0 per run (their rate tables are all zeros), so this file is where the real price lives — cost analytics only; it changes no routing, auth, or job behavior
 # PI_SETTINGS_FILE=                 # ABSOLUTE path to the runtime settings overlay (default: OS temp /pi-dispatch/settings.json); edited by the admin extension, read by the worker per job

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,12 @@ coverage/
 /subscriptions.json
 !subscriptions.example.json
 
+# Scoped limits (issue #242): per repo/folder run caps and concurrency. Holds local folder
+# paths (the scopes), so an operator's real file must never land in a checkout by accident;
+# scoped-limits.example.json is the template. Resolved only via PI_SCOPED_LIMITS_FILE.
+/scoped-limits.json
+!scoped-limits.example.json
+
 # The egress allowlist (issue #202): the hosts THIS deployment's jobs may reach. init scaffolds it into
 # the cwd, so without this rule the scaffold is committable by accident. There is no committed template
 # beside it, deliberately: the shipped default lives in init.mjs, and an example file here would be one

--- a/scoped-limits.example.json
+++ b/scoped-limits.example.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "limits": [
+    { "scope": "acme/web", "day": 10, "week": 40, "concurrent": 1 },
+    { "scope": "/srv/site", "month": 60 }
+  ]
+}

--- a/specs/interfaces.md
+++ b/specs/interfaces.md
@@ -2669,6 +2669,91 @@ validator rather than a second copy of it.
 
 ---
 
+## INT-SCOPED-LIMITS-FILE-CONTRACT
+
+- **Producer/Consumer**: The admin extension (operator dialogs + confirm-gated tools) writes; the worker
+  reads and enforces. The receiver does not read it. The enforcement and the admin/worker wiring land in
+  issue #242's later slices — this entry is the file's contract from day one so the sides cannot drift,
+  and its Validation/Write-protocol/Enforcement bullets state those slices' terms up front.
+- **Location**: `PI_SCOPED_LIMITS_FILE` (unset = no scoped caps and no scoped concurrency; the worker loads
+  `[]`). The one-job-per-folder mutex for local jobs is CODE, not configuration: it holds with no file, an
+  empty file, or any file, and no row can raise it (`min(configured, 1)` for a local scope — scope strings
+  are not reliably typeable folder-vs-repo, so the clamp is silent rather than a parse refusal that would
+  misfire on `"a/b"`).
+- **Shape**: `{ "version": 1, "limits": [ { scope, day?, week?, month?, concurrent? } ] }`.
+  - `version` (required): integer ≥ 1, fail-loud on newer (`scoped-limits file written by a newer
+    pi-dispatch (version N; this build understands 1)`). Adopted from `INT-SUBSCRIPTIONS-FILE-CONTRACT`
+    because this is a MONEY file: unknown fields are silently dropped per the operator-file policy, so a
+    v2 cap field an old worker dropped would be a silently WIDENED spend limit. The protection covers
+    STAMPED files only — a hand-edit that plants a future field in a `version: 1` file drops in silence,
+    the operator-file policy working as designed.
+  - `scope` (required): a forge `"owner/name"` or a local folder path, matched EXACTLY against the job's
+    canonical scope — no prefixes, and any scope containing `"*"` is refused at parse (an exact matcher
+    would make a glob row silently inert). The bare `"*"` carries its own refusal: the only non-redundant
+    reading (a per-scope default) would invert the pause file's `"*"` (one rule matching all scopes); if
+    a later version adopts it, an exact row beats `"*"`. Duplicate scopes (after trimming and
+    absolute-path resolution) refuse the file. Write local folder scopes as ABSOLUTE paths: the job side
+    always resolves, so a relative folder row can never match any local job — and worse, it CAN exactly
+    match a same-named forge repo and silently govern that instead; the doctor advisory flags
+    unreferenced scopes. Path shape is interpreted with the worker platform's own `path` semantics, so a
+    foreign-platform row (a Windows drive path on a POSIX worker) parses, stays verbatim, and is inert on
+    that platform — the one place the shared parser is platform-dependent, and the same advisory names it.
+  - `day` / `week` / `month` (optional): integer ≥ 1 run caps per UTC day / Monday-start UTC week /
+    calendar month, counted per scope beside the global windows. `0` is refused — "never run this scope"
+    already has two honest spellings (delete the trigger; a pause window).
+  - `concurrent` (optional): integer ≥ 1, the scope's in-flight ceiling, enforced by DEFERRAL through the
+    delayed set — never a refusal, a busy scope is transient state. At least one of the four is required.
+- **Canonicalization**: a local job's scope is `path.resolve(folder.trim())` and an absolute-path-shaped
+  row is stored resolved, so every spelling of one directory (`/srv/site/`, `/srv//site`, `/srv/x/../site`)
+  converges on one counter and one mutex slot, and Unicode is NFC-normalized on both sides (macOS's
+  filesystem hands back NFD while a dialog types NFC; ASCII is fixed under NFC so no existing key
+  changes); symlinks and filesystem case-insensitivity are deliberately not resolved (realpath is an fs
+  call on the hot path that can throw; on a case-insensitive volume `/Srv/Site` and `/srv/site` stay two
+  scopes — the pause matcher lives with both residuals). Forge scopes pass through with only the NFC
+  normalization. A
+  resolved local scope is always an absolute path and a repo string never is, so a folder and a repo both
+  named `a/b` cannot share counters. The pause matcher keeps the RAW `scopeOf` value — resolving there
+  would change which jobs an operator's existing trailing-slash window matches; the folder-vs-repo split
+  itself stays defined once, in `scopeOf`.
+- **Validation**: the SHARED `parseScopedLimits` (worker `./scoped-limits`) validates the WHOLE file
+  fail-loud (`configError`, positional labels); the admin reads AND writes through it and the worker
+  boot-loads through it, so the sides cannot drift (mirrors `INT-PAUSE-WINDOWS-FILE-CONTRACT`).
+- **Write protocol**: atomic tmp + rename, validated through `parseScopedLimits` before the write. A
+  MISSING file starts from the empty v1 shape; an EXISTING file with a missing or newer `version` refuses
+  the write (`{ invalid }`) — read and write both refuse, never a silent repair. This deliberately differs
+  from `INT-SUBSCRIPTIONS-FILE-CONTRACT`'s repair rule: repairing an analytics file risks nothing, while
+  re-stamping an enforcement file's version would launder a newer file's dropped fields into a valid v1 —
+  the exact widening the version field exists to prevent. The worker's directory watch hot-swaps on change
+  and keeps the last-good set on a bad edit.
+- **Enforcement** (issue #242, next slice): scoped windows reserve FIRST, between the token-cap read and
+  the global `reserveBudget`, under redis keys `budget:s:<16-hex sha256 of the canonical scope>` composed
+  by the budget module's own key builders; a scoped refusal returns `reason: "scope-cap"` pre-spend with
+  the global ledger untouched and its own counter kept (refused-still-counts, per ledger), and a GLOBAL
+  refusal after a scoped reserve releases the scoped slot — neither ledger may drain the other. The
+  refusal record's `budgetReserved` stays global-only (false on a `scope-cap` even though a scoped slot
+  was spent). The worker log names the scope by its 16-hex key, never the raw string (a folder path in the
+  log would breach no-PII-in-logs); the forge comment may name the repo it posts on. Concurrency defers at
+  the pickup gate with a fixed re-check delay; deferral consumes no attempt, no budget, no record. No
+  per-scope FIFO is promised: a newer job may take a freed scope ahead of an older deferred one, and a
+  sustained same-scope arrival rate can starve a deferred job indefinitely — deferral is a gate, not a
+  queue. A lowered `concurrent` never preempts in-flight jobs (next-pickup grain); a lowered cap applies
+  against counts already accrued. The forge semantic-dedup window is enqueue-time only, so a deferral
+  longer than that window admits the next identical delivery — unchanged from pause behavior. Each wake's
+  re-delay call is one more transient-redis-failure exposure (the job's `attempts: 2` absorbs a single
+  blip). The in-flight counter is process memory with no TTL: a hold leaked past the release seam (none is
+  known; the seam is guarded) recovers only by worker restart. A deployment with no limits file behaves
+  byte-identically, key for key and record for record, EXCEPT where the mutex serializes two same-folder
+  local jobs — which is the feature, visible in wall-clock and the queue's delayed count, never in keys or
+  records.
+- **Acceptance**: Given a file with `version: 2`, when either side reads it, then it is refused loudly
+  naming both versions, and a write against it is refused without touching the file. Given a row with
+  `scope: "*"`, `0` for any bound, a duplicate scope, or no limit field at all, when parsed, then the whole
+  file is refused with a positional message. Given rows `/srv/site` and `/srv/site/`, when parsed, then the
+  duplicate refusal fires — they are one scope. Given no `PI_SCOPED_LIMITS_FILE`, then the worker loads
+  `[]` and no scoped key is ever created.
+
+---
+
 ## INT-SUBSCRIPTIONS-FILE-CONTRACT
 
 - **Producer/Consumer**: operator → admin extension; the worker exports the validator and reads nothing.
@@ -2810,6 +2895,7 @@ recorded repair is re-running `/dispatch setup` (or editing the pointer by hand)
 
 | Date | Change |
 |---|---|
+| 2026-08-29 | Issue #242, schema slice. **NEW `INT-SCOPED-LIMITS-FILE-CONTRACT`**: `scoped-limits.json` (`PI_SCOPED_LIMITS_FILE`), per-scope day/week/month run caps and per-scope concurrency on the pause-windows scope vocabulary, shared-parser validated (`./scoped-limits`), versioned fail-loud-on-newer with a refuse-never-repair write rule, canonical (resolved) local scopes so one directory's spellings share one counter and one mutex slot. The enforcement and the admin/worker wiring land in this issue's later slices; the contract states their terms up front so the slices implement it rather than re-derive it. **`INT-PAUSE-WINDOWS-FILE-CONTRACT` UNCHANGED, checked**: `scopeOf` stays the single folder-vs-repo split and the pause matcher keeps matching the RAW scope — the new file's canonicalization is its own, recorded in both entries' terms. **`INT-SUBSCRIPTIONS-FILE-CONTRACT` UNCHANGED, checked**: its version rule is adopted by the new contract, its write-repair rule deliberately is not (analytics may repair; enforcement config must refuse), stated in the new entry. |
 | 2026-08-29 | Issue #231, surfaces slice, one CORRECTION. **`INT-TRIGGERS-FILE-CONTRACT` AMENDED**: the close-words paragraph claimed a merge that should release work "is a close too" unqualified; that holds on GitHub and Forgejo (both emit `closed` for a merged PR) and is FALSE on GitLab, whose `merge` is its own action no rule takes, so a GitLab close rule fires on an explicit close only. Stated as a per-forge gap rather than glossed; the READMEs, the operator skill and docs/gitlab.md carry the same qualification. No behavior changed, only the claim. |
 | 2026-08-29 | Issue #231, worker slice. **`INT-RUN-HISTORY-FILE-CONTRACT` AMENDED**: the `reason` enum gains `once-already-spent` -- the pre-spend policy refusal for a close job whose one-shot a FOREIGN job already spent (the job's own earlier attempt is excused, so BullMQ's attempts:2 survives; the refusal posts the sibling-pattern forge comment). Same admissible class as every policy reason: a fixed token, never payload text. **`INT-TRIGGERS-FILE-CONTRACT` UNCHANGED, checked**: the disarm writes exactly the `on.disarmed` mark that contract already specifies; the writer landed two slices ago and only its callers are new. |
 | 2026-08-28 | Issue #231, poller slice. **`INT-WEBHOOK-PAYLOAD-SUBSET` AMENDED** (synthesized row): the `closed` source rides the existing `/issues/events` feed -- a `closed` entry's `actor` is the closer with `{ id, login }` (verified live), PRs appear there discriminated by `issue.pull_request` and a merged PR emits `closed`, the PR arm fetches the PR once for shape parity, delivery ids stay `poll-e<event>`; the closer gate runs in the poller's choke point with the webhook arm's one-derivation predicate, an indeterminate lookup holds the cursor and retries, bounded, then drops that one close loudly (`poll_close_gate_gave_up`) -- nothing redelivers to a poller, so the availability half of fail-closed is a bound, not a wedge. Nothing is synthesized from open-PR-list disappearance (it cannot name the closer). The receiver-slice sentence "close triggers fire over webhooks only" is retired. **`REQ-DEDUP-BY-DELIVERY-GUID` UNCHANGED, checked**: `poll-e` ids were already in the `gh-` dedup space; closes add no id family. |

--- a/worker/.env.example
+++ b/worker/.env.example
@@ -74,6 +74,8 @@ PI_JOB_IMAGE=pi-job:latest          # the DEFAULT job image. Any trigger may nam
                                     # Unset = cron disabled for the worker; the receiver falls back to ./triggers.json in the folder it starts from (what `pi-dispatch init` scaffolds)
                                     # and refuses to start when neither exists (it holds the label/comment/pull_request trigger config)
 # PI_PAUSE_WINDOWS_FILE=            # ABSOLUTE path to pause-windows.json — "quiet hours" per folder/repo (pause runs between certain times/days/dates, auto-resume). Unset = feature off. See docs/pause-windows.md
+# PI_SCOPED_LIMITS_FILE=            # ABSOLUTE path to scoped-limits.json — per repo/folder job-count caps (day/week/month, refused pre-spend as scope-cap) and max concurrent jobs per scope (excess deferred, never dropped).
+                                    # Unset = no scoped caps or concurrency; the one-job-per-folder mutex for local jobs is always on and needs no file. See docs/scoped-limits.md
 # PI_SUBSCRIPTIONS_FILE=            # path to subscriptions.json — operator-declared subscription plan prices (the admin defaults to ./subscriptions.json in its working directory). Read by the ADMIN EXTENSION only, never at job time.
                                     # Subscription-backed providers bill 0 per run (their rate tables are all zeros), so this file is where the real price lives — cost analytics only; it changes no routing, auth, or job behavior
 # PI_SETTINGS_FILE=                 # ABSOLUTE path to the runtime settings overlay (default: OS temp /pi-dispatch/settings.json); edited by the admin extension, read by the worker per job

--- a/worker/package.json
+++ b/worker/package.json
@@ -55,6 +55,7 @@
     "./triggers-file": "./src/triggers-file.mjs",
     "./packages": "./src/packages.mjs",
     "./pause-windows": "./src/pause-windows.mjs",
+    "./scoped-limits": "./src/scoped-limits.mjs",
     "./identity": "./src/identity.mjs",
     "./gitlab-identity": "./src/gitlab-identity.mjs",
     "./forgejo-identity": "./src/forgejo-identity.mjs",

--- a/worker/src/config.mjs
+++ b/worker/src/config.mjs
@@ -244,6 +244,7 @@ export function loadConfig(env = process.env, { fileExists = existsSync } = {}) 
 		sandboxIdleMinutes: nonNegativeInt(env, "PI_SANDBOX_IDLE_MINUTES", 30), // bash's own TMOUT inside a sandbox; 0 = no idle logout
 		triggersFile: env.PI_TRIGGERS_FILE ?? null, // DES-CRON-VIA-BULLMQ-SCHEDULER: unified triggers file; null = cron disabled for the worker (it selects on.type:"cron")
 		pauseWindowsFile: env.PI_PAUSE_WINDOWS_FILE ?? null, // REQ-SCOPED-PAUSE-WINDOWS: per-folder/repo timed pause; null = no scoped pauses
+		scopedLimitsFile: env.PI_SCOPED_LIMITS_FILE ?? null, // issue #242: per-scope run caps + concurrency (INT-SCOPED-LIMITS-FILE-CONTRACT); null = none. The one-job-per-folder mutex for local jobs is code, not configuration, and holds regardless
 		schedulerStallMax: positiveInt(env, "PI_SCHEDULER_STALL_MAX", 2), // CONST-RETRY-INFRA-ONLY: per-scheduler stall backstop; positiveInt rejects <1 so a 0 threshold fails closed
 		logsDir: env.PI_LOGS_DIR || defaultLogsDir(), // || (not ??) so an empty string falls back to the default
 		settingsFile: env.PI_SETTINGS_FILE || defaultSettingsFile(), // || (not ??) so an empty string falls back; INT-CONFIG-OVERLAY-CONTRACT

--- a/worker/src/scoped-limits.mjs
+++ b/worker/src/scoped-limits.mjs
@@ -1,0 +1,277 @@
+/**
+ * Scoped limits (issue #242, INT-SCOPED-LIMITS-FILE-CONTRACT): per-scope run caps and per-scope
+ * concurrency, where a scope is what `scopeOf` already answers -- the folder for a local job, the repo
+ * for a forge one. One `scoped-limits.json` of `{ scope, day?, week?, month?, concurrent? }` entries:
+ * the day/week/month caps refuse a job pre-spend (reason `scope-cap`, a policy refusal), `concurrent`
+ * defers the excess through the delayed set (never a refusal -- a busy scope is transient state).
+ *
+ * This module is pure and fs-injectable (mirrors pause-windows.mjs in every respect): `parseScopedLimits`
+ * validates the file TEXT fail-loud, `loadScopedLimits` layers the one fs read on top, and the small
+ * helpers below are what the processor gate and the budget wiring consume. It also owns the in-process
+ * in-flight counter (`makeInFlight`) so the counter is unit-testable without a bullmq import, the same
+ * reason job-id.mjs is queue-free. The wiring that consumes all of this (the gate, the budget calls,
+ * the admin surfaces) lands in this issue's later slices; the module ships first so the contract has
+ * one implementation to bind to -- sentences below describing enforcement describe THOSE slices.
+ *
+ * The file is a SIBLING of pause-windows.json, not part of the settings overlay, deliberately: the
+ * deferral gate runs before the per-job overlay read, so gate-read config must come from a watched
+ * mutable ref, and the overlay's KNOWN_KEYS are flat scalars whose only map-shaped precedent
+ * (secretProfiles) is deliberately model-unreachable -- the opposite of what these limits need.
+ *
+ * `version` is REQUIRED and fail-loud-on-newer (subscriptions.mjs's rule, adopted here because this is a
+ * MONEY file): unknown fields are silently dropped per the operator-file policy, so a v2 cap field an old
+ * worker drops would be a silently WIDENED spend limit. Pause-windows shipping without a version is a
+ * sunk decision, not a precedent to extend to enforcement config.
+ *
+ * Custom: scoped limits validated inline per triggers.mjs/pause-windows.mjs precedent; zod not in deps
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync as fsExistsSync, readFileSync as fsReadFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import { configError } from "./config.mjs";
+import { scopeOf } from "./pause-windows.mjs";
+
+/** The schema version this build reads and writes. A file declaring a higher one is refused loudly. */
+export const SCOPED_LIMITS_VERSION = 1;
+
+/** The four limit fields a row may carry, in display order. */
+const LIMIT_FIELDS = ["day", "week", "month", "concurrent"];
+
+function isNonEmptyString(value) {
+	return typeof value === "string" && value.trim() !== "";
+}
+
+/**
+ * The canonical scope string for a job: the RESOLVED folder path for a local job, the repo for a forge
+ * one. `scopeOf` alone is not enough for enforcement: nothing on the trigger path normalizes
+ * `run.folder`, so `/srv/site`, `/srv/site/`, `/srv//site`, `/srv/x/../site` and a padded spelling are
+ * five distinct strings naming ONE directory -- an exact-string mutex keyed on the raw value would run
+ * them concurrently in one working tree, which is the exact race the mutex exists to close.
+ * `path.resolve` (not `normalize`, which keeps trailing slashes and whitespace) collapses them all; a
+ * relative folder resolves against the worker's cwd, the same base `prepareWorkspace`'s existence check
+ * uses; Unicode is NFC-normalized on both the job and the row side (see below). Two residuals,
+ * deliberate: symlinks are NOT resolved (realpath is an fs call on the hot path and can throw), and
+ * neither is filesystem case-insensitivity (on a default macOS/APFS volume `/Srv/Site` and `/srv/site`
+ * are one directory and two scopes) -- the pause matcher lives with both.
+ *
+ * The pause matcher itself keeps the RAW `scopeOf` value: resolving there would silently change which
+ * jobs an operator's existing trailing-slash window matches. The two features share the folder-vs-repo
+ * split (`scopeOf`, defined once) but not the normalization, and this comment is where that difference
+ * is recorded.
+ *
+ * A useful side effect: a resolved local scope is always an absolute path, and a repo string never is,
+ * so a folder named `a/b` and a repo named `a/b` can no longer collide in the counters or the mutex.
+ */
+export function canonicalScope(job) {
+	const scope = scopeOf(job);
+	if (!isNonEmptyString(scope)) return null;
+	// NFC on both kinds: macOS's filesystem hands paths back NFD while an admin dialog types NFC, so
+	// "wéb" can arrive as two byte sequences naming one thing -- without this, an NFD-spelled forge
+	// scope silently escapes an NFC-spelled cap (the local side would at least keep the structural
+	// mutex). ASCII is fixed under NFC, so no existing key changes.
+	return job?.kind === "local" ? resolve(scope.trim().normalize("NFC")) : scope.normalize("NFC");
+}
+
+/**
+ * Parse, validate, and normalize the scoped-limits file TEXT. Returns the normalized `limits` array
+ * (every row rebuilt as an explicit `{ scope, day, week, month, concurrent }` literal, `null` for absent
+ * fields, unknown fields dropped -- the operator-file policy). Throws `configError` (fail-loud) on any
+ * malformed entry. `path` is for error messages only -- this function touches no filesystem.
+ */
+export function parseScopedLimits(text, path) {
+	let parsed;
+	try {
+		parsed = JSON.parse(text);
+	} catch (error) {
+		throw configError(`scoped-limits file is not valid JSON: ${path} (${error.message})`);
+	}
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw configError(`scoped-limits file must be an object with "version" and "limits": ${path}`);
+	}
+	const version = parsed.version;
+	if (!Number.isInteger(version) || version < 1) {
+		throw configError(`scoped-limits file must have "version": 1 (an integer >= 1): ${path}`);
+	}
+	if (version > SCOPED_LIMITS_VERSION) {
+		throw configError(`scoped-limits file written by a newer pi-dispatch (version ${version}; this build understands ${SCOPED_LIMITS_VERSION}): ${path}`);
+	}
+	if (!Array.isArray(parsed.limits)) {
+		throw configError(`scoped-limits file must have a "limits" array: ${path}`);
+	}
+	const rows = parsed.limits.map((row, index) => normalizeLimit(row, index, path));
+	const seen = new Map();
+	rows.forEach((row, index) => {
+		if (seen.has(row.scope)) {
+			// Two rows for one scope is a precedence question with no right answer; the admin's
+			// edit-in-place never produces one, so a duplicate is always a hand-edit mistake.
+			throw configError(`scoped limit at index ${index}: duplicate scope ${JSON.stringify(row.scope)} (first at index ${seen.get(row.scope)}): ${path}`);
+		}
+		seen.set(row.scope, index);
+	});
+	return rows;
+}
+
+function normalizeLimit(row, index, path) {
+	const at = `scoped limit at index ${index}`;
+	if (row === null || typeof row !== "object" || Array.isArray(row)) {
+		throw configError(`${at}: must be an object: ${path}`);
+	}
+	if (!isNonEmptyString(row.scope)) throw configError(`${at}: scope must be a non-empty string: ${path}`);
+	const trimmed = row.scope.trim().normalize("NFC"); // the same NFC canonicalScope applies job-side
+	if (trimmed === "*") {
+		// "*" as ONE shared counter is redundant with the global caps, so the only useful reading is a
+		// per-scope default -- the OPPOSITE of what "*" means one file over (pause-windows: one rule
+		// matching all scopes). Refused rather than shipped divergent; a later version may adopt the
+		// per-scope-default reading, with an exact row beating "*" (recorded in the contract).
+		throw configError(`${at}: "*" is not supported -- add one row per scope (a per-scope default may adopt "*" later): ${path}`);
+	}
+	if (trimmed.includes("*")) {
+		// No globs, enforced rather than described: an exact matcher makes "acme/*" a row that governs
+		// nothing, and a silently inert money limit is the failure class this repo refuses outright.
+		throw configError(`${at}: scopes match exactly; a scope containing "*" is refused (no globs): ${path}`);
+	}
+	const norm = {
+		// An absolute path is stored resolved so a `/srv/site/` row governs `/srv/site` jobs -- the same
+		// collapse canonicalScope applies on the job side. isAbsolute is PLATFORM-NATIVE on purpose, so a
+		// foreign-platform row (a windows drive path on a POSIX worker) stays verbatim and is inert here;
+		// the doctor's unreferenced-scope advisory names it. Resolving it instead would "work" only by
+		// both sides mangling into the same cwd-prefixed string -- a match by accident, not by contract.
+		scope: isAbsolute(trimmed) ? resolve(trimmed) : trimmed,
+		day: null,
+		week: null,
+		month: null,
+		concurrent: null,
+	};
+	let any = false;
+	for (const field of LIMIT_FIELDS) {
+		const value = row[field];
+		// Absent-or-null (subscriptions.mjs's rule): null is the normalizer's OWN output for an unset
+		// field, so the parser must accept it back or it cannot re-parse what it produced -- the admin's
+		// read-modify-write goes through this parser on both edges.
+		if (value === undefined || value === null) continue;
+		// 0 is refused, not "never run": budget.mjs's caps treat every configured window as >= 1, and
+		// "never run this scope" already has two honest spellings (delete the trigger; a pause window).
+		// isSafeInteger, not isInteger: 1e21 passes isInteger and reads as a limit while being
+		// indistinguishable from unlimited -- a bound that cannot count is not a bound.
+		if (!Number.isSafeInteger(value) || value < 1) {
+			throw configError(`${at}: ${field} must be an integer >= 1: ${path}`);
+		}
+		norm[field] = value;
+		any = true;
+	}
+	if (!any) {
+		throw configError(`${at}: at least one of day, week, month, concurrent is required (a row that limits nothing is a row an operator sets and then trusts): ${path}`);
+	}
+	return norm;
+}
+
+/**
+ * Load and validate the scoped-limits file named by `config.scopedLimitsFile`. Returns `[]` when the file
+ * is unset (no scoped caps or concurrency -- a valid deployment; the folder mutex holds regardless, it is
+ * code, not configuration). `readFileSync`/`existsSync` are injectable for tests.
+ */
+export function loadScopedLimits(config, { readFileSync = fsReadFileSync, existsSync = fsExistsSync } = {}) {
+	const path = config.scopedLimitsFile;
+	if (path === null || path === undefined) return [];
+	if (!existsSync(path)) throw configError(`scoped-limits file does not exist: ${path}`);
+	return parseScopedLimits(readFileSync(path, "utf8"), path);
+}
+
+/**
+ * The exact-match row for a canonical scope, or null. Exact string equality only -- the pause matcher's
+ * semantics minus its "*" (refused above). With duplicates refused there is no precedence ladder.
+ */
+export function limitFor(limits, scope) {
+	if (!Array.isArray(limits) || !isNonEmptyString(scope)) return null;
+	return limits.find((l) => l.scope === scope) ?? null;
+}
+
+/**
+ * The scoped budget windows this job reserves against, or null when nothing applies (no row for the
+ * scope, or the row is concurrency-only). The returned `scope` is CANONICAL so the redis counters are
+ * spelling-stable. Shaped like the global `caps` object so `reserveBudget` consumes it unchanged.
+ */
+export function budgetCapsFor(job, limits) {
+	const scope = canonicalScope(job);
+	const row = limitFor(limits, scope);
+	if (!row || (row.day === null && row.week === null && row.month === null)) return null;
+	return { scope, caps: { day: row.day, week: row.week, month: row.month } };
+}
+
+/**
+ * The effective in-flight ceiling for this job's scope: `min(configured concurrent, structural)`, where
+ * structural is 1 for a local job -- the folder mutex -- and unbounded otherwise. The mutex is
+ * UNCONDITIONAL, in code, with no file configured and no off-switch: two agents in one bind-mounted
+ * working tree is the race `run.replicas` is already refused on local jobs for, and a cron trigger
+ * reaches it with no operator mistake at all (the scheduler mints the next occurrence at pickup and
+ * promotes on time alone, so a slow run overlaps its own successor). A configured `concurrent` above 1
+ * on a folder scope silently clamps to 1 rather than refusing at parse: scope strings are not reliably
+ * typeable as folder-vs-repo (`"a/b"` is a legal relative folder and a legal repo), so a parse-time
+ * classifier would misfire; min() cannot.
+ *
+ * No scope (a malformed payload) means no gate: Infinity, admit -- the job will fail its own validation
+ * downstream, and holding a mutex slot under key `null` helps nobody.
+ */
+export function concurrencyFor(job, limits) {
+	const scope = canonicalScope(job);
+	if (scope === null) return Infinity;
+	const structural = job?.kind === "local" ? 1 : Infinity;
+	const configured = limitFor(limits, scope)?.concurrent ?? Infinity;
+	return Math.min(structural, configured);
+}
+
+/**
+ * The redis key prefix for a scope's budget windows: `budget:s:<16 hex>`. Handed to
+ * `reserveBudget`/`releaseBudget` as `keyPrefix`, so `dayKey`/`weekKey`/`monthKey` compose
+ * `budget:s:<h>:YYYY-MM-DD` / `:w:...` / `:m:...` with zero new key-shape logic. A hash (the localJobId
+ * idiom: sha256, first 16 hex) rather than an escape: a scope legally contains `:` and `/` (folder
+ * paths, gitlab group/subgroup/project), which would collide with budget.mjs's own `w:`/`m:`/`t:`
+ * sub-namespaces, and a bijective escape grammar is a new thing to get wrong with unbounded key lengths.
+ * The one consumer that must map keys BACK to scopes is the admin's counter display, and it knows the
+ * configured scopes -- it recomputes keys through this same export, so unreadability in redis-cli is the
+ * accepted cost.
+ */
+export function scopeKeyPrefix(scope) {
+	const h = createHash("sha256").update(String(scope)).digest("hex").slice(0, 16);
+	return `budget:s:${h}`;
+}
+
+/**
+ * The per-process in-flight counter behind per-scope concurrency and the folder mutex. Process memory is
+ * the CORRECT store, not a compromise: one worker per docker daemon is the shape DES-CONCURRENCY-3
+ * assumes everywhere and `service install` enforces for installed units (`pi-dispatch start` holds no
+ * lock, and two hand-run workers are already unsupported -- the second one's boot reaper kills the
+ * first's live containers); the reaper removes every surviving `pi-job-*` container before the worker
+ * starts draining, so a fresh, empty map is never wrong about a live container except when the reap
+ * itself was skipped (`reaper_skipped`: docker missing/down at boot -- a state where no NEW container
+ * can start either); and a Redis-held counter would survive a crash WRONGLY -- a claim for a container
+ * the reaper just killed, demanding TTL/heartbeat machinery, a second source of truth about "what is
+ * running" (the OQ-008 failure mode).
+ *
+ * `tryAcquire` is a synchronous check-and-increment: no await between the read and the take, so under
+ * Node's single thread no interleaving exists at any concurrency. `release` never throws -- it runs in
+ * the processor's finally, where a throw would mask the job's real error -- and clamps at zero.
+ */
+export function makeInFlight() {
+	const counts = new Map();
+	return {
+		/** True and counted when under `limit`; false WITHOUT counting when at or over it. */
+		tryAcquire(scope, limit) {
+			const current = counts.get(scope) ?? 0;
+			if (current >= limit) return false;
+			counts.set(scope, current + 1);
+			return true;
+		},
+		/** Decrement, deleting at zero; a release without a matching acquire is a no-op, never a throw. */
+		release(scope) {
+			const current = counts.get(scope) ?? 0;
+			if (current <= 1) counts.delete(scope);
+			else counts.set(scope, current - 1);
+		},
+		/** The current in-flight count for a scope (tests and future observability). */
+		count(scope) {
+			return counts.get(scope) ?? 0;
+		},
+	};
+}

--- a/worker/test/config.test.mjs
+++ b/worker/test/config.test.mjs
@@ -279,6 +279,12 @@ test("triggers file is honored verbatim -- no default path, null means cron disa
 	assert.equal(c.triggersFile, "/abs/x.json");
 });
 
+test("scoped-limits file is honored verbatim -- no default path, null means no scoped limits", () => {
+	assert.equal(loadConfig({}).scopedLimitsFile, null);
+	const c = loadConfig({ PI_SCOPED_LIMITS_FILE: "/abs/scoped-limits.json" });
+	assert.equal(c.scopedLimitsFile, "/abs/scoped-limits.json");
+});
+
 test("configError is tagged for clean CLI reporting", () => {
 	assert.equal(configError("x").piDispatchConfig, true);
 });

--- a/worker/test/scoped-limits.test.mjs
+++ b/worker/test/scoped-limits.test.mjs
@@ -1,0 +1,267 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import {
+	SCOPED_LIMITS_VERSION,
+	parseScopedLimits,
+	loadScopedLimits,
+	canonicalScope,
+	limitFor,
+	budgetCapsFor,
+	concurrencyFor,
+	scopeKeyPrefix,
+	makeInFlight,
+} from "../src/scoped-limits.mjs";
+
+const wrap = (limits, version = 1) => JSON.stringify({ version, limits });
+const parse = (limits) => parseScopedLimits(wrap(limits), "sl.json");
+const localJob = (folder) => ({ kind: "local", folder });
+const ghJob = (repo) => ({ kind: "github", repo });
+
+// ── validator ───────────────────────────────────────────────────────────────────────────────────────────
+
+test("parseScopedLimits normalizes a full row and nulls absent fields", () => {
+	const [row] = parse([{ scope: "acme/web", day: 10, week: 40, month: 100, concurrent: 2 }]);
+	assert.deepEqual(row, { scope: "acme/web", day: 10, week: 40, month: 100, concurrent: 2 });
+	const [partial] = parse([{ scope: "acme/web", week: 40 }]);
+	assert.deepEqual(partial, { scope: "acme/web", day: null, week: 40, month: null, concurrent: null });
+});
+
+test("parseScopedLimits drops unknown fields (operator-file policy)", () => {
+	const [row] = parse([{ scope: "acme/web", day: 1, softHoldPct: 80, note: "x" }]);
+	assert.deepEqual(Object.keys(row).sort(), ["concurrent", "day", "month", "scope", "week"]);
+});
+
+test("parseScopedLimits round-trips its own output (null is absent, the subscriptions rule)", () => {
+	// The admin's read-modify-write goes through this parser on both edges, so the normalizer's own
+	// nulls must parse back clean or every partial edit refuses its own current state.
+	const first = parse([{ scope: "acme/web", week: 40 }, { scope: "/srv/site", concurrent: 1 }]);
+	const again = parseScopedLimits(JSON.stringify({ version: 1, limits: first }), "sl.json");
+	assert.deepEqual(again, first);
+	// An explicit null in a hand-written file counts as absent, so an all-null row still refuses.
+	assert.throws(() => parse([{ scope: "acme/web", day: null }]), /at least one of day, week, month, concurrent/);
+});
+
+test("parseScopedLimits rejects malformed files fail-loud", () => {
+	assert.throws(() => parseScopedLimits("{ not json", "sl.json"), /not valid JSON/);
+	assert.throws(() => parseScopedLimits(JSON.stringify([]), "sl.json"), /must be an object with "version" and "limits"/);
+	assert.throws(() => parseScopedLimits(JSON.stringify({ limits: [] }), "sl.json"), /must have "version": 1 \(an integer >= 1\)/);
+	assert.throws(() => parseScopedLimits(JSON.stringify({ version: 0, limits: [] }), "sl.json"), /must have "version": 1/);
+	assert.throws(() => parseScopedLimits(JSON.stringify({ version: "1", limits: [] }), "sl.json"), /must have "version": 1/);
+	assert.throws(() => parseScopedLimits(JSON.stringify({ version: 1 }), "sl.json"), /must have a "limits" array/);
+	assert.throws(() => parse(["nope"]), /must be an object/);
+	assert.throws(() => parse([null]), /must be an object/);
+	assert.throws(() => parse([{ day: 1 }]), /scope must be a non-empty string/);
+	assert.throws(() => parse([{ scope: "  ", day: 1 }]), /scope must be a non-empty string/);
+	assert.throws(() => parse([{ scope: "acme/web", day: 0 }]), /day must be an integer >= 1/);
+	assert.throws(() => parse([{ scope: "acme/web", week: -1 }]), /week must be an integer >= 1/);
+	assert.throws(() => parse([{ scope: "acme/web", month: 1.5 }]), /month must be an integer >= 1/);
+	assert.throws(() => parse([{ scope: "acme/web", concurrent: "2" }]), /concurrent must be an integer >= 1/);
+	// 2^53 passes Number.isInteger but cannot count; a bound indistinguishable from unlimited is refused.
+	assert.throws(() => parse([{ scope: "acme/web", day: 2 ** 53 }]), /day must be an integer >= 1/);
+	assert.equal(parse([{ scope: "acme/web", day: 1e3 }])[0].day, 1000);
+	assert.throws(() => parse([{ scope: "acme/web" }]), /at least one of day, week, month, concurrent is required/);
+});
+
+test("parseScopedLimits refuses a newer version loudly, naming both", () => {
+	assert.throws(
+		() => parseScopedLimits(wrap([], 2), "sl.json"),
+		/written by a newer pi-dispatch \(version 2; this build understands 1\)/,
+	);
+	assert.equal(SCOPED_LIMITS_VERSION, 1);
+});
+
+test('parseScopedLimits refuses "*" with the per-scope-default reversal note', () => {
+	assert.throws(() => parse([{ scope: "*", day: 1 }]), /"\*" is not supported -- add one row per scope/);
+	assert.throws(() => parse([{ scope: "  *  ", day: 1 }]), /"\*" is not supported/);
+});
+
+test("parseScopedLimits refuses any scope containing * (an exact matcher makes globs silently inert)", () => {
+	assert.throws(() => parse([{ scope: "acme/*", day: 1 }]), /scopes match exactly; a scope containing "\*" is refused/);
+	assert.throws(() => parse([{ scope: "*/web", day: 1 }]), /scopes match exactly/);
+	assert.throws(() => parse([{ scope: "/srv/*", day: 1 }]), /scopes match exactly/);
+});
+
+test("parseScopedLimits trims a padded row scope and drops unknown TOP-LEVEL keys", () => {
+	const rows = parseScopedLimits(JSON.stringify({ version: 1, limits: [{ scope: "  acme/web  ", day: 1 }], future: true }), "sl.json");
+	assert.equal(rows[0].scope, "acme/web");
+	assert.equal(rows.length, 1);
+});
+
+test("parseScopedLimits refuses duplicate scopes, including across path spellings", () => {
+	assert.throws(() => parse([{ scope: "acme/web", day: 1 }, { scope: "acme/web", week: 2 }]), /duplicate scope "acme\/web" \(first at index 0\)/);
+	// Both spellings resolve to /srv/site, so the duplicate check must see one scope, not two.
+	assert.throws(() => parse([{ scope: "/srv/site", day: 1 }, { scope: "/srv/site/", week: 2 }]), /duplicate scope "\/srv\/site"/);
+});
+
+test("parseScopedLimits stores absolute row scopes resolved; relative rows stay as written", () => {
+	const rows = parse([
+		{ scope: "/srv/site/", day: 1 },
+		{ scope: "/srv/x/../other", day: 1 },
+		{ scope: "./site", day: 1 },
+	]);
+	assert.equal(rows[0].scope, "/srv/site");
+	assert.equal(rows[1].scope, "/srv/other");
+	// A relative row is inert config (the job side always resolves); kept as written. The doctor
+	// advisory that flags it lands later in this issue -- until then the contract says: absolute paths.
+	assert.equal(rows[2].scope, "./site");
+});
+
+test("Unicode scopes NFC-normalize on both sides, so NFD and NFC spellings share one row and one key", () => {
+	const nfc = "acme/wéb"; // é as one codepoint
+	const nfd = "acme/wéb"; // e + combining acute
+	assert.notEqual(nfc, nfd); // distinct strings, one name
+	const limits = parse([{ scope: nfd, concurrent: 1 }]);
+	assert.equal(limits[0].scope, nfc);
+	assert.equal(canonicalScope(ghJob(nfd)), canonicalScope(ghJob(nfc)));
+	assert.equal(concurrencyFor(ghJob(nfd), limits), 1);
+	assert.equal(canonicalScope(localJob(`/srv/${nfd}`)), canonicalScope(localJob(`/srv/${nfc}`)));
+	assert.equal(scopeKeyPrefix(canonicalScope(ghJob(nfd))), scopeKeyPrefix(canonicalScope(ghJob(nfc))));
+});
+
+// ── loader ──────────────────────────────────────────────────────────────────────────────────────────────
+
+test("loadScopedLimits returns [] when the file is unset (no scoped limits; the mutex holds regardless)", () => {
+	assert.deepEqual(loadScopedLimits({ scopedLimitsFile: null }), []);
+	assert.deepEqual(loadScopedLimits({}), []);
+});
+
+test("the committed scoped-limits.example.json parses through the real loader (subscriptions' pin)", () => {
+	const limits = loadScopedLimits({ scopedLimitsFile: new URL("../../scoped-limits.example.json", import.meta.url).pathname });
+	assert.equal(limits.length, 2);
+	assert.equal(limits[0].scope, "acme/web");
+	assert.equal(limits[1].scope, "/srv/site");
+});
+
+test("loadScopedLimits throws when the configured file is missing, else parses it", () => {
+	const cfg = { scopedLimitsFile: "/x/sl.json" };
+	assert.throws(() => loadScopedLimits(cfg, { existsSync: () => false, readFileSync: () => "" }), /does not exist/);
+	const limits = loadScopedLimits(cfg, { existsSync: () => true, readFileSync: () => wrap([{ scope: "acme/web", day: 3 }]) });
+	assert.equal(limits.length, 1);
+	assert.equal(limits[0].day, 3);
+});
+
+// ── canonicalScope ──────────────────────────────────────────────────────────────────────────────────────
+
+test("canonicalScope collapses every spelling of one directory onto one key", () => {
+	const variants = ["/srv/site", "/srv/site/", "/srv//site", "/srv/x/../site", "  /srv/site  ", "/srv/site/.", "/srv/site//"];
+	const keys = new Set(variants.map((folder) => canonicalScope(localJob(folder))));
+	assert.deepEqual([...keys], ["/srv/site"]);
+});
+
+test("canonicalScope resolves a relative folder against the cwd (stated, not accidental)", () => {
+	assert.equal(canonicalScope(localJob("site")), resolve("site"));
+});
+
+test("canonicalScope passes a forge repo through untouched, so folder a/b and repo a/b cannot collide", () => {
+	assert.equal(canonicalScope(ghJob("acme/web")), "acme/web");
+	assert.equal(canonicalScope(ghJob("a/b")), "a/b");
+	assert.notEqual(canonicalScope(localJob("a/b")), "a/b"); // resolved to an absolute path
+});
+
+test("canonicalScope returns null when the job has no scope", () => {
+	assert.equal(canonicalScope({ kind: "local" }), null);
+	assert.equal(canonicalScope({ kind: "github" }), null);
+	assert.equal(canonicalScope(undefined), null);
+});
+
+// ── limitFor / budgetCapsFor / concurrencyFor ───────────────────────────────────────────────────────────
+
+test("limitFor is exact-match only", () => {
+	const limits = parse([{ scope: "acme/web", day: 10 }]);
+	assert.equal(limitFor(limits, "acme/web").day, 10);
+	assert.equal(limitFor(limits, "acme/other"), null);
+	assert.equal(limitFor(limits, "acme"), null);
+	assert.equal(limitFor([], "acme/web"), null);
+	assert.equal(limitFor(limits, null), null);
+});
+
+test("budgetCapsFor returns null for a concurrency-only row and for an unmatched scope", () => {
+	const limits = parse([{ scope: "acme/web", concurrent: 2 }]);
+	assert.equal(budgetCapsFor(ghJob("acme/web"), limits), null);
+	assert.equal(budgetCapsFor(ghJob("acme/other"), parse([{ scope: "acme/web", day: 1 }])), null);
+});
+
+test("budgetCapsFor shapes the caps like the global object, canonical scope included", () => {
+	const limits = parse([{ scope: "/srv/site", week: 40 }]);
+	const scoped = budgetCapsFor(localJob("/srv/site/"), limits);
+	assert.deepEqual(scoped, { scope: "/srv/site", caps: { day: null, week: 40, month: null } });
+});
+
+test("budgetCapsFor never leaks concurrent into the money caps (a mixed row keeps them apart)", () => {
+	const limits = parse([{ scope: "acme/web", week: 40, concurrent: 2 }]);
+	const scoped = budgetCapsFor(ghJob("acme/web"), limits);
+	assert.deepEqual(scoped, { scope: "acme/web", caps: { day: null, week: 40, month: null } });
+});
+
+test("canonicalScope leaves a forge scope's padding alone (passthrough means passthrough)", () => {
+	assert.equal(canonicalScope(ghJob(" acme/web ")), " acme/web ");
+});
+
+test("concurrencyFor: the folder mutex is the structural 1 and config cannot raise it", () => {
+	assert.equal(concurrencyFor(localJob("/srv/site"), []), 1);
+	assert.equal(concurrencyFor(localJob("/srv/site"), parse([{ scope: "/srv/site", concurrent: 5 }])), 1);
+	assert.equal(concurrencyFor(ghJob("acme/web"), []), Infinity);
+	assert.equal(concurrencyFor(ghJob("acme/web"), parse([{ scope: "acme/web", concurrent: 2 }])), 2);
+	assert.equal(concurrencyFor({ kind: "github" }, []), Infinity); // scopeless: no gate
+});
+
+// ── scopeKeyPrefix ──────────────────────────────────────────────────────────────────────────────────────
+
+test("scopeKeyPrefix is budget:s: plus 16 hex, pinned literally so the key shape cannot drift", () => {
+	// Literal vectors, never derived in the test: a changed hash or slice silently remaps every
+	// deployment's scoped counters to fresh keys (a cap reset nobody asked for).
+	assert.equal(scopeKeyPrefix("acme/web"), "budget:s:86f279ce9c29f106");
+	assert.equal(scopeKeyPrefix("/srv/site"), "budget:s:3cd3201de5fe686c");
+	assert.match(scopeKeyPrefix("anything at all"), /^budget:s:[0-9a-f]{16}$/);
+});
+
+test("scopeKeyPrefix keeps colon/slash rearrangements distinct (the reason it hashes)", () => {
+	assert.equal(scopeKeyPrefix("a:b/c"), "budget:s:fb7456513927a447");
+	assert.equal(scopeKeyPrefix("a/b:c"), "budget:s:3b07f80ca173745a");
+	assert.notEqual(scopeKeyPrefix("a:b/c"), scopeKeyPrefix("a/b:c"));
+	assert.notEqual(scopeKeyPrefix("a b/c"), scopeKeyPrefix("a/b c"));
+});
+
+// ── makeInFlight ────────────────────────────────────────────────────────────────────────────────────────
+
+test("makeInFlight admits under the limit and refuses at it, without counting the refusal", () => {
+	const m = makeInFlight();
+	assert.equal(m.tryAcquire("s", 2), true);
+	assert.equal(m.tryAcquire("s", 2), true);
+	assert.equal(m.tryAcquire("s", 2), false);
+	assert.equal(m.count("s"), 2); // the refused attempt did not increment
+	m.release("s");
+	assert.equal(m.tryAcquire("s", 2), true);
+});
+
+test("makeInFlight releases exactly ONE slot per release (a delete-all regression over-admits)", () => {
+	const m = makeInFlight();
+	assert.equal(m.tryAcquire("s", 3), true);
+	assert.equal(m.tryAcquire("s", 3), true);
+	assert.equal(m.tryAcquire("s", 3), true);
+	m.release("s");
+	assert.equal(m.count("s"), 2); // one release frees one slot, never the whole scope
+	assert.equal(m.tryAcquire("s", 3), true);
+	assert.equal(m.tryAcquire("s", 3), false);
+});
+
+test("makeInFlight release clamps at zero and deletes the key", () => {
+	const m = makeInFlight();
+	m.release("s"); // release with no acquire: no-op, never a throw
+	assert.equal(m.count("s"), 0);
+	assert.equal(m.tryAcquire("s", 1), true);
+	m.release("s");
+	m.release("s"); // double release must not open a second slot
+	assert.equal(m.tryAcquire("s", 1), true);
+	assert.equal(m.tryAcquire("s", 1), false);
+});
+
+test("makeInFlight: Infinity always admits and scopes are independent", () => {
+	const m = makeInFlight();
+	for (let i = 0; i < 20; i++) assert.equal(m.tryAcquire("a", Infinity), true);
+	assert.equal(m.tryAcquire("b", 1), true);
+	assert.equal(m.tryAcquire("b", 1), false);
+	assert.equal(m.count("a"), 20);
+	assert.equal(m.count("b"), 1);
+});


### PR DESCRIPTION
First slice of #242, deliberately inert: the `scoped-limits.json` operator file, its shared parser (`@edgehero/pi-dispatch/scoped-limits`), and `INT-SCOPED-LIMITS-FILE-CONTRACT`. Nothing consumes the module in production yet and the new `scopedLimitsFile` config key is read by nothing, so a deployment that configures nothing new is byte-identical by construction. The enforcement (the scope gate, the scoped budget windows, the folder mutex) and the admin/panel stack follow as the next slices; the contract states their terms up front so they implement it rather than re-derive it.

What the file is: `{ "version": 1, "limits": [ { "scope", "day"?, "week"?, "month"?, "concurrent"? } ] }` — per-scope run caps and a per-scope in-flight ceiling on the pause-windows scope vocabulary (folder for a local job, repo for a forge one; `scopeOf` stays the single place that split lives).

Decisions worth reviewing, each with its reason recorded in the module or the contract:

- **`version` required, fail-loud on newer, and the write side refuses rather than repairs.** Unknown fields drop silently per the operator-file policy, so a future cap field an old worker dropped would be a silently widened spend limit. Subscriptions repairs on write because it prices what already happened; enforcement config must refuse, and the contract says why the twins differ.
- **Canonical scopes.** Nothing on the trigger path normalizes `run.folder`, so `/srv/site`, `/srv/site/`, `/srv//site`, `/srv/x/../site` and a padded spelling are five strings naming one directory. The job side resolves (plus NFC), absolute-shaped rows are stored resolved the same way, and the pause matcher stays byte-untouched so no existing window changes meaning. Residuals (symlinks, case-insensitive volumes, foreign-platform rows) are named in the contract rather than discovered later.
- **`"*"` and every glob shape refused.** An exact matcher makes `acme/*` a row that governs nothing, and a silently inert money limit is the failure class the specs refuse outright. The per-scope-default reading of bare `"*"` is recorded as the compatible future extension, exact-beats-`*` pre-decided.
- **`budget:s:<16-hex>` key prefix** through `reserveBudget`'s existing `keyPrefix` seam, hash not escape (scopes legally contain `:` and `/`), pinned by literal vectors so a silent hash drift cannot remap live counters.
- **`makeInFlight` ships here** so the counter is unit-testable without a bullmq import; `concurrencyFor` clamps local scopes to 1 with no off-switch, which is the folder mutex the next slice wires into the pickup gate.

Specs: NEW `INT-SCOPED-LIMITS-FILE-CONTRACT`; `INT-PAUSE-WINDOWS-FILE-CONTRACT` and `INT-SUBSCRIPTIONS-FILE-CONTRACT` checked and unchanged, with the adopted-versus-rejected rules stated. One known tension, deliberate: the module's comments state the cron self-overlap fact that `DES-CRON-VIA-BULLMQ-SCHEDULER` still denies; that correction rides the enforcement PR so the fixed claim and the mechanism that makes it true land together.

Also: `.gitignore` gains `/scoped-limits.json` (the real file holds local folder paths), both `.env.example` mirrors gain the commented variable, and `scoped-limits.example.json` is the committed template (pinned to parse through the real loader). The `docs/scoped-limits.md` pointer resolves when the docs slice lands, before any release ships this.

Suite in the CI posture: 2791 tests, 0 fail, 1 skipped (the systemd unit parse, Linux-only). An adversarial pass over the parser fed it hostile vectors (float versions, BOMs, `__proto__` rows, 10k-char scopes, NFD spellings, `2^53` bounds) and every refusal message, round-trip, and key-composition claim held; the mutation checks on the new pins all go red when their behavior reverts.