### PR TITLE
release: v1.5.0 (worker 1.5.0, admin 1.5.0; receiver stays 1.3.0)

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -52,7 +52,7 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
  * follows in the same change.
  */
-export const RUNTIME_VERSION = "1.4.0";
+export const RUNTIME_VERSION = "1.5.0";
 
 /**
  * The `@edgehero/pi-dispatch-receiver` version the trigger-edge step installs -- pinned for exactly the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",
@@ -4253,7 +4253,7 @@
     },
     "worker": {
       "name": "@edgehero/pi-dispatch",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "description": "Self-hosted job harness for the pi coding agent: a BullMQ worker that drains the queue, mints scoped forge tokens, and runs one container per job — plus the pi-dispatch CLI (init, up, doctor, service).",
   "keywords": [


### PR DESCRIPTION
Ships #242 to npm: scoped limits (per-repo/per-folder run caps refused pre-spend as `scope-cap`, per-scope concurrency by deferral, the always-on one-job-per-folder mutex for local jobs), the confirm-gated `dispatch_limit_*` tools and the panel's `m` key, the doctor checks, and the corrected cron-overlap claims that the mutex makes true.

Version moves: root and worker and admin to 1.5.0, `RUNTIME_VERSION` to "1.5.0" (anti-drift tested). The receiver is deliberately untouched — nothing receiver-side reads the limits file — so it stays 1.3.0, its publish group skips on the version gate, its `^1.4.0` range admits worker 1.5.0, and `RECEIVER_VERSION` plus the wizard's two receiver pin literals stay put (grep-verified). The lock file carries only the four version substitutions.

Merging fires the npm publish for the worker and admin groups. Release notes get rewritten after the tags land.