### PR TITLE
release: v1.6.0 (worker 1.6.0, receiver 1.4.0, admin 1.6.0)

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -52,7 +52,7 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
  * follows in the same change.
  */
-export const RUNTIME_VERSION = "1.5.0";
+export const RUNTIME_VERSION = "1.6.0";
 
 /**
  * The `@edgehero/pi-dispatch-receiver` version the trigger-edge step installs -- pinned for exactly the
@@ -62,7 +62,7 @@ export const RUNTIME_VERSION = "1.5.0";
  * independently (the receiver's dependency range on the runtime is `^`), and pretending otherwise would
  * install a version that does not exist the first time they diverge.
  */
-export const RECEIVER_VERSION = "1.3.0";
+export const RECEIVER_VERSION = "1.4.0";
 
 /** The two npm package names, spelled once. Literals of this module -- see npmInstallArgsFor's argument. */
 const RUNTIME_PKG = "@edgehero/pi-dispatch";

--- a/admin/test/setup-wizard.test.mjs
+++ b/admin/test/setup-wizard.test.mjs
@@ -804,7 +804,7 @@ test("wizard: the edge's service answer installs the PINNED receiver, then the -
   assert.equal(attached.length, 2, "the npm install and the unit install — nothing else");
   assert.equal(attached[0].argv0, "npm", "posix npm, per npmSpawnOptions");
   assert.deepEqual(attached[0].args, mod.npmInstallArgsFor(RECEIVER_PKG, mod.RECEIVER_VERSION));
-  assert.ok(attached[0].args.includes(`${RECEIVER_PKG}@1.3.0`), "the pinned name@version token, spelled out");
+  assert.ok(attached[0].args.includes(`${RECEIVER_PKG}@1.4.0`), "the pinned name@version token, spelled out");
   assert.equal(attached[0].cwd, dir, "installed into the deployment dir, by cwd");
   assert.deepEqual(
     JSON.parse(readFileSync(join(dir, "package.json"), "utf8")),
@@ -818,7 +818,7 @@ test("wizard: the edge's service answer installs the PINNED receiver, then the -
   assert.equal(attached[1].cwd, dir);
 
   const c = seen.confirm.find((x) => /receiver/i.test(x.title));
-  assert.match(c.message, new RegExp(`${RECEIVER_PKG.replace("/", "\\/")}@1\\.3\\.0`), "the confirm shows the exact pin");
+  assert.match(c.message, new RegExp(`${RECEIVER_PKG.replace("/", "\\/")}@1\\.4\\.0`), "the confirm shows the exact pin");
   assert.match(c.message, /service install --receiver/, "and the unit command it will run after");
   assert.ok(c.message.includes(dir), "and names the cwd");
   assert.ok(reachedFirstTrigger(seen), "the wizard continued to step 11");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",
@@ -4236,10 +4236,10 @@
     },
     "receiver": {
       "name": "@edgehero/pi-dispatch-receiver",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@edgehero/pi-dispatch": "^1.4.0",
+        "@edgehero/pi-dispatch": "^1.6.0",
         "@octokit/webhooks": "14.2.0",
         "bullmq": "5.80.4",
         "ioredis": "5.11.1"
@@ -4253,7 +4253,7 @@
     },
     "worker": {
       "name": "@edgehero/pi-dispatch",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",

--- a/receiver/package.json
+++ b/receiver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-receiver",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "description": "Webhook receiver for pi-dispatch: the always-on edge that verifies GitHub, GitLab, Forgejo and Azure DevOps deliveries and enqueues (at most) one job per event for the worker.",
   "keywords": [
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@octokit/webhooks": "14.2.0",
-    "@edgehero/pi-dispatch": "^1.4.0",
+    "@edgehero/pi-dispatch": "^1.6.0",
     "bullmq": "5.80.4",
     "ioredis": "5.11.1"
   }

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Self-hosted job harness for the pi coding agent: a BullMQ worker that drains the queue, mints scoped forge tokens, and runs one container per job — plus the pi-dispatch CLI (init, up, doctor, service).",
   "keywords": [


### PR DESCRIPTION
The release for issue #230, `run.waitFor`. Five slices landed in #248, #249, #250, #251 and #252; this is the coordinated bump that makes them installable.

## Why all four move together

`run.waitFor` is carried by three packages and validated by three loaders, and a mismatched set fails in the worst available way.

**The receiver is the one that matters.** A widening like this is dropped silently by an older parser: a receiver below 1.4.0 matches the rule, enqueues the job **without** its conditions, and the worker runs it. The result is a perfectly normal record, a normal panel row and a normal log line, with nothing anywhere saying the wait did not happen. The worker detects that and refuses `wait-skew` from 1.6.0, but a backstop is not the fix.

So the dependency range moves too, and that is the substantive line in this diff: `^1.4.0` **admits** worker 1.6.0 without **requiring** it, so npm could pair a published receiver 1.4.0 with a 1.4.x worker whose bundled `parseTriggers` has no `validateWaitFor`. It is now `^1.6.0`.

**The admin bump is not cosmetic.** `admin/build.mjs` inlines the worker subpaths, so the console ships a validator frozen at build time and only a republish refreshes it. That is the third loader.

## What is in the diff

| File | Change |
|---|---|
| `package.json`, `worker/package.json`, `admin/package.json` | 1.5.0 to 1.6.0 |
| `receiver/package.json` | 1.3.0 to 1.4.0, and its `@edgehero/pi-dispatch` range to `^1.6.0` |
| `admin/src/setup-wizard.ts` | `RUNTIME_VERSION` to 1.6.0, `RECEIVER_VERSION` to 1.4.0 |
| `admin/test/setup-wizard.test.mjs` | two pins that spell the version out |
| `package-lock.json` | six lines: the four workspace versions and the range |

The two wizard pins spell their version out deliberately, so a constant that moves while the argv token does not gets caught. Both were moved by hand rather than swept, and the second (an escaped regex, `@1\.3\.0`) is exactly the one a `sed` over the literal string would have missed: the suite caught it.

The lockfile was edited to those six lines rather than regenerated. A regenerated one also stripped `libc` fields and rewrote a `bin` path, npm-version churn that has nothing to do with this release and would have differed from what CI produces.

## Verification

Full suite in CI posture with live Valkey: **2972 tests, 0 fail, 1 skip** (the systemd unit parse, Linux-only).

Merging fires the npm publish and creates four releases: `v1.6.0`, `worker-v1.6.0`, `receiver-v1.4.0` and `admin-v1.6.0`. Their bodies get rewritten after they are cut, and #230 closes then.