### PR TITLE
fix(test): the wiring tests decline without a queue rather than hanging (#57)

### DIFF
--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -17,7 +17,16 @@ try {
 if (!mod && process.env.PI_DISPATCH_REQUIRE_WORKER_TESTS === "1") {
 	throw new Error(`start wiring tests are REQUIRED here but a dependency could not import.\n${importError}`);
 }
-const skip = mod ? false : `worker deps not installed (node ${process.version} < 22.19.0); CI runs these`;
+// These tests need a REAL queue: `startWorker` connects for real (the fakes here stop at docker, not at
+// the queue), and BullMQ's connections carry `maxRetriesPerRequest: null`, so a URL pointing at nothing does
+// not fail, it HANGS forever. That makes "no Valkey" a state this file must DECLINE rather than attempt --
+// a hang has no error, no output and no end, and it wedged both the required contract job and the release
+// workflow, the latter of which has no Valkey service at all and would never have published.
+const skip = !mod
+	? `worker deps not installed (node ${process.version} < 22.19.0); CI runs these`
+	: process.env.VALKEY_TEST_URL
+		? false
+		: "needs VALKEY_TEST_URL (startWorker connects for real; a dead URL hangs rather than fails)";
 
 // The Valkey these tests actually reach. `startWorker` connects for real here -- the fakes stop at docker,
 // not at the queue -- so a URL pointing at nothing does not fail, it HANGS: BullMQ's connections carry


### PR DESCRIPTION
**The v1.7.0 release is stuck and this unsticks it.**

`release.yml` runs `npm test` before publishing and declares no Valkey service. The host-identity wiring tests merged in #57 connect for real, so with no queue to reach they hang rather than fail: BullMQ's connections carry `maxRetriesPerRequest: null`, which makes a command against an unreachable server queue forever instead of rejecting.

The publish step is therefore never reached. `@edgehero/pi-dispatch` and `@edgehero/pi-dispatch-admin` do not reach npm, `worker-v1.7.0` and `admin-v1.7.0` are never cut, and nothing reports an error: the workflow simply runs to the six hour ceiling. `v1.7.0` (the root release) was cut by a different workflow and did land, so the repo currently claims a version its packages do not have.

Pointing the tests at `VALKEY_TEST_URL` fixed the required contract job, which sets one. It does not fix this workflow, which has none to point at. "No Valkey" has to be a state this file **declines** rather than attempts, so it now skips on the same idiom `cli.test.mjs` already uses.

**Nothing that gates a merge is weakened.** The required job sets `VALKEY_TEST_URL` and `PI_DISPATCH_REQUIRE_WORKER_TESTS=1` together, so every one of these tests still runs there.

Verified in all three shapes:

| Shape | Before | After |
|---|---|---|
| Required contract job (`VALKEY_TEST_URL` set) | 32 pass | 32 pass |
| No queue (`release.yml`) | **never terminates** | 38 skip, exits at once |
| Full suite, CI posture | 3060 / 0 / 1 | 3060 / 0 / 1 |
| Full suite, release posture | **never terminates** | 3013 pass, 55 skip, exit 0 |

Why it was missed: a hang is not a failure. It has no error, no output and no end, so it reads as "still running" until someone measures it against a job that historically takes ninety seconds.