### PR TITLE
ci: one run per commit, and cancel the superseded ones (#259)

### DIFF
--- a/.github/workflows/deploy-lint.yml
+++ b/.github/workflows/deploy-lint.yml
@@ -18,7 +18,12 @@
 name: deploy lint
 
 on:
+  # MAIN ONLY, for the reason `pi-upgrade-check.yml` records at greater length: without a `branches:` key
+  # this fired on every branch, so a PR branch touching `deploy/` ran twice and produced two check runs
+  # under one context name. This check is deliberately NOT required, so the duplicate could not deadlock a
+  # merge -- but it could still show green twice while one of them was red.
   push:
+    branches: [main]
     paths:
       - "deploy/**"
       - ".github/workflows/deploy-lint.yml"
@@ -27,6 +32,12 @@ on:
       - "deploy/**"
       - ".github/workflows/deploy-lint.yml"
   workflow_dispatch:
+
+# Superseded runs are cancelled rather than queued. Same reasoning as `pi-upgrade-check.yml`: a literal
+# group would serialise every PR against every other, and nothing here is a publish that must finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/pi-upgrade-check.yml
+++ b/.github/workflows/pi-upgrade-check.yml
@@ -15,7 +15,15 @@
 name: pi upgrade check
 
 on:
+  # MAIN ONLY. Without a `branches:` key this fired on every branch, so a commit on a PR branch ran the
+  # whole suite TWICE -- once here, once as `pull_request` -- and both runs emitted the same five required
+  # context names for the same sha. That is exactly the failure the comment below rejects a companion
+  # workflow for ("two check runs then share one context name -- a green stand-in that can mask a red real
+  # run"), reached through a different door. A PR branch now gets one run, from `pull_request`; main gets
+  # one, from here. The cost is that pushing a branch with no PR open runs nothing, which is the intended
+  # trade: checks report when there is something for them to gate.
   push:
+    branches: [main]
     paths:
       - "image/**"
       - "worker/**"
@@ -44,6 +52,19 @@ on:
     # project's design being written. A pin that is never exercised rots silently.
     - cron: "0 6 * * 1"
   workflow_dispatch:
+
+# A BARE LITERAL GROUP WOULD BE WRONG HERE, which is why this departs from the four publisher workflows
+# (image, receiver-image, release, repo-release). Those are `push: branches: [main]` only, so `group: image`
+# names one queue that genuinely should be serial. This workflow runs on `pull_request`, and a literal
+# would put EVERY open PR in one group -- each new PR cancelling the last one's checks.
+#
+# `cancel-in-progress` is safe here and is not safe there: a superseded run of this workflow is one whose
+# commit nobody is merging any more, while a superseded run of `release` is a publish halfway through.
+# Ten pushes to a branch used to leave ten sets of runs queued against each other, and the newest commit --
+# the only one that matters -- waited behind its own predecessors.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   version-pin:


### PR DESCRIPTION
Closes #259. Two changes, and the first is the one the issue did not name.

## The push trigger had no `branches:` key

Path-filtered only, so it fired on **every** branch. A commit on a PR branch therefore ran the whole suite **twice** — once as `push`, once as `pull_request` — and both runs emitted the same five required context names for the same sha:

```
$ gh api repos/edgehero/pi-dispatch/commits/311159b/check-runs
   2 success  pins are exact (CONST-PI-VERSION-PINNED)
   2 success  no automatic merge (CONST-MERGE-NEVER-AUTOMATIC)
   2 success  pinned assumptions still hold (offline, no API key)
   2 success  the job image holds its contract
   2 success  the admin extension survives latest pi (canary)
```

**That is the failure this workflow's own comment already rejects a companion-workflow design for**, reached through a different door:

> two check runs then share one context name -- a green stand-in that can mask a red real run

It also made the naive fix actively unsafe: `cancel-in-progress: true` on its own would have produced a **cancelled** run and a **green** run sharing one required context name.

Scoping `push:` to `main` gives a PR branch exactly one run and main exactly one. The cost is that pushing a branch with no PR open now runs nothing — the intended trade, since checks should report when there is something for them to gate.

## Then the concurrency group

Ten pushes to a branch left ten sets of runs queued against each other, so the newest commit waited behind its own predecessors. During #57 this made the required contract job read `pending` for over an hour, which is indistinguishable from a slow job and — as it turned out that day — from a hung one.

**The group is an expression, not the bare literal the four publisher workflows use, and that is deliberate.** `image`, `receiver-image`, `release` and `repo-release` are all `push: branches: [main]` with no `pull_request`, so `group: release` names one queue that genuinely should be serial. A literal here would put **every open PR in one group**, each new PR cancelling the last one's checks.

`cancel-in-progress: true` is safe here and would not be there: a superseded run of this workflow is one whose commit nobody is merging any more, where a superseded run of `release` is a publish halfway through. None of the existing four carries a comment explaining its choice — the conspicuous exception to this repo's "comments explain why" rule — so these two do.

## What did not change

`pull_request:` on `pi-upgrade-check.yml` stays **unfiltered**, verified by parsing the file. That is what stops a docs-only PR from reporting nothing and becoming unmergeable forever (#105), and re-adding a `paths:` there would re-open that deadlock.

## Verification

All six workflow files parse, and the two changed ones now differ from the publishers only where intended:

| workflow | push.branches | concurrency | cancel |
|---|---|---|---|
| pi-upgrade-check | `['main']` | yes | **true** |
| deploy-lint | `['main']` | yes | **true** |
| image | `['main']` | yes | false |
| receiver-image | `['main']` | yes | false |
| release | `['main']` | yes | false |
| repo-release | `['main']` | yes | false |

All five required contexts still resolve to jobs in this workflow, matched against live branch protection.

**This PR is its own test.** It should produce exactly one run (`event=pull_request`), and each context should appear **once** rather than twice. Worth watching before merging anything else, since the contexts are configured server-side by name with `enforce_admins` on; the documented escape hatch is in CLAUDE.md if they ever fail to report.

No version bump: `.github/` is not a workspace and is not in `release.yml`'s trigger paths.