### PR TITLE
chore(release): 1.10.1, so the resume fix reaches an installed deployment

### DIFF
--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -52,7 +52,7 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
  * follows in the same change.
  */
-export const RUNTIME_VERSION = "1.10.0";
+export const RUNTIME_VERSION = "1.10.1";
 
 /**
  * The `@edgehero/pi-dispatch-receiver` version the trigger-edge step installs -- pinned for exactly the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -4238,7 +4238,7 @@
     },
     "worker": {
       "name": "@edgehero/pi-dispatch",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "description": "Self-hosted job harness for the pi coding agent: a BullMQ worker that drains the queue, mints scoped forge tokens, and runs one container per job — plus the pi-dispatch CLI (init, up, doctor, service).",
   "keywords": [


### PR DESCRIPTION
1.10.0 shipped with `REQ-RESUMABLE-SESSION` **inert**, and the fix landed on `main` after the release was cut. An operator installing 1.10.0 still has the broken behaviour, so worker and root move to 1.10.1.

The defect predates 1.10.0: `makeProcessor`'s `prepareWorkspace` wrapper replaced `runJob`'s third argument instead of extending it, so `piVersion` never arrived and `readCanonical`'s first gate fired on every job. Every `run.resume` cold-started while reporting success. See #275.

- **worker** and **root** to 1.10.1
- **admin** stays 1.10.0, because nothing in it changed
- **receiver** stays 1.5.0, both pins unmoved
- the wizard's `RUNTIME_VERSION` follows the worker, as its anti-drift test requires

Suite **3226 tests, 0 fail, 1 skip** in CI posture.