### PR TITLE
chore(release): 1.10.2, so the discoverable configuration reaches an installed deployment (#282)

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -52,7 +52,7 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
  * follows in the same change.
  */
-export const RUNTIME_VERSION = "1.10.1";
+export const RUNTIME_VERSION = "1.10.2";
 
 /**
  * The `@edgehero/pi-dispatch-receiver` version the trigger-edge step installs -- pinned for exactly the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",
@@ -4238,7 +4238,7 @@
     },
     "worker": {
       "name": "@edgehero/pi-dispatch",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "type": "module",
   "description": "Self-hosted job harness for the pi coding agent: a BullMQ worker that drains the queue, mints scoped forge tokens, and runs one container per job — plus the pi-dispatch CLI (init, up, doctor, service).",
   "keywords": [


### PR DESCRIPTION
Cuts v1.10.2, which is what carries #282 to installed deployments: `.env.example` ships inside `@edgehero/pi-dispatch`, and `pi-dispatch init` copies it verbatim into a new deployment, so nine newly documented variables reach an operator only through a version bump.

## What moves

| Package | From | To | Why |
|---|---|---|---|
| root | 1.10.1 | 1.10.2 | cuts the `v*` product release, and retags both container images off it |
| `@edgehero/pi-dispatch` | 1.10.1 | 1.10.2 | `.env.example` ships inside it |
| `@edgehero/pi-dispatch-admin` | 1.10.0 | 1.10.1 | see below, this one is a correction |
| `@edgehero/pi-dispatch-receiver` | 1.5.0 | 1.5.0 | nothing in it changed |

**The admin bump is a correction, not just a consequence.** The wizard pins the worker version it installs (`RUNTIME_VERSION`), bolted to `worker/package.json` by an anti-drift test, so a worker bump moves that literal and changes admin's published bundle. 1.10.1 shipped without bumping admin in exactly this situation, which is why npm's `@edgehero/pi-dispatch-admin@1.10.0` still installs a worker one patch behind. Bumping here closes that rather than widening it by one more patch.

**The receiver stays put deliberately.** Its publish group skips on the version gate, its dependency range `^1.6.0` already admits 1.10.2, and `RECEIVER_VERSION` plus the spelled-out `@1.5.0` literal in `admin/test/setup-wizard.test.mjs` stay with it.

## What ships

* **#282**, the discoverable configuration: nine variables become keys in `.env.example`, seventeen carry a marker at their read site, `docs/polling.md` is new, `REQ-DEPLOYMENT-BOOTSTRAP` states the rule and `worker/test/env-docs.test.mjs` enforces it.
* **#284**, the four `run-mirror` tests whose fixed 2026-08-30 fixtures aged past a seven day retention window and turned `main` red. Test-only, no product behaviour.

## Verification

* Suite **3233 tests, 0 fail, 1 skip** in CI posture. `test-count-check` clean over 138 files.
* Both anti-drift version pins pass, and a grep for stale `1.10.0` / `1.10.1` literals across `worker/src`, `receiver/src`, `admin/src` and the wizard's tests comes back empty.
* `package-lock.json` regenerated: the diff is the four version lines and nothing else, which is the thing to check when the lock is rebuilt under a different npm minor.

## After merge

All three release bodies get rewritten with `gh release edit --notes-file`; the generated body is a raw commit list. Upgrade action is `npm install`, no service reinstall, and `init` never overwrites an existing `.env`, so an operator wanting the new commentary diffs it against the `.env.example` that ships in the package.

Two things found in this window and filed rather than fixed: **#286** (`doctor` passes `PI_PROVIDER=google` with only `GOOGLE_API_KEY`, and passes `gemini`; pi reads neither, so both refuse every job after a green preflight) and **#295** (`startWorker` never closes its three `fs.watch` handles, so one test's worker logs into another's capture).