### PR TITLE
fix(test,docs): the scanner's parser, and two claims that shipped wrong (#282)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -287,8 +287,10 @@ AZURE_WEBHOOK_HEADER=
 #   place. Several of them are also conditional, present only when the job has a flow, a command, staged
 #   packages or a session to resume. These are the container's side of INT-CONTAINER-RUNTIME-CONTRACT
 #   (specs/interfaces.md, docs/job-image.md), and run.secrets refuses the names at load so a trigger cannot
-#   bind one either. PI_FORWARD_ENV is NOT checked against them and its forwarded values are applied last,
-#   so naming one there does override the worker's own value. That is a real edge and not a recommendation.
+#   bind one either. PI_FORWARD_ENV is NOT checked against these names, and it is applied after the worker's
+#   own map, so naming one there does override it. Not everything is: run.secrets, the egress variables and
+#   the minted forge token are all written later still and win over a forwarded value. A real edge, not a
+#   recommendation.
 #
 #   PI_ENV_SETUP is an argument to `pi-dispatch service render|install --env-setup <absolute path>`, never a
 #   key. The service wrappers capture it BEFORE they source ./.env, precisely so that anything able to write

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -6,7 +6,8 @@ the same job from the other direction: it reads `api.github.com` with your own c
 connections it opens itself, and enqueues exactly the same jobs. No inbound surface at all.
 
 It is the same gate, not a second one (with one addition: a close rule resolves the closer's write
-access first, which the webhook arm does too, and which has its own failure mode below). Every object the poller reads is reshaped into the webhook
+access first, which the webhook arm does too, and which has its own failure mode below). Every
+object the poller reads is reshaped into the webhook
 payload it corresponds to and run through the receiver's own `parseSubset` and the unchanged
 `filter()`: the label allowlist, the author gate, the pull request author gate and the bot loop guard
 have one implementation, and the poller cannot drift from it because it reimplements none of it. What
@@ -29,11 +30,13 @@ npx pi-dispatch-receiver poll
 ```
 
 `WEBHOOK_SECRET` is not needed: there is no inbound delivery to verify, so demanding one would block
-exactly the deployment this mode exists for. It is not quite unread, though, and the difference can
-stop a boot. `poll` builds its config through the receiver's own loader rather than forking it, so a
-`WEBHOOK_SECRET` that is present but blank-ish (spaces) still fails that loader's own check, and a
-malformed `RECEIVER_PORT` refuses too, even though `poll` binds no port. A secret with a real value is
-simply carried and unused, which is what lets one env file serve both commands.
+exactly the deployment this mode exists for. It is not quite unread, though, and the difference can stop
+a boot. `poll` builds its config through the receiver's own loader rather than forking it, and a
+genuinely empty value is swapped for a placeholder before that loader ever sees it, so `WEBHOOK_SECRET=`
+boots while `WEBHOOK_SECRET=" "` does not: a space is a value, and the loader rejects it as one that
+cannot verify a signature. A malformed `RECEIVER_PORT` refuses too, even though `poll` binds no port. A
+secret with a real value is simply carried and unused, which is what lets one env file serve both
+commands.
 
 Everything else is shared with `serve`: the same `triggers.json` (`PI_TRIGGERS_FILE`), the same GitHub
 auth block, the same queue. Pair it with `pi-dispatch setup github --no-webhook`, which mints
@@ -132,7 +135,8 @@ servicing those forges needs the webhook edge for them, and can still poll GitHu
 
 `POLL_INTERVAL_SECONDS` defaults to 60, and a positive value below 30 is raised to 30: a typo'd `1`
 must not turn the harness into a hammer. Only a positive integer gets that treatment. `0`, a negative,
-a fraction or junk refuses the boot instead, which is the same split `PI_WAIT_INTERVAL_MS` makes. The effective delay is the larger of your interval and any `x-poll-interval`
+a fraction or junk refuses the boot instead, which is the same split `PI_WAIT_INTERVAL_MS` makes.
+The effective delay is the larger of your interval and any `x-poll-interval`
 GitHub asked for, so it can be longer than you configured and never shorter than 30.
 
 ### 4. A reopen inside one cycle is invisible
@@ -157,6 +161,7 @@ Comments self heal, because their cursor advances and the next cycle collects th
 
 `WEBHOOK_SECRET`, `RECEIVER_PORT` and `RECEIVER_BIND` are `serve` concerns and `poll` uses none of
 them, but it does load them, because it reuses the receiver's loader rather than forking it. A
-malformed value in any of the three refuses a `poll` boot with that loader's message. Everything in
-[`docs/secrets.md`](secrets.md) about the receiver applies here unchanged: the poller holds the same
-forge credential and the same queue URL.
+malformed `WEBHOOK_SECRET` or `RECEIVER_PORT` therefore refuses a `poll` boot with that loader's own
+message. `RECEIVER_BIND` is taken verbatim and validated by nothing, so there is no malformed value of
+it to refuse. Everything in [`docs/secrets.md`](secrets.md) about the receiver applies here unchanged:
+the poller holds the same forge credential and the same queue URL.

--- a/worker/.env.example
+++ b/worker/.env.example
@@ -287,8 +287,10 @@ AZURE_WEBHOOK_HEADER=
 #   place. Several of them are also conditional, present only when the job has a flow, a command, staged
 #   packages or a session to resume. These are the container's side of INT-CONTAINER-RUNTIME-CONTRACT
 #   (specs/interfaces.md, docs/job-image.md), and run.secrets refuses the names at load so a trigger cannot
-#   bind one either. PI_FORWARD_ENV is NOT checked against them and its forwarded values are applied last,
-#   so naming one there does override the worker's own value. That is a real edge and not a recommendation.
+#   bind one either. PI_FORWARD_ENV is NOT checked against these names, and it is applied after the worker's
+#   own map, so naming one there does override it. Not everything is: run.secrets, the egress variables and
+#   the minted forge token are all written later still and win over a forwarded value. A real edge, not a
+#   recommendation.
 #
 #   PI_ENV_SETUP is an argument to `pi-dispatch service render|install --env-setup <absolute path>`, never a
 #   key. The service wrappers capture it BEFORE they source ./.env, precisely so that anything able to write

--- a/worker/test/env-docs.test.mjs
+++ b/worker/test/env-docs.test.mjs
@@ -80,7 +80,9 @@ const REGEX_PRECEDING_WORDS = new Set(["return", "typeof", "instanceof", "in", "
  *     operands cannot carry an unbalanced quote or a backtick. When the candidate span does, the regex
  *     reading is taken.
  *   - `word` resets at whitespace. Without that, `else return` concatenates to `elsereturn`, which is in
- *     no keyword set, so the regex after it reads as division.
+ *     no keyword set, so the regex after it reads as division. This one is also redundant with the
+ *     content rule below, and kept for the same reason: it settles the case before a coarser layer has
+ *     to. Reverting it leaves this file green.
  */
 export function stripComments(src) {
 	let out = "";
@@ -185,11 +187,14 @@ function startsRegex(prevChar, word) {
 }
 
 /**
- * Settle a `/` that the preceding character called division. Two facts separate the cases, and both are
- * needed: a real division's operands carry no backtick and no unbalanced quote, and a regular expression
- * never opens with a space while `x / y` always does. Without the first, `if (a) /["]/.test(b)` misreads
- * and its quote eats the line; without the second, `(x) / y + "a/b"` misreads the other way and the same
- * thing happens from the opposite side.
+ * Settle a `/` that the preceding character called division: a real division's operands carry no backtick
+ * and no unbalanced quote, and a regular expression never opens with a space while `x / y` always does.
+ *
+ * Both rules are REDUNDANT with the per-line repair below, and deliberately kept. Reverting either one
+ * leaves this file green, which was measured rather than assumed. They earn their place by keeping the
+ * common cases from reaching the repair at all: the repair is a last resort that throws away everything
+ * it knew about where the strings on that line were, so the fewer lines that need it, the less of the
+ * file is read by a rule that coarse.
  */
 function ambiguousSpanIsRegex(span) {
 	if (/^\/\s/.test(span)) return false; // `/ y + ...` is division, whatever it contains
@@ -395,6 +400,9 @@ test("the stripper survives the literal forms that would otherwise fake a read",
 		['const a = (x) / y + "a/b";', "division on a line that also holds a quoted slash"],
 		["const t = `pre ${s.replace(/`/g, \"x\")} post`;", "a backtick regex inside a template expression"],
 		["function f(s) { if (a) {} else return /[\"]/.test(s); }", "a regex after `else return`, two words deep"],
+		["const t = `a ${ `inner ${x}` } b`;", "a template nested inside another template's expression"],
+		["const t = `a ${ JSON.stringify({k: 1}) } b`;", "an object literal in an expression, whose braces must not close it"],
+		["const t = `a ${ `i ${s.replace(/`/g, 1)}` } b`;", "a backtick regex inside a NESTED template expression"],
 	];
 	for (const [code, what] of cases) {
 		// BOTH directions. Every case here used to append the comment on the NEXT line, which is the half
@@ -420,6 +428,16 @@ test("the stripper survives the literal forms that would otherwise fake a read",
 	// the `//` reads as a comment, and a live read after it is deleted silently.
 	const survives = stripComments('if (a) /["]/.test(b) && f("x//y"); const v = env.PI_REAL_READ;\n');
 	assert.ok(survives.includes("env.PI_REAL_READ"), "a real read was stripped as if it were a comment");
+
+	// Reads inside a template EXPRESSION are code and must survive, including after nesting closes: the
+	// frame stack is the newest part of this parser and has the most ways to go wrong.
+	for (const [code, what] of [
+		["const t = `a ${env.PI_INNER} b`;", "a read inside a template expression"],
+		["const t = `a ${ `i` } b`;\nconst v = env.PI_INNER;", "a read after a nested template closes"],
+		["const t = `${ {a:1} }`;\nconst v = env.PI_INNER;", "a read after an object literal inside an expression"],
+	]) {
+		assert.ok(stripComments(code).includes("env.PI_INNER"), `a read was lost: ${what}`);
+	}
 
 	// A template literal genuinely spans lines and must NOT be reset at the newline.
 	const template = stripComments("const t = `one\n// still inside the template\ntwo`;\n// env.PI_TAIL\n");

--- a/worker/test/env-docs.test.mjs
+++ b/worker/test/env-docs.test.mjs
@@ -444,3 +444,53 @@ test("the stripper survives the literal forms that would otherwise fake a read",
 	assert.ok(template.includes("still inside the template"), "a multiline template was cut at its first newline");
 	assert.ok(!template.includes("PI_TAIL"), "the comment after the template survived");
 });
+
+/**
+ * The parser above is hand written, and four rounds of fixes on it shared one property: every defect was
+ * LATENT. The suite was green before and after each one, because nothing in this tree happened to use the
+ * literal forms that broke it, so a green run was never evidence the parsing was right.
+ *
+ * This asks a real parser instead of arguing. Be precise about what it buys, because it does NOT close
+ * that gap: a defect no file triggers is invisible here too. What it does is remove the need for anyone
+ * to THINK of the case. The day a file arrives using a form the hand parser gets wrong, this fails on
+ * that commit rather than years later, and it was measured: with template expressions broken, this test
+ * passes on today's tree and fails the moment a file using `` /`/ `` inside a `${}` is added.
+ *
+ * esbuild is already installed for the admin bundle. When it cannot be resolved the check skips rather
+ * than failing, on the same principle as the other conditional tests here.
+ */
+let esbuild = null;
+try {
+	esbuild = (await import("esbuild")).default;
+} catch {
+	// no esbuild in this install: the cross-check skips, the rest of the file still runs
+}
+
+test("the hand written stripper agrees with a real parser on every file in the tree", { skip: esbuild ? false : "esbuild is not installed" }, () => {
+	const namesIn = (code) => {
+		const found = new Set();
+		for (const re of READ_PATTERNS) {
+			re.lastIndex = 0;
+			for (let m; (m = re.exec(code)) !== null; ) found.add(m[1]);
+		}
+		return found;
+	};
+	const invented = [];
+	const missed = [];
+	for (const f of allSources()) {
+		const src = readFileSync(f, "utf8");
+		let real;
+		try {
+			real = namesIn(esbuild.transformSync(src, { loader: f.endsWith(".ts") ? "ts" : "js", legalComments: "none" }).code);
+		} catch {
+			continue; // a file esbuild will not parse is not this test's business
+		}
+		const mine = namesIn(stripComments(src));
+		for (const n of mine) if (!real.has(n)) invented.push(`${rel(f)}: ${n}`);
+		for (const n of real) if (!mine.has(n)) missed.push(`${rel(f)}: ${n}`);
+	}
+	// Invented is the failure that matters: a name the stripper sees and a real parser does not is a
+	// comment leaking into the scan, which fails this file's first test on a tree that is correct.
+	assert.deepEqual(invented.sort(), [], "the stripper found reads a real parser does not: a comment is leaking");
+	assert.deepEqual(missed.sort(), [], "a real parser found reads the stripper missed");
+});

--- a/worker/test/env-docs.test.mjs
+++ b/worker/test/env-docs.test.mjs
@@ -26,7 +26,9 @@
  *     would fail on a correct tree.
  *   - It FAILS CLOSED on an unfamiliar RECEIVER: any identifier ending in `env` other than the known
  *     ones is a fourth way to read the environment, and the test says so instead of silently shrinking
- *     its own scope. Destructuring the environment is refused for the same reason.
+ *     its own scope. Destructuring the environment is refused too, in its plain form: a default value
+ *     holding braces, or a spread copy, still slips past that guard, and it is named here rather than
+ *     implied to be covered.
  *   - It does NOT see a read through a NAME ARRAY. `["A","B"].filter((k) => env[k])` at
  *     `worker/src/doctor.mjs:565`, `:595` and `:915` reads real variables this scan cannot attribute.
  *     Every name those three sites touch is covered from another file today, which is why nothing
@@ -56,7 +58,7 @@ const ENV_RECEIVERS = new Set(["env", "hostEnv"]);
 const NON_ENV_RECEIVERS = new Map();
 
 // Words after which a `/` opens a regular expression rather than dividing. The character before is not
-// enough on its own: `return /x/` ends in a letter and `a / b` ends in a letter too.
+// enough on its own: `return /x/` ends in a letter, and so does `a / b`.
 const REGEX_PRECEDING_WORDS = new Set(["return", "typeof", "instanceof", "in", "of", "case", "do", "else", "yield", "await", "new", "delete", "void", "throw"]);
 
 /**
@@ -64,54 +66,135 @@ const REGEX_PRECEDING_WORDS = new Set(["return", "typeof", "instanceof", "in", "
  * `positiveInt(env, "PI_DAILY_CAP", 25)` is a read and must survive). Newlines inside a stripped block
  * are kept so reported line numbers stay honest.
  *
- * Regular expressions are tracked, and that is not fussiness. A literal like `/^["\']$/` holds a quote,
- * and without regex state that quote opens a phantom string that never closes, so EVERY comment after it
- * in the file survives into the scanned text and every variable a comment merely names reads as a live
- * read. The failure is a red test on a correct tree, and `["\']` is an ordinary idiom, used by this file's
- * own patterns below. The stripper's own behaviour is pinned by tests at the bottom of this file.
+ * Three things here exist because a simpler version was measured and found wrong, and every one of them
+ * fails in the same direction: a quote the scanner misreads opens a string that never closes, every
+ * later comment survives into the scanned text, and a variable some comment merely NAMES reads as a live
+ * read. That is a red test on a correct tree, which is worse than a name slipping through.
+ *
+ *   - Template EXPRESSIONS are code. `${...}` returns to code state and the matching `}` returns to the
+ *     template, tracked with a brace count per frame. Without it, a backtick inside a regex inside a
+ *     `${}` closes the template early and the rest of the file cascades, and `/`/` is an ordinary
+ *     escaping regex.
+ *   - The `/` ambiguity is settled by CONTENT, not only by the preceding character. `)` is followed by
+ *     division far more often than by a regex, so the heuristic says division, but a real division's
+ *     operands cannot carry an unbalanced quote or a backtick. When the candidate span does, the regex
+ *     reading is taken.
+ *   - `word` resets at whitespace. Without that, `else return` concatenates to `elsereturn`, which is in
+ *     no keyword set, so the regex after it reads as division.
  */
 export function stripComments(src) {
 	let out = "";
+	let line = 0;
+	const templateLines = new Set();
+	const damagedLines = new Set(); // lines where a quote never closed, so the read of them is not trusted
 	let state = "code";
+	const frames = []; // one per open `${`, holding its brace depth
 	let prevChar = ""; // last non-space character emitted in code state
 	let word = ""; // and the identifier it belongs to, when it is one
+	let afterSpace = false;
 	for (let i = 0; i < src.length; ) {
 		const c = src[i];
 		const d = src[i + 1];
 		if (state === "code") {
 			if (c === "/" && d === "/") { state = "line"; i += 2; continue; }
 			if (c === "/" && d === "*") { state = "block"; i += 2; continue; }
-			if (c === "/" && startsRegex(prevChar, word)) {
+			if (c === "/") {
 				const end = regexEnd(src, i);
-				if (end > 0) { out += src.slice(i, end); prevChar = "/"; word = ""; i = end; continue; }
+				if (end > 0 && (startsRegex(prevChar, word) || ambiguousSpanIsRegex(src.slice(i, end)))) {
+					out += src.slice(i, end);
+					prevChar = "/"; word = ""; afterSpace = false;
+					i = end; continue;
+				}
 			}
-			if (c === '"' || c === "'" || c === "`") state = c;
+			if (c === "`") { state = "`"; frames.push({ braces: 0, template: true }); out += c; i++; continue; }
+			if (c === '"' || c === "'") state = c;
+			if (frames.length > 0 && frames[frames.length - 1].template === false) {
+				if (c === "{") frames[frames.length - 1].braces++;
+				else if (c === "}") {
+					if (frames[frames.length - 1].braces === 0) { frames.pop(); state = "`"; out += c; i++; continue; }
+					frames[frames.length - 1].braces--;
+				}
+			}
 			out += c;
-			if (!/\s/.test(c)) {
+			if (c === "\n") line++;
+			if (/\s/.test(c)) { afterSpace = true; } else {
 				prevChar = c;
-				word = /[\w$]/.test(c) ? word + c : "";
+				word = /[\w$]/.test(c) ? (afterSpace ? c : word + c) : "";
+				afterSpace = false;
 			}
 			i++; continue;
 		}
-		if (state === "line") { if (c === "\n") { state = "code"; out += c; } i++; continue; }
-		if (state === "block") { if (c === "*" && d === "/") { state = "code"; i += 2; } else { if (c === "\n") out += c; i++; } continue; }
-		// A quoted string cannot span a line in JavaScript, so a newline while inside one means the quote
-		// that opened it was never a string quote at all. This is the BOUND on the regex heuristic below:
-		// `if (a) /["]/.test(b)` opens a regex after `)`, which the heuristic reads as division, and that
-		// stray quote would otherwise swallow every comment in the rest of the FILE. Resetting here costs
-		// the remainder of one line and cannot cascade. Backticks are excluded: those really do span lines.
-		if (c === "\n" && state !== "`") { state = "code"; out += c; i++; continue; }
+		if (state === "line") { if (c === "\n") { state = "code"; out += c; line++; } i++; continue; }
+		if (state === "block") { if (c === "*" && d === "/") { state = "code"; i += 2; } else { if (c === "\n") { out += c; line++; } i++; } continue; }
 		if (c === "\\") { out += c + (d ?? ""); i += 2; continue; } // an escape cannot close the literal
+		if (state === "`") {
+			templateLines.add(line);
+			if (c === "\n") line++;
+			if (c === "$" && d === "{") { frames.push({ braces: 0, template: false }); state = "code"; out += "${"; i += 2; continue; }
+			if (c === "`") { frames.pop(); state = frames.length > 0 && frames[frames.length - 1].template === false ? "code" : "code"; }
+			out += c; i++; continue;
+		}
+		// A quoted string cannot span a line, so a newline inside one means the quote that opened it was
+		// never a string quote. The bound on everything above: a misreading costs one line, not a file.
+		if (c === "\n") { damagedLines.add(line); state = "code"; out += c; line++; i++; continue; }
 		if (c === state) state = "code";
 		out += c; i++;
 	}
-	return out;
+	return repairPerLine(out, templateLines, damagedLines);
+}
+
+/**
+ * The last resort, applied ONLY to lines the pass above knows it misread: a quote that never closed
+ * before the newline, which a real quoted string cannot do. Such a line is re-scanned on its own and cut
+ * at the first `//`, because whatever the quote was, it was not a string, and the comment after it must
+ * not survive. Scoping it to those lines is the point: a line the pass read correctly is left alone, so
+ * a live read cannot be cut by a repair aimed at a line that did not need one.
+ *
+ * Lines written from inside a multi-line template are skipped as well: a `//` in template TEXT is content.
+ */
+function repairPerLine(text, templateLines, damagedLines) {
+	return text
+		.split("\n")
+		.map((l, n) => {
+			if (!damagedLines.has(n) || templateLines.has(n) || !l.includes("//")) return l;
+			let quote = "";
+			for (let i = 0; i < l.length; i++) {
+				const c = l[i];
+				if (c === "\\") { i++; continue; }
+				if (quote) { if (c === quote) quote = ""; continue; }
+				if (c === '"' || c === "'") { quote = c; continue; }
+				if (c === "/" && l[i + 1] === "/") return l.slice(0, i);
+			}
+			// Reaching the end still inside a quote means this line's quoting does not balance, and a real
+			// quoted string always balances within its line. So the quote was part of something else, a
+			// regular expression being the case that put this whole function here, and the quote reading is
+			// what to discard: cut at the first `//` and stop pretending to know where the strings were.
+			if (quote) {
+				const at = l.indexOf("//");
+				return at === -1 ? l : l.slice(0, at);
+			}
+			return l;
+		})
+		.join("\n");
 }
 
 function startsRegex(prevChar, word) {
 	if (prevChar === "") return true; // start of file
 	if (/[\w$)\]]/.test(prevChar)) return REGEX_PRECEDING_WORDS.has(word);
 	return true; // an operator, a comma, a brace: a value is expected, so this opens one
+}
+
+/**
+ * Settle a `/` that the preceding character called division. Two facts separate the cases, and both are
+ * needed: a real division's operands carry no backtick and no unbalanced quote, and a regular expression
+ * never opens with a space while `x / y` always does. Without the first, `if (a) /["]/.test(b)` misreads
+ * and its quote eats the line; without the second, `(x) / y + "a/b"` misreads the other way and the same
+ * thing happens from the opposite side.
+ */
+function ambiguousSpanIsRegex(span) {
+	if (/^\/\s/.test(span)) return false; // `/ y + ...` is division, whatever it contains
+	const odd = (ch) => (span.split(ch).length - 1) % 2 === 1;
+	return span.includes("`") || odd('"') || odd("'");
 }
 
 /** Index just past the closing `/` of the literal starting at `i`, or -1 when it does not terminate on
@@ -246,6 +329,8 @@ test("a read shape the scan cannot see is refused rather than missed", () => {
 			offenders.push(`${rel(f)}: ${m[0].replace(/\s+/g, " ").slice(0, 60)}`);
 		}
 	}
+	// Honest about its own reach: `const { A = {} } = process.env` and `{ ...process.env }` are NOT caught
+	// by this pattern. Widening it needs a balanced-brace scan, and the plain form is what anyone writes.
 	assert.deepEqual(offenders.sort(), [], "destructuring the environment hides the read from this scan: use env.NAME");
 });
 
@@ -308,10 +393,16 @@ test("the stripper survives the literal forms that would otherwise fake a read",
 		['const t = `a ${o["K"]} b`;', "a template literal with a quoted key inside its expression"],
 		['if (a) /["]/.test(b);', "a regex after `)`, which the heuristic reads as division"],
 		['const a = (x) / y + "a/b";', "division on a line that also holds a quoted slash"],
+		["const t = `pre ${s.replace(/`/g, \"x\")} post`;", "a backtick regex inside a template expression"],
+		["function f(s) { if (a) {} else return /[\"]/.test(s); }", "a regex after `else return`, two words deep"],
 	];
 	for (const [code, what] of cases) {
-		const out = stripComments(`${code}\n// env.PI_GHOST_NAME\n`);
-		assert.ok(!out.includes("PI_GHOST_NAME"), `a comment survived after ${what}: ${JSON.stringify(out)}`);
+		// BOTH directions. Every case here used to append the comment on the NEXT line, which is the half
+		// the line bound handles on its own, so three same-line leaks sat under a green test.
+		const next = stripComments(`${code}\n// env.PI_GHOST_NAME\n`);
+		assert.ok(!next.includes("PI_GHOST_NAME"), `a comment on the next line survived after ${what}: ${JSON.stringify(next)}`);
+		const same = stripComments(`${code} // env.PI_GHOST_NAME\n`);
+		assert.ok(!same.includes("PI_GHOST_NAME"), `a comment on the SAME line survived after ${what}: ${JSON.stringify(same)}`);
 	}
 	// And the other direction: a real read must never be stripped along with the comments.
 	const kept = stripComments('const v = env.PI_REAL; // and a trailing note\n');
@@ -323,6 +414,12 @@ test("the stripper survives the literal forms that would otherwise fake a read",
 	const bounded = stripComments('const s = "unclosed\nconst v = env.PI_AFTER; // note\n');
 	assert.ok(bounded.includes("env.PI_AFTER"), "a mis-read quote swallowed the following lines");
 	assert.ok(!bounded.includes("note"), "a mis-read quote stopped comments being stripped after it");
+
+	// The direction that loses a name rather than inventing one: a misread `/`, an odd quote, then a real
+	// `//` inside a genuine string later on the same line. The phantom string closes on the real quote,
+	// the `//` reads as a comment, and a live read after it is deleted silently.
+	const survives = stripComments('if (a) /["]/.test(b) && f("x//y"); const v = env.PI_REAL_READ;\n');
+	assert.ok(survives.includes("env.PI_REAL_READ"), "a real read was stripped as if it were a comment");
 
 	// A template literal genuinely spans lines and must NOT be reset at the newline.
 	const template = stripComments("const t = `one\n// still inside the template\ntwo`;\n// env.PI_TAIL\n");


### PR DESCRIPTION
Follows #294. An adversarial pass over that PR's own fixes found they were still wrong in four ways, and that two sentences in files the next release publishes were false. Everything here was reproduced before it was touched, and the reproductions are now tests.

## The stripper could still swallow the whole file

The line bound added in #294 exempted template literals, because those genuinely span lines. So a backtick the parser misread opened template state, and template state was never reset. `` /`/ `` inside a `${}` closes the template early and every comment to the end of the file survives into the scanned text, where any variable a comment merely names counts as a live read.

A 50 line probe leaked all 50. That is precisely the failure the previous header claimed could not happen, and `` /`/ `` is an ordinary escaping regex.

Three more in the same direction:

* **`word` never reset at whitespace**, so identifiers concatenated across it. `else return` became `elsereturn`, which is in no keyword set, so the regex after it read as division.
* **The pinned backtick case passed only because it sat after `= `.** Moved after `)` it cascaded. The test was giving confidence it had not earned.
* **A line could lose a real read**: a misread `/`, an odd quote, then a genuine `//` inside a string later on the same line, and everything after it is stripped including a live `env.NAME`. That is the direction that loses a name rather than inventing one.

## The fix

Template **expressions** are modelled as code, which is what they are, with a brace count per frame. The `/` ambiguity is settled by content as well as by the preceding character: a division's operands carry no backtick and no unbalanced quote, and a regular expression never opens with a space while `x / y` always does. **Both halves are needed** — each was added because the other alone produced the same leak from the opposite side. A per-line repair backs all of it, scoped to lines the parser *knows* it misread (a quote still open at the newline), so a line read correctly can never be cut by a repair meant for one that was not.

Twelve forms are pinned, each in **both** directions, next line and same line. The previous test only checked the next line, which is the half the bound already handled, and three same-line leaks sat under it green.

## Worth recording about this class of check

A differential run of the broken parser and the fixed one over all 130 files in the four scanned trees extracts **the same names from both**. Every defect above was latent, and a green suite was never evidence the parsing was right.

## Two claims that would have shipped

* **`RECEIVER_BIND` is validated by nothing.** `receiver/src/config.mjs:70` is `env.RECEIVER_BIND ?? "0.0.0.0"`, so there is no malformed value of it to refuse, and #294's "a malformed value in any of the three refuses a poll boot" was an overcorrection of the previous overcorrection. The page now says which two refuse and why the third cannot.
* **`.env.example` said `PI_FORWARD_ENV` is "applied last".** The forward loop is third of six: `run.secrets`, the egress variables and the minted forge token all land later and win over a forwarded value. The conclusion was right and the mechanism was wrong, which is the same shape as the two corrections before it, and `worker/src/env-allowlist.mjs` says so in its own comments three times.

## Also

The destructuring guard's reach is stated rather than implied, since a default value holding braces or a spread copy slips past it. The `WEBHOOK_SECRET` asymmetry is spelled out: an empty value boots and a space does not, because the placeholder swap happens before the loader's check. And two prose lines inserted mid-paragraph are rewrapped to the file's own width.

## Verification

Suite **3233 tests, 0 fail, 1 skip** in CI posture. `test-count-check` clean over 138 files. The scan still finds 106 names on the real tree, unchanged.

Release PR #296 waits on this and rebases after it lands, so the release does not publish either false sentence.