### PR TITLE
Release 1.10.3: a worker stops watching when it stops working

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch-admin",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Operator console (a pi extension) + skill for pi-dispatch: run the pi coding agent as a self-hosted service. A /dispatch TUI for the queue, spend caps, run history, editable GitHub, GitLab, Forgejo and Azure DevOps triggers (cron/label/comment/PR/MR/work item), and scheduled pause windows — plus AI-operable, human-confirmed controls. Runs against a live pi-dispatch deployment.",
   "keywords": [
     "pi-package",

--- a/admin/src/setup-wizard.ts
+++ b/admin/src/setup-wizard.ts
@@ -52,7 +52,7 @@ type Notify = ((message: string, type?: string) => void) | undefined;
  * version, so a release bump stays atomic: bump the worker and the test fails here until this literal
  * follows in the same change.
  */
-export const RUNTIME_VERSION = "1.10.2";
+export const RUNTIME_VERSION = "1.10.3";
 
 /**
  * The `@edgehero/pi-dispatch-receiver` version the trigger-edge step installs -- pinned for exactly the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-dispatch",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-dispatch",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "license": "MIT",
       "workspaces": [
         "image/runner",
@@ -20,7 +20,7 @@
     },
     "admin": {
       "name": "@edgehero/pi-dispatch-admin",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
         "bullmq": "5.80.4",
@@ -4238,7 +4238,7 @@
     },
     "worker": {
       "name": "@edgehero/pi-dispatch",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-dispatch",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "private": true,
   "description": "A containerized job harness for the pi coding agent",
   "license": "MIT",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgehero/pi-dispatch",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "type": "module",
   "description": "Self-hosted job harness for the pi coding agent: a BullMQ worker that drains the queue, mints scoped forge tokens, and runs one container per job — plus the pi-dispatch CLI (init, up, doctor, service).",
   "keywords": [


### PR DESCRIPTION
Ships #295 to npm.

`worker` 1.10.2 to **1.10.3**. The three live-edit directory watches now return a stop handle registered
with the shutdown. The defect reached npm: every deployment on 1.10.2 and earlier leaves three armed
`fs.watch` handles behind whenever a worker shuts down inside a process that keeps running, each still
holding that worker's log closure.

Root 1.10.2 to **1.10.3**, which cuts the product release and retags both container images off it.

`admin` 1.10.1 to **1.10.2**, a consequence rather than a change of its own. The wizard pins the worker
version it installs (`RUNTIME_VERSION`), bolted to `worker/package.json` by an anti-drift test, so the
worker bump moves that literal and changes admin's published bundle. Shipping a worker bump without it
is what left `@edgehero/pi-dispatch-admin@1.10.0` installing a worker one patch behind, which 1.10.2
corrected. Bumping here keeps it corrected.

`receiver` stays **1.5.0**. Nothing in it changed, its publish group skips on the version gate, and its
dependency range on the worker already admits 1.10.3. Its own watch has the same shape and is filed as
#301 rather than fixed here.

## Upgrade

`npm install`. No operator action beyond that: nothing in the configuration surface moved, and the
change is a lifecycle fix inside the worker process.

## Verification

Suite 3238 tests, 0 fail, 1 skipped in CI posture (the systemd-only case). test-count-check clean over
138 files. Both anti-drift version pins pass, and no stale 1.10.1 or 1.10.2 literal remains anywhere in
`worker/src`, `receiver/src`, `admin/src` or the wizard's tests. The lockfile moves the same four lines
the 1.10.2 release moved.
