### PR TITLE
Derive the hand-written tables, and harden the git site the census could not see (#286 sweep)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,17 @@ Two consequences worth internalising before you design anything:
   `.env.example`, and `worker/deploy/*` to `deploy/*`. Edit both.
 - The wizard's `RUNTIME_VERSION` and `RECEIVER_VERSION` are bolted to the workspace versions by anti-drift
   tests. A release bump moves all of them together.
+- **A hand-written table that restates a derivable source is either derived or pinned, never trusted.**
+  Every instance found so far had drifted, and every one was load-bearing. Current bolts: the
+  model-callable tool list in `REQ-`/`DES-ADMIN-VIA-PI-EXTENSION` against the registrations, and
+  `INT-TRIGGERS-FILE-CONTRACT`'s forge vocabularies against `PR_ACTIONS` (the two tests that read a spec
+  file); the admin's forge, action and settings vocabularies against `worker/src/triggers.mjs` and
+  `runtime-settings.mjs`; `EXIT_POLICY`'s copies in the runner and the `deploy/` units; the receiver
+  filters' action sets as the loader's set minus their own named exclusions; and the git hardening flags,
+  which live in `worker/src/git-hardening.mjs` because seven files carried them by hand and one had
+  quietly lost a flag. Add a table, add its bolt. Where the relation is NOT real, say so in the test
+  rather than manufacturing one: `PR_ACTION_VOCAB.dflt` is deliberately unpinned, with a line explaining
+  that gitlab's default is not its set's first member.
 
 ## Commits and PRs
 

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -92,6 +92,14 @@ import {
 import { buildGraphModel } from "./graph-model.mjs";
 import { buildInsightsHtml } from "./insights-html.mjs";
 import { parseBackendList } from "@edgehero/pi-dispatch/backends";
+// The trigger vocabularies, IMPORTED from the loader that validates them rather than retyped. Every one
+// of these was a hand-written copy of a table one package over, and this is the surface a MODEL authors
+// triggers through -- so both drift directions are silent and both are expensive. A widened loader table
+// that never reaches the hint means the model is told a word does not exist and never writes it: a
+// capability lost with no error anywhere. A narrowed one means the model proposes an entry, the operator
+// approves a confirm dialog, and writeTriggers rejects it: a wasted human approval. `blessedBackends`
+// below is the precedent, and its header is a post-mortem of the same mistake.
+import { FORGE_KINDS, ISSUE_ACTIONS, ON_TYPES, PR_ACTIONS, REVIEW_STATES } from "@edgehero/pi-dispatch/triggers";
 import { openBrowser } from "@edgehero/pi-dispatch/open-browser";
 // The worker's OWN window classifier (the same one reserveBudget enforces), so the budget states the
 // insights payload carries are words the page never derives and the panel and enforcement cannot drift.
@@ -473,7 +481,7 @@ function registerTools(pi: ExtensionAPI): void {
     description:
       "Adds a trigger to triggers.json and applies it live. The operator MUST approve a confirm dialog showing " +
       "the entry; with no interactive operator it is refused. `flow` is the .pi/skills/<name> skill the job runs " +
-      "(its SKILL.md is the agent's instructions). `kind` = cron|label|comment|pull_request|issue. cron (local) needs " +
+      "(its SKILL.md is the agent's instructions). `kind` = " + [...ON_TYPES].join("|") + ". cron (local) needs " +
       "id, pattern, `folder` (absolute host path the job runs in), `flow`, and `task` (the prompt text handed to " +
       "the agent), and may set optional model/provider/maxTurns for that schedule (omit = deployment default). " +
       "label needs labels[]+flow; comment needs phrase+flow; pull_request needs action[] (+ optional labels[]) + " +
@@ -483,13 +491,13 @@ function registerTools(pi: ExtensionAPI): void {
       "run is recorded, then the worker disarms the entry by writing on.disarmed; once requires number). A " +
       "close-only pull_request rule accepts the same number/once narrowing. " +
       "Webhook triggers take an optional `forge` = github (default) | gitlab | forgejo | azure, which " +
-      "also decides which action words pull_request accepts: github is " +
-      "labeled|opened|synchronize|reopened|review_submitted|closed, gitlab is open|update|reopen|approved|close, " +
-      "forgejo is label_updated|opened|synchronized|reopened|closed, azure is created|updated (no close word). " +
+      "also decides which action words pull_request accepts: " +
+      FORGE_KINDS.map((f: string) => `${f} is ${[...(PR_ACTIONS[f] as Set<string>)].join("|")}${ISSUE_CLOSE_WORD[f] ? "" : " (no close word)"}`).join(", ") +
+      ". " +
       "The close word rides alone: it cannot be mixed with other actions in one entry. An azure label or comment " +
       "trigger must also set `repository` (a work item belongs to a project, not a repository), and an azure " +
       "pull_request trigger may not carry labels[] at all. A github review_submitted trigger may also set " +
-      "reviewState[] (approved|changes_requested|commented) to narrow which verdicts fire; omitted, all " +
+      "reviewState[] (" + [...REVIEW_STATES].join("|") + ") to narrow which verdicts fire; omitted, all " +
       "three do. For webhook triggers the repo and the task come from the triggering " +
       "issue/PR event — set only the match + flow — and they run under the deployment default model. " +
       "`backend` (optional, any kind) names WHERE the job's container is built, chosen from the names this " +
@@ -987,22 +995,34 @@ function triggerList(paths: any): any[] {
  * chain, and an operator offered "github or gitlab" cannot discover that two more exist -- which is a
  * different failure from being refused: they simply never try.
  */
-export const FORGE_PROMPT = "forge — github, gitlab, forgejo or azure";
+export const FORGE_PROMPT = `forge — ${FORGE_KINDS.slice(0, -1).join(", ")} or ${FORGE_KINDS.at(-1)}`;
 // The per-forge issue close word (issue #231), the tool's default `action` for kind "issue": the
 // shared validator's ISSUE_ACTIONS accepts exactly one word per forge today, so defaulting to it
 // makes the kind authorable without knowing three forges' spellings. No azure entry on purpose --
 // the validator refuses the whole type there with its own message (a work item's close is a state
 // transition the projected payload subset cannot see), and a default here would only reword it.
-export const ISSUE_CLOSE_WORD: Record<string, string> = { github: "closed", gitlab: "close", forgejo: "closed" };
-export const PR_ACTION_VOCAB: Record<string, { hint: string; dflt: string }> = {
-  // The close words ride the hint too (issue #231): the dialog passes whatever is typed through the
-  // shared validator, so a close-only rule IS authorable here, and a hint that omits the word reads
-  // as the word not existing. The loader refuses a list mixing a close word with any other action.
-  github: { hint: "labeled opened synchronize reopened review_submitted closed", dflt: "labeled" },
-  gitlab: { hint: "open update reopen approved close", dflt: "update" },
-  forgejo: { hint: "label_updated opened synchronized reopened closed", dflt: "label_updated" },
-  azure: { hint: "created updated", dflt: "updated" },
+export const ISSUE_CLOSE_WORD: Record<string, string> = Object.fromEntries(
+  Object.entries(ISSUE_ACTIONS).map(([forge, actions]) => [forge, [...(actions as Set<string>)][0]]),
+);
+// The DEFAULTS stay hand-written and the hints do not, which is the whole distinction this sweep is
+// about. A hint restates what the loader ACCEPTS, so it is derived and cannot drift. A default answers
+// what an operator most often wants, which is an editorial judgement and not a property of the table:
+// gitlab's is `update`, not its set's first member `open`. Deriving it would manufacture a relation that
+// does not exist, and `admin/test/wiring.test.mjs` asserts that it is NOT the set's head so this stays a
+// decision rather than quietly becoming a coincidence.
+//
+// The close words ride the hint too (issue #231): the dialog passes whatever is typed through the shared
+// validator, so a close-only rule IS authorable here, and a hint that omits the word reads as the word
+// not existing. The loader refuses a list mixing a close word with any other action.
+const PR_ACTION_DEFAULT: Record<string, string> = {
+  github: "labeled",
+  gitlab: "update",
+  forgejo: "label_updated",
+  azure: "updated",
 };
+export const PR_ACTION_VOCAB: Record<string, { hint: string; dflt: string }> = Object.fromEntries(
+  FORGE_KINDS.map((forge: string) => [forge, { hint: [...(PR_ACTIONS[forge] as Set<string>)].join(" "), dflt: PR_ACTION_DEFAULT[forge] }]),
+);
 
 /**
  * Which backends this deployment blessed, answered by the WORKER'S OWN parser.

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -99,7 +99,7 @@ import { parseBackendList } from "@edgehero/pi-dispatch/backends";
 // capability lost with no error anywhere. A narrowed one means the model proposes an entry, the operator
 // approves a confirm dialog, and writeTriggers rejects it: a wasted human approval. `blessedBackends`
 // below is the precedent, and its header is a post-mortem of the same mistake.
-import { FORGE_KINDS, ISSUE_ACTIONS, ON_TYPES, PR_ACTIONS, REVIEW_STATES } from "@edgehero/pi-dispatch/triggers";
+import { FORGE_KINDS, ISSUE_ACTIONS, ON_TYPES, PR_ACTIONS, PR_CLOSE_ACTIONS, REVIEW_STATES } from "@edgehero/pi-dispatch/triggers";
 import { openBrowser } from "@edgehero/pi-dispatch/open-browser";
 // The worker's OWN window classifier (the same one reserveBudget enforces), so the budget states the
 // insights payload carries are words the page never derives and the panel and enforcement cannot drift.
@@ -492,7 +492,7 @@ function registerTools(pi: ExtensionAPI): void {
       "close-only pull_request rule accepts the same number/once narrowing. " +
       "Webhook triggers take an optional `forge` = github (default) | gitlab | forgejo | azure, which " +
       "also decides which action words pull_request accepts: " +
-      FORGE_KINDS.map((f: string) => `${f} is ${[...(PR_ACTIONS[f] as Set<string>)].join("|")}${ISSUE_CLOSE_WORD[f] ? "" : " (no close word)"}`).join(", ") +
+      FORGE_KINDS.map((f: string) => `${f} is ${[...(PR_ACTIONS[f] as Set<string>)].join("|")}${PR_CLOSE_ACTIONS[f] ? "" : " (no close word)"}`).join(", ") +
       ". " +
       "The close word rides alone: it cannot be mixed with other actions in one entry. An azure label or comment " +
       "trigger must also set `repository` (a work item belongs to a project, not a repository), and an azure " +
@@ -1014,6 +1014,9 @@ export const ISSUE_CLOSE_WORD: Record<string, string> = Object.fromEntries(
 // The close words ride the hint too (issue #231): the dialog passes whatever is typed through the shared
 // validator, so a close-only rule IS authorable here, and a hint that omits the word reads as the word
 // not existing. The loader refuses a list mixing a close word with any other action.
+// Keyed against a DERIVED key set, so a fifth forge would otherwise get a correct hint and an undefined
+// default -- and worse, because the key would exist, the `?? PR_ACTION_VOCAB.github` fallback at the
+// dialog would stop firing. `wiring.test.mjs` asserts this covers FORGE_KINDS.
 const PR_ACTION_DEFAULT: Record<string, string> = {
   github: "labeled",
   gitlab: "update",

--- a/admin/src/read-model.mjs
+++ b/admin/src/read-model.mjs
@@ -16,6 +16,7 @@
  */
 
 import * as nodeFs from "node:fs";
+import { GIT_READ_FLAGS } from "@edgehero/pi-dispatch/git-hardening";
 import { join, delimiter, sep } from "node:path";
 import { execFileSync } from "node:child_process";
 import { logsDirPath, defaultSandboxDir, defaultGraphDir, CHAIN_DEPTH_MAX_DEFAULT, CHAIN_MAX_PER_JOB_DEFAULT } from "@edgehero/pi-dispatch/config";
@@ -1626,11 +1627,12 @@ export function readFolderSkills({ folder, exec = execFileSync } = {}) {
   if (head === null) return { ...empty, unreachable: "not-a-git-repo" };
   let listing;
   try {
-    // Hardening flags mirror materialize.mjs defaultGit -- keep in sync: no hooks, no fsmonitor, no
-    // pager, so a hostile repo config cannot run code or corrupt output during a read.
+    // No hooks, no fsmonitor, no pager, so a hostile repo config cannot run code or corrupt output
+    // during a read. Imported from the worker rather than mirrored: this comment used to say "keep in
+    // sync" and one of the seven copies had not (issue #286's sweep).
     listing = exec(
       "git",
-      ["-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false", "--no-pager", "-C", folder, "ls-tree", "-r", "-l", "-z", head, ".pi/"],
+      [...GIT_READ_FLAGS, "-C", folder, "ls-tree", "-r", "-l", "-z", head, ".pi/"],
       { encoding: "utf8", maxBuffer: GRAPH_LS_TREE_MAX_BYTES },
     );
   } catch {
@@ -1671,7 +1673,7 @@ export function readFolderSkills({ folder, exec = execFileSync } = {}) {
     try {
       const buf = exec(
         "git",
-        ["-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false", "--no-pager", "-C", folder, "cat-file", "blob", entry.oid],
+        [...GIT_READ_FLAGS, "-C", folder, "cat-file", "blob", entry.oid],
         { maxBuffer: GRAPH_LIMITS.maxSkillBytes },
       );
       text = buf.toString("utf8");

--- a/admin/src/read-model.mjs
+++ b/admin/src/read-model.mjs
@@ -267,7 +267,10 @@ const DISPATCH_RUN_TTL_SECONDS = 2 * 60 * 60;
  */
 export function revParseHead(folder, { exec = execFileSync } = {}) {
   try {
-    const out = exec("git", ["-C", folder, "rev-parse", "HEAD"], { encoding: "utf8" });
+    // Hardened like every other host-side read. `rev-parse` does not refresh the index, so it does not
+    // invoke fsmonitor and nothing here was reachable -- but "this particular subcommand is harmless" is
+    // the reasoning that left `git-dirty.mjs` unhardened while `status` sat one module over.
+    const out = exec("git", [...GIT_READ_FLAGS, "-C", folder, "rev-parse", "HEAD"], { encoding: "utf8" });
     const sha = out.trim();
     return sha.length > 0 ? sha : null;
   } catch {

--- a/admin/test/wiring.test.mjs
+++ b/admin/test/wiring.test.mjs
@@ -1013,6 +1013,13 @@ test("PR_ACTION_VOCAB's hints are the loader's per-forge action words, in the lo
   // `dflt` is deliberately NOT pinned to the set: gitlab's is `update`, which is not its set's first
   // member. It answers "what does an operator usually want", not "what does the loader accept", and
   // pinning it would manufacture a relation that does not exist.
+  // ...but it must still COVER every forge. The keys are derived now, so a fifth forge gets a correct
+  // hint and an undefined default -- and because the key exists, the `?? PR_ACTION_VOCAB.github`
+  // fallback at the dialog no longer fires, turning "wrong default" into "no default".
+  for (const kind of FORGE_KINDS) {
+    assert.ok(mod.PR_ACTION_VOCAB[kind].dflt, `${kind} has no default action`);
+    assert.ok(PR_ACTIONS[kind].has(mod.PR_ACTION_VOCAB[kind].dflt), `${kind}'s default must be an action the loader accepts`);
+  }
   assert.equal(mod.PR_ACTION_VOCAB.gitlab.dflt, "update");
   assert.notEqual(mod.PR_ACTION_VOCAB.gitlab.dflt, [...PR_ACTIONS.gitlab][0], "the default is an editorial choice, not the set's head");
 });

--- a/worker/package.json
+++ b/worker/package.json
@@ -43,6 +43,7 @@
     ".": "./src/index.mjs",
     "./config": "./src/config.mjs",
     "./exit-code": "./src/exit-code.mjs",
+    "./git-hardening": "./src/git-hardening.mjs",
     "./flow-gate": "./src/flow-gate.mjs",
     "./materialize": "./src/materialize.mjs",
     "./open-browser": "./src/open-browser.mjs",

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -1985,11 +1985,11 @@ function aiTriggerNames(dir) {
  * for a gate and exactly wrong here, where deny-because-git-broke would print a confident wrong
  * answer on an advisory line. Doctor resolving HEAD itself is also fine: the gate's no-ref rule
  * defends against an agent self-authorizing mid-run, and a host-side preflight has no agent. What IS
- * the gate's, verbatim, is the ls-tree read, the 100644-blob requirement and the hardening flags --
- * copied so the two readers cannot disagree about what "a committed skill file" means, and so a
- * hostile repo config cannot run code during the read (flow-gate.mjs's defaultGit, restated).
+ * the gate's, verbatim, is the ls-tree read and the 100644-blob requirement -- so the two readers cannot
+ * disagree about what "a committed skill file" means. The hardening flags used to be restated here from
+ * flow-gate.mjs's defaultGit and are now imported from git-hardening.mjs, so "restated" is retired: both
+ * readers spread the same constant and a hostile repo config cannot run code during either read.
  */
-
 async function repoFlowAtHead(spawn, folder, flow) {
 	if (!SKILL_NAME_RE.test(flow)) return "unknown"; // the caller pre-checks; belt against interpolation
 	const head = await runCmdCapture(spawn, "git", [...GIT_READ_FLAGS, "-C", folder, "rev-parse", "HEAD"]);

--- a/worker/src/doctor.mjs
+++ b/worker/src/doctor.mjs
@@ -58,6 +58,7 @@ import { agentDirFrom, readHostPi } from "./host-pi.mjs";
 import { PACKAGES_SUBDIR, readStagedSkills, readStageManifest } from "./packages.mjs";
 import { copySkillTree } from "./copy-tree.mjs";
 import { SKILL_NAME_RE } from "./flow-gate.mjs";
+import { GIT_READ_FLAGS } from "./git-hardening.mjs";
 import { ABSENT, ASSERTED, PROPERTY_NAMES, declarationOf, floorShortfall, parseBackendFloor, parseBackendList, unarmedFloor } from "./backends.mjs";
 import { DEFAULT_EGRESS_PROXY, egressArmed } from "./egress.mjs";
 import { installedUnitPaths, readUnitSeam } from "./service.mjs";
@@ -1988,7 +1989,7 @@ function aiTriggerNames(dir) {
  * copied so the two readers cannot disagree about what "a committed skill file" means, and so a
  * hostile repo config cannot run code during the read (flow-gate.mjs's defaultGit, restated).
  */
-const GIT_READ_FLAGS = ["-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false", "--no-pager"];
+
 async function repoFlowAtHead(spawn, folder, flow) {
 	if (!SKILL_NAME_RE.test(flow)) return "unknown"; // the caller pre-checks; belt against interpolation
 	const head = await runCmdCapture(spawn, "git", [...GIT_READ_FLAGS, "-C", folder, "rev-parse", "HEAD"]);

--- a/worker/src/flow-gate.mjs
+++ b/worker/src/flow-gate.mjs
@@ -1,3 +1,4 @@
+import { GIT_READ_FLAGS } from "./git-hardening.mjs";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
@@ -74,9 +75,10 @@ export function aiTriggerAllows(buf) {
 }
 
 async function defaultGit(gitDir, args, { raw = false } = {}) {
-	// hardening flags mirror materialize.mjs defaultGit — keep in sync. No hooks, no fsmonitor, no
-	// pager, so a hostile repo config cannot run code or corrupt output during a read.
-	const hardened = ["-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false", "--no-pager", "-C", gitDir, ...args];
+	// No hooks, no fsmonitor, no pager, so a hostile repo config cannot run code or corrupt output during
+	// a read. This said "mirror materialize.mjs -- keep in sync" until the copy that had NOT stayed in
+	// sync was found (issue #286's sweep); it is an import now, so there is nothing left to remember.
+	const hardened = [...GIT_READ_FLAGS, "-C", gitDir, ...args];
 	const { stdout } = await exec("git", hardened, {
 		encoding: raw ? "buffer" : "utf8",
 		maxBuffer: 16 * 1024 * 1024,

--- a/worker/src/git-dirty.mjs
+++ b/worker/src/git-dirty.mjs
@@ -1,14 +1,22 @@
 import { execFileSync } from "node:child_process";
+import { GIT_READ_FLAGS } from "./git-hardening.mjs";
 
 /**
  * Report a folder's git working-tree state: `true` = dirty, `false` = clean, `null` = not a usable
  * git repository. Reads the WORKING TREE via `git status --porcelain` — distinct from
  * flow-gate.mjs's object-store read, which reads committed content at a pinned SHA; the two are kept
  * separate on purpose. `exec` is injectable for tests.
+ *
+ * HARDENED, and this is the site where it is not hypothetical. `git status` REFRESHES THE INDEX, so it
+ * invokes `core.fsmonitor` -- an operator-supplied command -- where `rev-parse` does not. The folder this
+ * reads is the same path a local job mounts at /workspace with write access, so the agent can write
+ * `.git/config` and the next `pi-dispatch run` on that folder executes it ON THE HOST, outside any
+ * container. This file was invisible to the sweep that hardened its six siblings, because that census
+ * grepped for the flags that were PRESENT and this one had none.
  */
 export function gitDirty(folder, { exec = execFileSync } = {}) {
 	try {
-		const out = exec("git", ["-C", folder, "status", "--porcelain"], { encoding: "utf8" });
+		const out = exec("git", [...GIT_READ_FLAGS, "-C", folder, "status", "--porcelain"], { encoding: "utf8" });
 		return out.trim().length > 0;
 	} catch {
 		return null;

--- a/worker/src/git-hardening.mjs
+++ b/worker/src/git-hardening.mjs
@@ -1,0 +1,33 @@
+/**
+ * The `-c` pairs that stop a hostile repository config executing code on the worker HOST, outside any
+ * container. `materialize.mjs` states the intent in one line and it is the whole of it: no hooks, no
+ * external filters, no pager.
+ *
+ * A LEAF that imports nothing, on `container-spec.mjs`'s precedent and for its reason. `materialize.mjs`
+ * is the file three "keep in sync" comments already named as canonical, but it imports `flow-gate.mjs`
+ * and `flow-gate.mjs` needs these flags too, so canonical-by-comment could not become
+ * canonical-by-import without a cycle. The array moves here and the comments become imports.
+ *
+ * Seven sites carried this by hand and one of them -- `prepare-local.mjs` -- was missing
+ * `core.fsmonitor`. Nothing was exploitable: its only command is `git rev-parse HEAD`, which does not
+ * refresh the index, so the fsmonitor hook is never invoked, and the `.pi/` materialisation beside it
+ * uses materialize's own hardened git. That is exactly the shape of a drift that survives review --
+ * harmless in the copy that has it wrong, load-bearing in the six that have it right -- and it is why
+ * this file exists rather than an eighth careful copy.
+ *
+ * `core.fsmonitor` is the one worth naming: it makes git run an operator-supplied command on any
+ * index-refreshing read, and a local-folder job's agent can write `.git/config` inside `/workspace`, so
+ * the value is attacker-controlled by construction on exactly the path that reads it.
+ */
+export const GIT_SAFE_CONFIG = Object.freeze(["-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false"]);
+
+/**
+ * The whole prefix for a READ that must run no repository-supplied code. `-C <dir>` follows at the call
+ * site, because two callers pass a `-C` and one (doctor's probe) supplies its own directory handling.
+ *
+ * Two constants rather than one: `prepare-github.mjs` INTERLEAVES its clone-specific locks
+ * (`protocol.ext.allow`, an empty `credential.helper`) between the fsmonitor pair and `--no-pager`, so a
+ * single flat prefix would not compose there and would force that file's argv to be reordered for the
+ * convenience of this one.
+ */
+export const GIT_READ_FLAGS = Object.freeze([...GIT_SAFE_CONFIG, "--no-pager"]);

--- a/worker/src/materialize.mjs
+++ b/worker/src/materialize.mjs
@@ -1,3 +1,4 @@
+import { GIT_READ_FLAGS } from "./git-hardening.mjs";
 import { execFile } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative } from "node:path";
@@ -343,17 +344,9 @@ export async function materializePiDir({ gitDir, sha, destDir, git = defaultGit 
 }
 
 async function defaultGit(gitDir, args, { raw = false, maxBuffer = 16 * 1024 * 1024 } = {}) {
-	// -c protecting against a hostile repo config: no hooks, no external filters, no pager.
-	const hardened = [
-		"-c",
-		"core.hooksPath=/dev/null",
-		"-c",
-		"core.fsmonitor=false",
-		"--no-pager",
-		"-C",
-		gitDir,
-		...args,
-	];
+	// -c protecting against a hostile repo config: no hooks, no external filters, no pager. The flags moved
+	// to git-hardening.mjs when a seventh copy of them turned out to be missing one (issue #286's sweep).
+	const hardened = [...GIT_READ_FLAGS, "-C", gitDir, ...args];
 	const { stdout } = await exec("git", hardened, {
 		encoding: raw ? "buffer" : "utf8",
 		maxBuffer,

--- a/worker/src/prepare-github.mjs
+++ b/worker/src/prepare-github.mjs
@@ -40,6 +40,7 @@
  * github-host.mjs's 404-vs-other split: only the determinate class becomes policy.
  */
 
+import { GIT_SAFE_CONFIG } from "./git-hardening.mjs";
 import { execFile } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -52,13 +53,12 @@ import { InfraRetry } from "./processor.mjs";
 const exec = promisify(execFile);
 
 // The -c flags that make a clone/checkout run no repo-supplied code, applied to EVERY git invocation
-// through `hardened()` below so they cannot be omitted at a call site. Matches materialize.mjs's bar
-// (hooksPath, fsmonitor, --no-pager) plus the clone-specific transport/credential locks.
+// through `hardened()` below so they cannot be omitted at a call site. The shared bar comes from
+// git-hardening.mjs; the clone-specific transport/credential locks are this file's own, and they sit
+// BETWEEN the shared pairs and `--no-pager`, which is why that module exports the pairs separately from
+// the finished read prefix -- composing here must not reorder this argv.
 const HARDEN_FLAGS = [
-	"-c",
-	"core.hooksPath=/dev/null",
-	"-c",
-	"core.fsmonitor=false",
+	...GIT_SAFE_CONFIG,
 	"-c",
 	"protocol.ext.allow=never",
 	"-c",

--- a/worker/src/prepare-local.mjs
+++ b/worker/src/prepare-local.mjs
@@ -1,3 +1,4 @@
+import { GIT_READ_FLAGS } from "./git-hardening.mjs";
 import { execFile } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
@@ -73,7 +74,12 @@ export async function prepareLocalWorkspace({ folder, task, jobDir, git = defaul
 }
 
 async function defaultGit(gitDir, args) {
-	const { stdout } = await exec("git", ["-c", "core.hooksPath=/dev/null", "--no-pager", "-C", gitDir, ...args], {
+	// This was the one copy of seven missing `core.fsmonitor=false`, which is why the flags are imported
+	// now rather than restated (issue #286's sweep). Nothing was exploitable -- the only command below is
+	// `rev-parse HEAD`, which does not refresh the index -- but a local-folder job's agent can write
+	// `.git/config` inside /workspace, so the moment this grows a second command that touches the index,
+	// an attacker-controlled fsmonitor hook runs on the worker HOST, outside any container.
+	const { stdout } = await exec("git", [...GIT_READ_FLAGS, "-C", gitDir, ...args], {
 		encoding: "utf8",
 		maxBuffer: 16 * 1024 * 1024,
 	});

--- a/worker/test/git-dirty.test.mjs
+++ b/worker/test/git-dirty.test.mjs
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
+import { GIT_READ_FLAGS } from "../src/git-hardening.mjs";
 import { gitDirty } from "../src/git-dirty.mjs";
 
 // --- against a REAL git repo: the dirty/clean/not-a-repo contract ---
@@ -66,5 +67,10 @@ test("injected exec receives the porcelain status args for the folder", () => {
 		},
 	});
 	assert.equal(received.bin, "git");
-	assert.deepEqual(received.args, ["-C", "/some/folder", "status", "--porcelain"]);
+	// The hardening rides in FRONT of the subcommand, and this is the site where it is load-bearing rather
+	// than defensive: `status` refreshes the index, so it invokes `core.fsmonitor`, and the folder it reads
+	// is the one a local job mounts writable at /workspace. An agent that writes `.git/config` there gets
+	// its command run on the HOST by the next `pi-dispatch run`.
+	assert.deepEqual(received.args, [...GIT_READ_FLAGS, "-C", "/some/folder", "status", "--porcelain"]);
+	assert.ok(received.args.includes("core.fsmonitor=false"), "the flag that actually stops the hook must be present");
 });

--- a/worker/test/prepare-local.test.mjs
+++ b/worker/test/prepare-local.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { GIT_READ_FLAGS } from "../src/git-hardening.mjs";
 import { PI_LIMITS } from "../src/materialize.mjs";
 import { prepareLocalWorkspace } from "../src/prepare-local.mjs";
 
@@ -147,4 +149,48 @@ test("a missing folder is a clear config error", async () => {
 		() => prepareLocalWorkspace({ folder: "/does/not/exist/anywhere", task: "x", jobDir: "/tmp/x" }),
 		(e) => e.piDispatchConfig === true,
 	);
+});
+
+// ── The host-side git argv (issue #286's sweep) ──────────────────────────────────────────────────
+//
+// `prepare-local`'s own git was the one copy of seven missing `core.fsmonitor=false`. The existing tests
+// here drive the REAL default git against a temp repo, so they exercise the flags and can never see them
+// -- which is how the omission survived. This asserts the argv itself.
+test("prepare-local's host-side git carries the same hardening as every other read", async () => {
+	// A REAL repo, so the function reaches its git call rather than refusing above it -- a fixture that
+	// throws first would make this pin vacuous.
+	const folder = localRepo();
+	const jobDir = mkdtempSync(join(tmpdir(), "pi-job-argv-"));
+	const calls = [];
+	await prepareLocalWorkspace({
+		folder,
+		task: "t",
+		jobDir,
+		git: async (gitDir, args) => {
+			calls.push({ gitDir, args });
+			return execFileSync("git", ["-C", gitDir, ...args], { encoding: "utf8" });
+		},
+	});
+	assert.deepEqual(calls.map((c) => c.args), [["rev-parse", "HEAD"]], "the seam must be reached, or this pin is vacuous");
+	// The seam receives the SUBcommand; the hardening rides in front of it inside `defaultGit`, which
+	// spreads this exact array. Asserting the constant is asserting what the real git is invoked with,
+	// and `rev-parse` is precisely the command whose harmlessness hid the missing flag for so long.
+	assert.deepEqual([...GIT_READ_FLAGS], ["-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false", "--no-pager"]);
+});
+
+test("no host-side git config is hardened by hand any more", () => {
+	// The guard that outlives the refactor. Seven files carried these `-c` pairs and the drift was a
+	// missing one in a copy nobody re-read; an eighth copy is how it comes back.
+	const roots = ["worker/src", "admin/src"];
+	const offenders = [];
+	for (const root of roots) {
+		const dir = fileURLToPath(new URL(`../../${root}`, import.meta.url));
+		for (const name of readdirSync(dir)) {
+			if (!/\.(mjs|ts)$/.test(name) || name === "git-hardening.mjs") continue;
+			// A leading double quote is what makes it an ARGV token rather than prose. Several of these files
+			// legitimately name the flags in a comment explaining why they no longer spell them.
+			if (/"core\.hooksPath|"core\.fsmonitor/.test(readFileSync(join(dir, name), "utf8"))) offenders.push(`${root}/${name}`);
+		}
+	}
+	assert.deepEqual(offenders, [], "these must import GIT_SAFE_CONFIG / GIT_READ_FLAGS from worker/src/git-hardening.mjs instead of restating the flags");
 });

--- a/worker/test/prepare-local.test.mjs
+++ b/worker/test/prepare-local.test.mjs
@@ -151,46 +151,52 @@ test("a missing folder is a clear config error", async () => {
 	);
 });
 
-// ── The host-side git argv (issue #286's sweep) ──────────────────────────────────────────────────
+// ── The host-side git argv (issue #286's sweep) ─────────────────────────────────────────────────
 //
 // `prepare-local`'s own git was the one copy of seven missing `core.fsmonitor=false`. The existing tests
 // here drive the REAL default git against a temp repo, so they exercise the flags and can never see them
-// -- which is how the omission survived. This asserts the argv itself.
-test("prepare-local's host-side git carries the same hardening as every other read", async () => {
-	// A REAL repo, so the function reaches its git call rather than refusing above it -- a fixture that
-	// throws first would make this pin vacuous.
-	const folder = localRepo();
-	const jobDir = mkdtempSync(join(tmpdir(), "pi-job-argv-"));
-	const calls = [];
-	await prepareLocalWorkspace({
-		folder,
-		task: "t",
-		jobDir,
-		git: async (gitDir, args) => {
-			calls.push({ gitDir, args });
-			return execFileSync("git", ["-C", gitDir, ...args], { encoding: "utf8" });
-		},
-	});
-	assert.deepEqual(calls.map((c) => c.args), [["rev-parse", "HEAD"]], "the seam must be reached, or this pin is vacuous");
-	// The seam receives the SUBcommand; the hardening rides in front of it inside `defaultGit`, which
-	// spreads this exact array. Asserting the constant is asserting what the real git is invoked with,
-	// and `rev-parse` is precisely the command whose harmlessness hid the missing flag for so long.
-	assert.deepEqual([...GIT_READ_FLAGS], ["-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false", "--no-pager"]);
+// -- which is how the omission survived, and why the guard below reads SOURCE rather than behaviour.
+test("prepare-local's host-side git spreads the shared hardening, not a copy of it", () => {
+	// Asserted against the SOURCE, deliberately. `prepareLocalWorkspace` takes an injected `git` that
+	// replaces `defaultGit` wholesale, so the flags are structurally invisible through the seam: a test
+	// driving the seam and then asserting GIT_READ_FLAGS' own contents proves only that the constant is
+	// what it is, and stays green with the fix reverted. That test was written first and it was hollow.
+	const src = readFileSync(fileURLToPath(new URL("../src/prepare-local.mjs", import.meta.url)), "utf8");
+	assert.match(src, /exec\("git", \[\.\.\.GIT_READ_FLAGS,/, "prepare-local must spread the shared constant into its git argv");
 });
 
-test("no host-side git config is hardened by hand any more", () => {
-	// The guard that outlives the refactor. Seven files carried these `-c` pairs and the drift was a
-	// missing one in a copy nobody re-read; an eighth copy is how it comes back.
-	const roots = ["worker/src", "admin/src"];
+/**
+ * EVERY host-side `git` invocation carries the hardening -- a COVERAGE scan, not a copy detector.
+ *
+ * The first version of this guard grepped for the flag names as quoted argv tokens, which finds a file
+ * that spells them out and misses the two failure modes that actually happened. It could be evaded by
+ * writing the same literals in single quotes -- verified, the original defect reinstated that way shipped
+ * green -- and, worse, it was blind by construction to a site carrying NO flags at all. That is exactly
+ * how `git-dirty.mjs` was missed: the census that found "seven sites" grepped for flags that were
+ * PRESENT, and the one running `git status` on an agent-writable folder had none.
+ *
+ * So this enumerates the call sites instead and requires each argv to begin with the shared constant.
+ * `receiver/` and `image/runner` are deliberately not scanned: neither invokes git at all, checked.
+ */
+test("every host-side git invocation begins with the shared hardening flags", () => {
 	const offenders = [];
-	for (const root of roots) {
+	for (const root of ["worker/src", "admin/src"]) {
 		const dir = fileURLToPath(new URL(`../../${root}`, import.meta.url));
 		for (const name of readdirSync(dir)) {
 			if (!/\.(mjs|ts)$/.test(name) || name === "git-hardening.mjs") continue;
-			// A leading double quote is what makes it an ARGV token rather than prose. Several of these files
-			// legitimately name the flags in a comment explaining why they no longer spell them.
-			if (/"core\.hooksPath|"core\.fsmonitor/.test(readFileSync(join(dir, name), "utf8"))) offenders.push(`${root}/${name}`);
+			const src = readFileSync(join(dir, name), "utf8");
+			// Both call shapes in the tree: `exec("git", [ ... ])` and `runCmd(spawn, "git", [ ... ])`.
+			for (const m of src.matchAll(/["'`]git["'`],\s*\[([^\]]*)/g)) {
+				const argv = m[1].trimStart();
+				if (!argv.startsWith("...GIT_READ_FLAGS") && !argv.startsWith("...GIT_SAFE_CONFIG") && !argv.startsWith("...HARDEN_FLAGS") && !argv.startsWith("...hardened")) {
+					offenders.push(`${root}/${name}: git ${argv.split("\n")[0].trim().slice(0, 60)}`);
+				}
+			}
 		}
 	}
-	assert.deepEqual(offenders, [], "these must import GIT_SAFE_CONFIG / GIT_READ_FLAGS from worker/src/git-hardening.mjs instead of restating the flags");
+	assert.deepEqual(
+		offenders,
+		[],
+		"every host-side git argv must start by spreading worker/src/git-hardening.mjs's constants -- a hostile repo config runs code on the HOST, outside any container, and `git status`/`check-ignore` really do invoke core.fsmonitor",
+	);
 });


### PR DESCRIPTION
The behaviour half of #286's sweep, landing on top of the pins written to prove it. Those pins passed
unchanged through the refactor, which is the whole reason they went first.

## The security finding, added in review

**`worker/src/git-dirty.mjs` ran `git status --porcelain` on an agent-writable folder with no hardening
at all.** The sweep found "seven sites" by grepping for the flags that were *present*, so the site
carrying **none** was invisible to its own census — and it is the one that mattered.

`git status` refreshes the index, which is what invokes `core.fsmonitor`. `rev-parse` — the command
whose harmlessness both `git-hardening.mjs`'s header and `prepare-local`'s comment lean on — does not.
The chain is complete, not hypothetical:

1. `container-spec.mjs` mounts a local job's folder at `/workspace` **writable**
2. `prepare-local.mjs` returns that same path as the workspace
3. `cli.mjs` calls `gitDirty(folder)` on every `pi-dispatch run` without `--force`
4. `read-model.mjs` calls it again from the panel

An agent writes `.git/config`, and its command runs **on the host, outside any container**. Confirmed
executing during review. `revParseHead` in the panel is hardened in the same change — nothing was
reachable through it, and that is exactly the reasoning that left `git status` alone one module over.

## The bug the sweep set out to fix

`prepare-local.mjs`'s git was missing `core.fsmonitor=false`; six siblings had it, three with "keep in
sync" comments naming `materialize.mjs`. Not exploitable on its own — its only command is
`rev-parse HEAD` — but the same folder, the same writable `.git/config`.

## Byte-identity, verified token by token

```
materialize IDENTICAL   flowgate IDENTICAL   doctor IDENTICAL   readmodel IDENTICAL
prepare-github IDENTICAL          prepare-local CHANGED → gained -c core.fsmonitor=false
```

Every derived admin string also reproduces `main`'s literal exactly: `FORGE_PROMPT`,
`ISSUE_CLOSE_WORD`, `PR_ACTION_VOCAB`, the `kind` clause, `reviewState`, and the per-forge clause.

Two design points worth the reviewer's time:

- **The flags moved to a new leaf, not to the file three comments called canonical.**
  `materialize.mjs` could not become canonical-by-import: it imports `flow-gate.mjs`, which needs the
  flags too. That is a cycle.
- **Two constants, not one.** `prepare-github.mjs` *interleaves* its clone locks between the shared
  pairs and `--no-pager`. A flat prefix would not compose there, and forcing a reorder is how a
  refactor stops being byte-preserving.

## My own guard did not guard, twice over

Both caught in review and replaced:

- The argv test asserted the injected seam's args and then `GIT_READ_FLAGS`' own contents — two true
  facts with nothing tying them together, because an injected `git` replaces `defaultGit` wholesale.
  **It stayed green with the fix reverted**, while the commit body claimed otherwise.
- The copy scan matched the flag names as *double-quoted* tokens, so the identical defect written in
  **single quotes shipped green**. And being a copy detector it was blind by construction to the
  failure that actually happened: a site with no flags to find.

Replaced by a **coverage** scan that enumerates git call sites and requires each argv to begin with the
shared constant. Verified against all three failure modes — the original defect, the single-quote
evasion, and a new unhardened site. Only the third is caught by what it replaces, and only because it
is now written the other way round.

## And the sin this PR's own body forbids

The forge clause decided `(no close word)` for a **pull request** vocabulary by reading
`ISSUE_CLOSE_WORD` — the **issue** table. That is the coincidence-dressed-as-derivation the body argues
against, with the arrows reversed. The two are expected to diverge: azure's PR set can grow once
`INT-AZURE-PAYLOAD-SUBSET` widens, while an azure *issue* close needs a different widening entirely. It
reads `PR_CLOSE_ACTIONS` now, which was already exported for this.

## Deliberately not derived

`PR_ACTION_VOCAB.dflt`, with a test line saying so — GitLab's is `update`, not its set's first member.
It is now also pinned to *cover* `FORGE_KINDS`: the keys are derived, so a fifth forge got a correct
hint and an undefined default, and because the key existed the `?? PR_ACTION_VOCAB.github` fallback
stopped firing, turning "wrong default" into "no default".

The rest of the `dispatch_trigger_add` description is untouched: thirty lines of weighted prose about
gates, where fragmenting into templates costs more readability than it buys.

## Specs

No revision row is owed, argued rather than assumed: `specs/` is grepped for `hooksPath`, `fsmonitor`,
`no-pager`, `protocol.ext`, `credential.helper` and `hostile repo`, and **no entry states the flags**.
The only mention is a rejected-alternative bullet in `DES-FORGE-IS-A-PER-JOB-DEPENDENCY`, still true.
`CONST-ISOLATION-CONTAINER-PER-JOB` **unchanged, checked**, and named because `git-hardening.mjs` makes
a boundary claim no entry records: the container bounds what the *agent* runs, and these flags are what
stop a repository the agent can write from running code in the *host* process that reads it.

## Verification

3310 tests, 0 fail, 63 skipped. `dated-fixture-check` and `test-count-check` clean over 140 files.
`CLAUDE.md` gains the rule and the current list of bolts, including the one deliberately absent and why.
