### PR TITLE
fix(worker,specs): the boot releases what it opened

### DIFF
--- a/specs/design.md
+++ b/specs/design.md
@@ -1056,6 +1056,50 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   `DES-SCOPED-LIMITS-AND-FOLDER-MUTEX`, `DES-WRAPPER-STOPS-WHAT-IT-STARTED`,
   `INT-HOST-REGISTRY-CONTRACT`
 
+## DES-SHUTDOWN-RELEASES-THE-SHARED-CLIENT
+
+- **Decision** (issue #300): the shutdown releases the one raw ioredis client `startWorker` builds --
+  shared by the budget, the wait state, the two fleet leases, the run mirror, the host registry, the
+  scheduler stall guard and the boot scope-claim sweep -- with a guarded `redis?.disconnect?.()`
+  SEQUENCED AFTER the `extraClosers` drain and before `process.exit(0)`. And the boot-image read's
+  five-second fuse is cleared when the read wins, through `settleWithin`, which races a promise against
+  an unref'd timer and clears the timer whichever side settles.
+- **Why the client is not an `extraCloser`, in two steps that must both be stated or the sequencing gets
+  refactored away**: the raw client has no `.close`, so pushing it into the list is a silent no-op the
+  drain's `c?.close?.()` never notices -- and the natural repair, wrapping it as
+  `{ close: () => redis.disconnect() }`, is worse than nothing, because the list is drained with
+  `Promise.all` and the wrapper takes the connection down CONCURRENTLY with `registry.close()`. Measured
+  against a recording server: the concurrent shape delivered NO commands at all, the sequenced shape
+  delivered the registry's DEL and SREM. The DEL is what keeps a stopped host from lingering as a ghost
+  peer for its full TTL (`INT-HOST-REGISTRY-CONTRACT`).
+- **Why `disconnect()` and not `quit()`, measured rather than reasoned**: `quit()` answers OK in 0ms
+  against a REFUSED port; the hang it can suffer is a server that accepts the TCP connection and never
+  answers, where the client sits in status "connect" awaiting its ready check -- independent of
+  `maxRetriesPerRequest` and of `enableOfflineQueue`, both measured. `disconnect()` returns immediately
+  in every case, and by this point everything whose replies matter has already drained. The plausible
+  explanation, that `maxRetriesPerRequest: null` queues commands forever so `quit()` waits on the offline
+  queue, is FALSE and is recorded here so it does not get written into a comment later.
+- **The fuse, and why it gets a helper**: `unref'd is not cleaned up` is `DES-WATCHERS-CLOSE-WITH-THE-WORKER`'s
+  lesson restated for a timer, and the old inline race left its five-second fuse armed for the full term
+  whenever the read won. The property is not observable from outside a boot -- `process.getActiveResourcesInfo()`
+  does not report unref'd timers at all (measured), and a census over a whole boot races every other timer
+  the boot arms -- so the race lives in an exported `settleWithin` a unit test pins through `async_hooks`,
+  with the call site pinned against the source. The losing READ stays pending; a wedged `docker inspect`
+  has no cancel, which is the read-is-a-nicety posture the call site already documents.
+- **What this deliberately does not do**: close the client on a boot REFUSAL. A refusal path that stops
+  what the boot built is issue #299's whole subject and lands with its own acceptance; this entry only
+  makes the signal-driven shutdown release what it owns. The test harness's own
+  `captured?.redis?.disconnect?.()` survives as the BACKSTOP for a faked `createWorker` -- the real
+  release lives inside the real one, which `start-wiring.test.mjs` never constructs -- and stops being
+  the only closer anywhere, which was the tell #300 named.
+- **Rejected**: *widening `extraClosers` into an ordered, phased list* so the client could ride it last:
+  a second ordering contract on a list whose only rule today is append-only with pinned heads, for one
+  member that is not a closer at all. *`quit()` with a timeout wrapper*: a bound around a graceful close
+  is a slower spelling of `disconnect()` with a new timer to leak. *Counting on process exit to reap the
+  socket*: true and useless, since the harness case -- many boots, one process -- is exactly where reaping
+  never comes.
+- **Traces to**: `DES-WATCHERS-CLOSE-WITH-THE-WORKER`, `INT-HOST-REGISTRY-CONTRACT`, `DES-CONCURRENCY-3`
+
 ## DES-RETENTION-SWEEPS-ON-A-TIMER
 
 - **Decision** (issue #292, resolving `OQ-007`): the three host-side retention reapers — the run history
@@ -3384,3 +3428,4 @@ a tunnel.
 | 2026-09-08 | Issue #316, transient faults tagged as configuration. **NEW `DES-TRANSIENT-VERSUS-DETERMINATE-IS-ONE-RULE`**: the transient/determinate question is answered once, in an import-free module every classifying site shares, because the convention had drifted into two incompatible halves one file apart and #310 had just made the wrong answer cost a refund, an unretried delivery and a public comment naming the operator. The rule is an allow-list in the determinate direction, with one deliberate exception: a TLS trust failure IS determinate, which the identity modules' own tests caught before a reviewer did. Each caller pairs the rule with the throw its layer can afford, `InfraRetry` per job and an untagged `Error` at boot, because tagged at boot means EXIT_POLICY 2 and a supervisor that leaves the service stopped. **`DES-JOB-OUTBOX-CHAINING` UNCHANGED, checked**: the chain refusals classify nothing and were not touched. **Code evidence**: worker/src/transient.mjs -> isTransientStatus, isDeterminateFsCode, isDeterminateFetchFailure, transientError; worker/src/get-token.mjs -> classifyAppMintError, runGhAuthToken; worker/src/prepare-local.mjs -> requirePath; worker/src/identity.mjs -> resolveSelfId; worker/src/gitlab-identity.mjs -> resolveGitLabSelfId; worker/src/forgejo-identity.mjs -> resolveForgejoSelfId; worker/src/azure-identity.mjs -> resolveAzureSelfId; worker/src/start.mjs -> startWorker (attachAuth, ensureAuth); worker/test/transient.test.mjs |
 | 2026-09-08 | Issue #313, the duplicate-key refusal. **`DES-TRIGGERS-UNIFIED-FILE` AMENDED**: the refusal joins `run.flow`'s charset check as the file's third true NARROWING, and is the safest of the three, because the only files it rejects are ones whose reviewed value and running value already differ. It carries the same release-ordering constraint as the other two, and the reason it is enforced on the WRITER's raw read as well as in the validator is that an old console cannot produce a duplicate but can rewrite a shadowed file, silently discarding the evidence. **`DES-PER-TRIGGER-SECRET-PROFILE` UNCHANGED, checked, and motivating**: its whole argument is that a trigger names a NAME and the file is the reviewed artifact, which a shadowed key defeats. **`DES-TRANSIENT-VERSUS-DETERMINATE-IS-ONE-RULE` UNCHANGED, checked**: a duplicate key is determinate by any reading and refuses at load, so nothing about classification moves. **Code evidence**: worker/src/json-duplicates.mjs -> findDuplicateKey; worker/src/triggers.mjs -> parseTriggers; worker/src/triggers-file.mjs -> writeTriggers, disarmTrigger. |
 | 2026-09-09 | Issue #301, the receiver's unclosed triggers watch. **`DES-WATCHERS-CLOSE-WITH-THE-WORKER` AMENDED**: the receiver residual is closed, and the Rejected list's "arming only on the real entry point" entry is now marked historical, because that posture muted the defect under test rather than closing it and cost the receiver the only coverage that its watch arms at all. `makeWatchCloser` moved from `worker/src/start.mjs` to its own import-free `worker/src/watch-closer.mjs` (the `transient.mjs` precedent), re-exported from `start.mjs` so every importer keeps its address, and published as the `./watch-closer` subpath; the receiver arms the watch unconditionally, hands the factory an object-shaped `log` adapter, and drains a `closers` array in its shutdown before `process.exit(0)`. The signal handlers deliberately stay on the real-entry guard: a `process.once` cannot ride a closers array. A new bolt in `worker/test/publish.test.mjs` pins that every `@edgehero/pi-dispatch/<subpath>` imported by `receiver/src` or `admin/src` exists in the worker's exports map, because the symlinked workspaces make a missing entry invisible to every in-repo test while an npm-installed receiver throws at module load; the version-floor half of that hazard is undecidable offline and stays a release-PR obligation. `INT-TRIGGERS-FILE-CONTRACT`, `DES-HOST-REGISTRY`, `INT-HOST-REGISTRY-CONTRACT` UNCHANGED, checked. **Code evidence**: worker/src/watch-closer.mjs · receiver/src/start.mjs -> watchTriggers, closers · receiver/test/start.test.mjs -> "the triggers watch ARMS under test, and a shut-down watch writes NOTHING" |
+| 2026-09-09 | Issue #300, the two handles `startWorker` never released. **NEW `DES-SHUTDOWN-RELEASES-THE-SHARED-CLIENT`**: the shutdown releases the shared ioredis client with a guarded `disconnect()` sequenced strictly AFTER the `extraClosers` drain, and the boot-image read's five-second fuse is cleared through a new exported `settleWithin` when the read wins. The entry records three measured facts so they cannot be re-derived wrongly: the raw client cannot ride `extraClosers` (no `.close`, and the natural wrapper is drained concurrently with `registry.close()` -- a recording server received NO commands where the sequenced order delivered the DEL and SREM); `quit()`'s hang is a server that accepts and never answers, independent of `maxRetriesPerRequest` and `enableOfflineQueue`, so the plausible offline-queue explanation is false; and `process.getActiveResourcesInfo()` is blind to unref'd timers, which is why the fuse is pinned through `async_hooks` on the helper rather than a census over a boot. A boot REFUSAL still releases nothing, deliberately: that is issue #299's own acceptance. The harness's `captured?.redis?.disconnect?.()` is re-documented as the backstop for a faked `createWorker` rather than the only closer anywhere. **`DES-WATCHERS-CLOSE-WITH-THE-WORKER`, `INT-HOST-REGISTRY-CONTRACT`, `DES-CRON-VIA-BULLMQ-SCHEDULER` UNCHANGED, checked.** **Code evidence**: worker/src/index.mjs -> shutdown · worker/src/start.mjs -> settleWithin · worker/test/wiring.test.mjs -> "shutdown releases the shared redis client AFTER every closer, by disconnect, never quit" |

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -877,8 +877,15 @@ export function createWorker({ connection, name, stopContainer, containerName, h
 		// connection and never answers, where the client sits in status "connect" awaiting its ready check --
 		// independent of `maxRetriesPerRequest` and of `enableOfflineQueue`, both measured. `disconnect()`
 		// returns immediately in every case, and everything whose replies matter has already drained above.
-		// Guarded, because the wiring tests hand createWorker a bare `redis: {}`.
-		redis?.disconnect?.();
+		// Guarded, because the wiring tests hand createWorker a bare `redis: {}`. And wrapped, on the loop's
+		// own rule stated above: a SYNCHRONOUS throw from this line would skip the `process.exit(0)` below
+		// and hang the stop. The real client's disconnect does not throw; a test-injected one is one edit
+		// away from doing so.
+		try {
+			redis?.disconnect?.();
+		} catch {
+			// A release that failed has already stopped mattering; the exit below is what the stop owes.
+		}
 		process.exit(0);
 	};
 	process.once("SIGTERM", shutdown);

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -860,6 +860,25 @@ export function createWorker({ connection, name, stopContainer, containerName, h
 				}
 			}),
 		);
+		// Release the shared ioredis client LAST (issue #300). Eight consumers ride it -- the budget, the
+		// wait state, the leases, the run mirror, the host registry, the stall guard, the scope-claim sweep
+		// -- and until here nothing in the product ever closed it; only the test harness did, reaching into
+		// the captured wiring, which was the tell.
+		//
+		// SEQUENCED AFTER the drain above, never inside it. The raw client has no `.close`, so pushing it
+		// into `extraClosers` is a silent no-op -- and the natural wrapper, `{ close: () => redis.disconnect() }`,
+		// is worse than nothing: drained CONCURRENTLY by the Promise.all, it takes the connection down beside
+		// `registry.close()`, and a recording server then received NO commands at all where this ordering
+		// delivers the registry's DEL and SREM -- the DEL being what keeps a stopped host from lingering as
+		// a ghost peer for its full TTL.
+		//
+		// `disconnect()`, not `quit()`, for a MEASURED reason rather than the plausible one. `quit()` answers
+		// OK in 0ms against a REFUSED port; the hang it can suffer is a server that accepts the TCP
+		// connection and never answers, where the client sits in status "connect" awaiting its ready check --
+		// independent of `maxRetriesPerRequest` and of `enableOfflineQueue`, both measured. `disconnect()`
+		// returns immediately in every case, and everything whose replies matter has already drained above.
+		// Guarded, because the wiring tests hand createWorker a bare `redis: {}`.
+		redis?.disconnect?.();
 		process.exit(0);
 	};
 	process.once("SIGTERM", shutdown);

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -121,6 +121,33 @@ const WORKER_VERSION = (() => {
 export { makeWatchCloser } from "./watch-closer.mjs";
 
 /**
+ * Race a read against a fuse, and CLEAN THE FUSE UP whichever side wins (issue #300). The fuse is
+ * unref'd, deliberately: it exists so a wedged docker daemon cannot hold boot, and it must never itself
+ * hold the process. But unref'd is not cleaned up (#295's lesson, both halves): when the read won, the
+ * old inline race left its five-second timer armed for the full term. The LOSING read stays pending --
+ * a wedged `docker inspect` has no cancel -- which is the read-is-a-nicety posture the call site
+ * documents, unchanged here.
+ *
+ * EXPORTED for the reason `makeWatchCloser` is: the cleared-fuse property is not observable through a
+ * full boot without racing every other timer the boot arms, and a guarantee the shutdown story rests on
+ * deserves a deterministic pin rather than a census.
+ */
+export async function settleWithin(promise, ms, fallback) {
+	let timer = null;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise((resolve) => {
+				timer = setTimeout(() => resolve(fallback), ms);
+				timer.unref?.();
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
  * Watch the DIRECTORY holding the triggers file (robust to the admin's atomic tmp+rename, which swaps the
  * inode a file-watch would lose), debounce, and re-reconcile the cron schedulers on change via
  * `reloadSchedules`. Best-effort: a platform without `fs.watch` logs and the worker keeps its boot-time
@@ -738,10 +765,7 @@ export async function startWorker(
 	// here. This read is a nicety -- a digest for the boot line and the registry -- and a nicety may
 	// never be able to stop a worker starting. The per-JOB preflight keeps its unbounded wait, where a
 	// wedged daemon is the job's problem and the 30-minute job timeout already covers it.
-	const bootImage = await Promise.race([
-		imagePreflight({}).catch(() => ({})),
-		new Promise((resolve) => setTimeout(() => resolve({}), BOOT_IMAGE_TIMEOUT_MS).unref?.()),
-	]);
+	const bootImage = await settleWithin(imagePreflight({}).catch(() => ({})), BOOT_IMAGE_TIMEOUT_MS, {});
 	// Resolved once: `Intl` is not free, and this value cannot change without a restart.
 	const hostTz = Intl.DateTimeFormat().resolvedOptions().timeZone ?? "";
 	const registry = makeHostRegistryFn({ redis, name: config.workerName, log });

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -128,6 +128,11 @@ export { makeWatchCloser } from "./watch-closer.mjs";
  * a wedged `docker inspect` has no cancel -- which is the read-is-a-nicety posture the call site
  * documents, unchanged here.
  *
+ * NOT FOR BARE CONTEXTS, and the boundary is the fuse's own unref: awaited when nothing else holds the
+ * event loop, the fuse never fires and node exits mid-await (measured, exit 13). In this boot the shared
+ * redis client and the workers hold the loop, so the fallback always arrives; a caller with an empty
+ * loop needs a ref'd timer and a different trade.
+ *
  * EXPORTED for the reason `makeWatchCloser` is: the cleared-fuse property is not observable through a
  * full boot without racing every other timer the boot arms, and a guarantee the shutdown story rests on
  * deserves a deterministic pin rather than a census.

--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -1649,6 +1649,12 @@ test("settleWithin clears its fuse when the read wins, and still answers when it
 	// this pin counts through async_hooks, where `destroy` fires for a cleared timer and not for a merely
 	// unref'd one. Ungated: no Valkey, no boot, one helper.
 	const { createHook } = await import("node:async_hooks");
+	// SELF-CONTAINED, deliberately: the second settleWithin call below awaits an unref'd fuse, and a
+	// process running ONLY this test (a --test-name-pattern debug run) has nothing else holding the
+	// loop -- node then abandons the pending await ("Promise resolution is still pending but the event
+	// loop has already resolved"), which is the helper's own documented bare-context boundary biting the
+	// test that pins it. This ref'd interval is the ambient loop the real boot provides.
+	const keepAlive = setInterval(() => {}, 1000);
 	const live = new Set();
 	const hook = createHook({
 		init(asyncId, type) {
@@ -1672,6 +1678,7 @@ test("settleWithin clears its fuse when the read wins, and still answers when it
 		const fell = await mod.settleWithin(new Promise(() => {}), 5, { fellBack: true });
 		assert.deepEqual(fell, { fellBack: true }, "a read that never answers still yields the fallback");
 	} finally {
+		clearInterval(keepAlive);
 		hook.disable();
 	}
 });

--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -188,7 +188,11 @@ async function runStart({ env = {}, makeAuth, makeHost, makeGitLabAuth, makeGitL
 		// up as the whole test FILE hanging rather than as a failure anyone can read.
 		captured = calls[0];
 		try {
-			captured?.redis?.disconnect?.(); // release the background reconnect handle
+			// The BACKSTOP for a faked createWorker, no longer the only closer anywhere (issue #300): the
+			// real shutdown releases this client itself, sequenced after the closer drain, but that shutdown
+			// lives inside the real createWorker and this file fakes createWorkerFn -- so the product's
+			// release is unreachable here by construction and `wiring.test.mjs` is where it is pinned.
+			captured?.redis?.disconnect?.();
 			// EVERY extraCloser, not just the first: since issue #57 a deployment that declares a worker name
 			// also opens a host-queue handle, and since issue #295 the three live-edit file watchers ride the
 			// same list -- so this loop is what proves, on every test in this file, that a watch does not
@@ -1636,4 +1640,48 @@ test("the sweep re-runs the SAME closures boot already built, so one config read
 	const before = logReaperCalls.length + sandboxReaperCalls.length;
 	for (const r of handed.reapers) await r.reap();
 	assert.equal(logReaperCalls.length + sandboxReaperCalls.length, before, "a sweep constructs nothing");
+});
+
+test("settleWithin clears its fuse when the read wins, and still answers when it does not", async () => {
+	// ISSUE #300, the timer half. The boot-image read races a five-second unref'd fuse, and when the read
+	// won, the inline race left that fuse armed for its full term -- invisible to every census, because
+	// `process.getActiveResourcesInfo()` does not report unref'd timers at all (measured), which is why
+	// this pin counts through async_hooks, where `destroy` fires for a cleared timer and not for a merely
+	// unref'd one. Ungated: no Valkey, no boot, one helper.
+	const { createHook } = await import("node:async_hooks");
+	const live = new Set();
+	const hook = createHook({
+		init(asyncId, type) {
+			if (type === "Timeout") live.add(asyncId);
+		},
+		destroy(asyncId) {
+			live.delete(asyncId);
+		},
+	});
+	hook.enable();
+	try {
+		const before = new Set(live);
+		const won = await mod.settleWithin(Promise.resolve({ imageDigest: "sha" }), 5000, {});
+		assert.deepEqual(won, { imageDigest: "sha" }, "the read's own answer wins");
+		// A cleared timer's destroy hook fires on a later tick; give it two.
+		await new Promise((resolve) => setImmediate(resolve));
+		await new Promise((resolve) => setImmediate(resolve));
+		const leaked = [...live].filter((id) => !before.has(id));
+		assert.deepEqual(leaked, [], "the losing fuse is CLEARED, not left armed: unref'd is not cleaned up");
+
+		const fell = await mod.settleWithin(new Promise(() => {}), 5, { fellBack: true });
+		assert.deepEqual(fell, { fellBack: true }, "a read that never answers still yields the fallback");
+	} finally {
+		hook.disable();
+	}
+});
+
+test("the boot-image read goes THROUGH settleWithin (source pin)", () => {
+	// The helper's guarantee only reaches production if the call site uses it. The property is not
+	// observable through a full boot without racing every other timer the boot arms, so the call site is
+	// pinned against the source, the `wiring.test.mjs` SIGBREAK precedent. NEGATIVE half included: the
+	// inline race must not come back beside the helper.
+	const src = readFileSync(new URL("../src/start.mjs", import.meta.url), "utf8");
+	assert.match(src, /const bootImage = await settleWithin\(imagePreflight/, "the boot-image read must ride the fuse-clearing helper");
+	assert.ok(!/setTimeout\(\(\) => resolve\({}\), BOOT_IMAGE_TIMEOUT_MS\)/.test(src), "the inline race that leaked its timer must stay gone");
 });

--- a/worker/test/wiring.test.mjs
+++ b/worker/test/wiring.test.mjs
@@ -149,6 +149,51 @@ test("shutdown closes each extraCloser after the worker drains", { skip }, async
 	}
 });
 
+test("shutdown releases the shared redis client AFTER every closer, by disconnect, never quit", { skip }, async () => {
+	// ISSUE #300. The raw client createWorker receives is what the budget, the wait state, the leases,
+	// the run mirror, the host registry, the stall guard and the scope-claim sweep all share, and nothing
+	// in the product ever released it -- the test harness reached into the captured wiring instead, which
+	// was the tell. The ORDER is the contract here: the client has no `.close`, so it cannot ride
+	// `extraClosers` at all, and the natural wrapper would be drained CONCURRENTLY with
+	// `registry.close()`, losing the DEL that keeps a stopped host from lingering as a ghost peer.
+	const origExit = process.exit;
+	const beforeTerm = new Set(process.listeners("SIGTERM"));
+	const beforeInt = new Set(process.listeners("SIGINT"));
+	const order = [];
+	let worker;
+	try {
+		process.exit = () => {};
+		worker = mod.createWorker({
+			connection: { host: "127.0.0.1", port: 1 },
+			concurrency: 1,
+			getSettings: () => ({ provider: "anthropic", model: "m", maxTurns: 30, dailyCap: 10, concurrency: 3 }),
+			redis: {
+				disconnect: () => order.push("redis.disconnect"),
+				quit: () => order.push("redis.quit"),
+			},
+			deps: {},
+			stopContainer: async () => {},
+			extraClosers: [
+				// One SLOW closer, so a disconnect that merely comes later in source order still fails this:
+				// it must come after the drain has RESOLVED, not after it was started.
+				{ close: async () => { await new Promise((resolve) => setTimeout(resolve, 30)); order.push("closer.slow"); } },
+				{ close: async () => order.push("closer.fast") },
+			],
+		});
+		worker.on("error", () => {});
+		const shutdown = process.listeners("SIGTERM").find((l) => !beforeTerm.has(l));
+		await shutdown();
+		assert.deepEqual(order.filter((o) => o.startsWith("redis")), ["redis.disconnect"], "disconnect, exactly once, and never quit: quit hangs on a server that accepts and goes mute");
+		assert.equal(order.at(-1), "redis.disconnect", "the client is released LAST -- after the slow closer resolved, or the registry's DEL rides a dead connection");
+		assert.ok(order.includes("closer.slow") && order.includes("closer.fast"), "both closers ran");
+	} finally {
+		process.exit = origExit;
+		for (const l of process.listeners("SIGTERM")) if (!beforeTerm.has(l)) process.removeListener("SIGTERM", l);
+		for (const l of process.listeners("SIGINT")) if (!beforeInt.has(l)) process.removeListener("SIGINT", l);
+		await Promise.resolve(worker?.close()).catch(() => {});
+	}
+});
+
 test("a closer pushed AFTER createWorker returns is still closed by the shutdown", { skip }, async () => {
 	// `start.mjs` hands this array over BEFORE its three live-edit watches exist, then pushes their closers in
 	// once they are armed -- which it may only do because this shutdown reads the array LATE, at signal time,


### PR DESCRIPTION
Closes #300.

Two handles `startWorker` created and nothing in the product ever released. The shared ioredis client, ridden by the budget, the wait state, the two fleet leases, the run mirror, the host registry, the scheduler stall guard and the boot scope-claim sweep, was closed only by the test harness reaching into the captured `createWorker` argument, which was the tell the issue named. And the boot-image read's five second fuse stayed armed for its full term whenever the read won, because unref'd is not cleaned up, the #295 lesson restated for a timer.

## What changed

* The shutdown releases the client with a guarded `redis?.disconnect?.()` sequenced strictly after the `extraClosers` drain and before `process.exit(0)`. It cannot ride `extraClosers`: the raw client has no `.close`, so pushing it in is a silent no-op, and the natural wrapper is drained concurrently by the `Promise.all`, taking the connection down beside `registry.close()`. Measured against a recording server, the concurrent shape delivered no commands at all where the sequenced shape delivered the registry's DEL and SREM, the DEL being what keeps a stopped host from lingering as a ghost peer for its full TTL.
* `disconnect()`, not `quit()`, for a measured reason rather than the plausible one: `quit()` answers OK in 0ms against a refused port, and the hang it can suffer is a server that accepts the TCP connection and never answers, independent of `maxRetriesPerRequest` and of `enableOfflineQueue`, both measured. The false offline-queue explanation is recorded in the spec so it cannot be written into a comment later.
* The boot-image race moves into an exported `settleWithin` that clears its fuse whichever side settles. `process.getActiveResourcesInfo()` is blind to unref'd timers (measured), so the property is pinned through `async_hooks` on the helper in isolation, with the call site pinned against the source and the inline race banned by a negative assertion.

Deliberately not done here: releasing anything on a boot refusal. That is #299's own acceptance and lands next. The harness's `captured?.redis?.disconnect?.()` survives as the backstop for a faked `createWorker`, re-documented as such, and stops being the only closer anywhere.

## Tests

The new ordering test drives the real SIGTERM handler with a deliberately slow closer, so a disconnect that merely comes later in source order still fails it: the release must follow the drain's resolution. The `settleWithin` unit test counts live Timeout resources through `async_hooks`, where `destroy` fires for a cleared timer and not for a merely unref'd one. Five mutations run, all killed: never releasing, `quit` for `disconnect`, releasing before the drain, dropping the `clearTimeout`, and bringing the inline race back.

Also driven directly against the live Valkey, composing this with #302's fix: SIGTERM with a registry beat in flight leaves the row deleted, the index clean, the client at status `end`, and zero log lines after shutdown began.

## Specs

New `DES-SHUTDOWN-RELEASES-THE-SHARED-CLIENT` records the ordering constraint, the measured `quit()` facts, and the census blindness. `DES-WATCHERS-CLOSE-WITH-THE-WORKER`, `INT-HOST-REGISTRY-CONTRACT`, `DES-CRON-VIA-BULLMQ-SCHEDULER` UNCHANGED, checked. No version bump, so `release.yml` skips every publish.

## Verification

Full suite in the CI posture (live Valkey, all three REQUIRE flags): 3453 tests, 0 fail, 1 skipped (the macOS reading of the systemd unit test only Linux runs).

A second commit carries the review findings: the release line is wrapped on the shutdown's own no-synchronous-throw rule, and the `settleWithin` pin is now self-contained (run alone, its unref'd fuse used to be abandoned by an empty loop; a ref'd keep-alive interval is the ambient loop the real boot provides). One residual named for its own issue: the receiver poller's sleep timer survives a `stop()` by up to one poll interval, masked in production by the entry's `process.exit(0)`.
