### PR TITLE
fix(worker,specs): a boot that refuses stops the worker it built

### DIFF
--- a/specs/design.md
+++ b/specs/design.md
@@ -1100,6 +1100,50 @@ money with no upstream turn limit (`REQ-RUNNER-TURN-BUDGET`).
   never comes.
 - **Traces to**: `DES-WATCHERS-CLOSE-WITH-THE-WORKER`, `INT-HOST-REGISTRY-CONTRACT`, `DES-CONCURRENCY-3`
 
+## DES-BOOT-REFUSAL-STOPS-THE-WORKER
+
+- **Decision** (issue #299): a `startWorker` refusal that lands AFTER `createWorkerFn` has constructed
+  the Worker stops what it built before the rejection surfaces. `createWorker`'s shutdown splits into
+  `stop()` -- the cancel, the per-worker close, the `extraClosers` drain, the shared-client release --
+  and the signal handler, which is `stop()` followed by `process.exit(0)` under its unchanged name.
+  `stop` rides the returned worker the way `hostWorker` does, so no caller's contract moves, and the
+  whole post-handoff region of `startWorker` sits in a catch that runs
+  `await Promise.resolve(worker?.stop?.()).catch(() => {})` and RETHROWS.
+- **Why this was the bad one of the four**: the Worker starts consuming at construction, so everything
+  after the handoff runs beside a live, paid drain. `cli.mjs` sets `process.exitCode` and never exits,
+  so a refusal printed its error while the worker kept taking jobs against a paid provider -- fail loud,
+  then silently continue, with a spend consequence.
+- **The rethrow is half the fix**: `entryExitCode` turns a tagged configError into `EXIT_POLICY` 2 and
+  anything else into the retryable 1, and a catch that swallowed would hand a supervisor a clean 0 for
+  a boot that refused.
+- **Why `cli.mjs` is untouched, measured rather than argued**: the issue's acceptance offered "or the
+  entry point exits", and a `process.exit` in the shared `.catch` would fire for every subcommand, can
+  truncate a pipe's pending stdout, and would MASK a leaked handle instead of closing it. With the stop
+  above plus `DES-SHUTDOWN-RELEASES-THE-SHARED-CLIENT`'s release, nothing holds the loop: measured with
+  a real Worker and a real client against a dead port, `worker.close()` plus `redis.disconnect()`
+  reached `beforeExit` at ~2.7s (the reconnect backoff's tail; prompt against a reachable Valkey) with
+  the exit code intact, while every other combination was still alive at 8s. That pairing is also the
+  ordering argument: #300 had to land first, because the wrap alone stops the draining and still hangs
+  the process.
+- **The refusal window, enumerated so the next reader does not re-derive it small**: the `worker.on`
+  registrations, `makeStallGuard`, `servedSchedules`, the failFast `makeQueue`, `reconcileGated` (the
+  reachable one the issue reproduced), the three watcher pushes, and the retention sweep's construction
+  and `start()`. The catch covers the REGION, not a list of calls, so a step added tomorrow is covered
+  the day it is added -- and the two regression tests refuse from OPPOSITE ends of the region for
+  exactly that reason.
+- **The `Promise.resolve` spelling is load-bearing**: a test double whose recording `stop` is
+  synchronous makes `worker?.stop?.().catch(...)` a TypeError that REPLACES the boot's real error, so
+  the exit-code assertion meant to go red under mutation goes green for the wrong reason. Both
+  directions are mutation-checked: a synchronous double stays green under the shipped spelling and goes
+  red under the optional-chained one. A synchronous throw from `stop` itself still escapes, exactly as
+  the closer loop documents for `extraClosers` -- a known bound, not a new one.
+- **Rejected**: *`process.exit` in `cli.mjs`* (above -- and it would mask, not close). *Swallowing the
+  boot error after a successful stop*: exit 0 on a refusal. *Registering the signal handlers only after
+  the boot completes*: narrows the mid-boot-signal story but orphans the containers a mid-boot SIGTERM
+  should stop; a different trade for a different issue.
+- **Traces to**: `DES-SHUTDOWN-RELEASES-THE-SHARED-CLIENT`, `DES-WATCHERS-CLOSE-WITH-THE-WORKER`,
+  `CONST-BUDGET-BEFORE-TOKENS`, `CONST-RETRY-INFRA-ONLY`
+
 ## DES-RETENTION-SWEEPS-ON-A-TIMER
 
 - **Decision** (issue #292, resolving `OQ-007`): the three host-side retention reapers — the run history
@@ -3429,3 +3473,4 @@ a tunnel.
 | 2026-09-08 | Issue #313, the duplicate-key refusal. **`DES-TRIGGERS-UNIFIED-FILE` AMENDED**: the refusal joins `run.flow`'s charset check as the file's third true NARROWING, and is the safest of the three, because the only files it rejects are ones whose reviewed value and running value already differ. It carries the same release-ordering constraint as the other two, and the reason it is enforced on the WRITER's raw read as well as in the validator is that an old console cannot produce a duplicate but can rewrite a shadowed file, silently discarding the evidence. **`DES-PER-TRIGGER-SECRET-PROFILE` UNCHANGED, checked, and motivating**: its whole argument is that a trigger names a NAME and the file is the reviewed artifact, which a shadowed key defeats. **`DES-TRANSIENT-VERSUS-DETERMINATE-IS-ONE-RULE` UNCHANGED, checked**: a duplicate key is determinate by any reading and refuses at load, so nothing about classification moves. **Code evidence**: worker/src/json-duplicates.mjs -> findDuplicateKey; worker/src/triggers.mjs -> parseTriggers; worker/src/triggers-file.mjs -> writeTriggers, disarmTrigger. |
 | 2026-09-09 | Issue #301, the receiver's unclosed triggers watch. **`DES-WATCHERS-CLOSE-WITH-THE-WORKER` AMENDED**: the receiver residual is closed, and the Rejected list's "arming only on the real entry point" entry is now marked historical, because that posture muted the defect under test rather than closing it and cost the receiver the only coverage that its watch arms at all. `makeWatchCloser` moved from `worker/src/start.mjs` to its own import-free `worker/src/watch-closer.mjs` (the `transient.mjs` precedent), re-exported from `start.mjs` so every importer keeps its address, and published as the `./watch-closer` subpath; the receiver arms the watch unconditionally, hands the factory an object-shaped `log` adapter, and drains a `closers` array in its shutdown before `process.exit(0)`. The signal handlers deliberately stay on the real-entry guard: a `process.once` cannot ride a closers array. A new bolt in `worker/test/publish.test.mjs` pins that every `@edgehero/pi-dispatch/<subpath>` imported by `receiver/src` or `admin/src` exists in the worker's exports map, because the symlinked workspaces make a missing entry invisible to every in-repo test while an npm-installed receiver throws at module load; the version-floor half of that hazard is undecidable offline and stays a release-PR obligation. `INT-TRIGGERS-FILE-CONTRACT`, `DES-HOST-REGISTRY`, `INT-HOST-REGISTRY-CONTRACT` UNCHANGED, checked. **Code evidence**: worker/src/watch-closer.mjs · receiver/src/start.mjs -> watchTriggers, closers · receiver/test/start.test.mjs -> "the triggers watch ARMS under test, and a shut-down watch writes NOTHING" |
 | 2026-09-09 | Issue #300, the two handles `startWorker` never released. **NEW `DES-SHUTDOWN-RELEASES-THE-SHARED-CLIENT`**: the shutdown releases the shared ioredis client with a guarded `disconnect()` sequenced strictly AFTER the `extraClosers` drain, and the boot-image read's five-second fuse is cleared through a new exported `settleWithin` when the read wins. The entry records three measured facts so they cannot be re-derived wrongly: the raw client cannot ride `extraClosers` (no `.close`, and the natural wrapper is drained concurrently with `registry.close()` -- a recording server received NO commands where the sequenced order delivered the DEL and SREM); `quit()`'s hang is a server that accepts and never answers, independent of `maxRetriesPerRequest` and `enableOfflineQueue`, so the plausible offline-queue explanation is false; and `process.getActiveResourcesInfo()` is blind to unref'd timers, which is why the fuse is pinned through `async_hooks` on the helper rather than a census over a boot. A boot REFUSAL still releases nothing, deliberately: that is issue #299's own acceptance. The harness's `captured?.redis?.disconnect?.()` is re-documented as the backstop for a faked `createWorker` rather than the only closer anywhere. **`DES-WATCHERS-CLOSE-WITH-THE-WORKER`, `INT-HOST-REGISTRY-CONTRACT`, `DES-CRON-VIA-BULLMQ-SCHEDULER` UNCHANGED, checked.** **Code evidence**: worker/src/index.mjs -> shutdown · worker/src/start.mjs -> settleWithin · worker/test/wiring.test.mjs -> "shutdown releases the shared redis client AFTER every closer, by disconnect, never quit" |
+| 2026-09-09 | Issue #299, the boot refusal that left a worker draining paid jobs. **NEW `DES-BOOT-REFUSAL-STOPS-THE-WORKER`**: `createWorker`'s shutdown splits into `stop()` (the teardown) and the signal handler (`stop()` then `process.exit(0)`, name unchanged for the source pin); `stop` rides the returned worker beside `hostWorker`; `startWorker`'s whole post-handoff region sits in a catch that stops what was built and RETHROWS, so `entryExitCode` still maps the refusal to 2 or 1 and never 0. `cli.mjs` is deliberately untouched: with the stop plus #300's release nothing holds the loop, measured to `beforeExit` with the code intact, while a `process.exit` in the shared catch would truncate pipes and mask leaks -- and that measured pairing is why #300 landed first. The `Promise.resolve` spelling of the stop call is mutation-checked in both directions against a synchronous test double. The refusal window is enumerated in the entry; the two regression tests refuse from opposite ends of the region. **No requirements row**: the boot-refusal acceptances in `requirements.md` each own a specific refusal, none owns the post-construction window, and minting one to mirror a design mechanism would restate rather than require -- checked, and recorded here instead. `CONST-BUDGET-BEFORE-TOKENS`, `CONST-RETRY-INFRA-ONLY`, `DES-SHUTDOWN-RELEASES-THE-SHARED-CLIENT`, `INT-RUNNER-EXIT-CODE-PROTOCOL` UNCHANGED, checked. **Code evidence**: worker/src/index.mjs -> stop, shutdown · worker/src/start.mjs -> the post-handoff catch · worker/test/start-wiring.test.mjs -> "a refusal from a DIFFERENT post-handoff point stops the worker too" |

--- a/worker/src/index.mjs
+++ b/worker/src/index.mjs
@@ -829,7 +829,7 @@ export function createWorker({ connection, name, stopContainer, containerName, h
 	// returned as a pair so every existing caller keeps receiving exactly what it received before.
 	primary.hostWorker = workers[1] ?? null;
 
-	const shutdown = async () => {
+	const stop = async () => {
 		// Abort active jobs (=> docker stop via onAbort), then close. Without the cancel,
 		// worker.close() would wait up to 30 minutes for the container. ONE shutdown for every queue: two
 		// registrations would mean two `process.exit(0)` racing, and the second worker's containers would
@@ -884,8 +884,17 @@ export function createWorker({ connection, name, stopContainer, containerName, h
 		try {
 			redis?.disconnect?.();
 		} catch {
-			// A release that failed has already stopped mattering; the exit below is what the stop owes.
+			// A release that failed has already stopped mattering; the exit that follows is what a stop owes.
 		}
+	};
+	// The signal path is `stop()` then exit, and the split is issue #299's: a boot that refuses AFTER the
+	// Worker exists must be able to undo what it built WITHOUT exiting, because the refusal's own error --
+	// not a 0 -- has to reach `cli.mjs`'s entryExitCode, and with every handle released above the process
+	// drains to that code on its own. The closure keeps the name `shutdown` because the source pin in
+	// `wiring.test.mjs` reads the registration lines below, deliberately, rather than constructing a
+	// Worker to observe them.
+	const shutdown = async () => {
+		await stop();
 		process.exit(0);
 	};
 	process.once("SIGTERM", shutdown);
@@ -894,6 +903,13 @@ export function createWorker({ connection, name, stopContainer, containerName, h
 	// (handled above); SIGBREAK covers console-close. Route it to the same shutdown so a stopped
 	// worker still aborts in-flight jobs and docker-stops their containers rather than orphaning them.
 	if (process.platform === "win32") process.once("SIGBREAK", shutdown);
+
+	// Beside `hostWorker` and for the same reason it rides the return value rather than changing it:
+	// every existing caller keeps receiving exactly what it received before, and the one new caller --
+	// `startWorker`'s post-handoff catch (issue #299) -- reaches the teardown through the worker it was
+	// handed. `stop` is the shutdown minus the exit; it is safe to call more than once, because every
+	// step it takes is idempotent by that step's own contract.
+	primary.stop = stop;
 
 	return primary;
 }

--- a/worker/src/start.mjs
+++ b/worker/src/start.mjs
@@ -1143,131 +1143,153 @@ export async function startWorker(
 		},
 	});
 
-	// REQ-LOCAL-JOB-VISIBILITY: exactly one terminal line per job, carrying the job id and outcome,
-	// where the operator is already looking. This is the local counterpart of the GitHub issue
-	// comment and the signal for CONST-PI-VERSION-PINNED's silent-no-op mode -- a missing line is
-	// what tells a human a run did nothing. The container's own output already streams via
-	// runContainer's onOutput during the run.
-	// `reason` is a fixed enum (worker-abort | over-budget | unprotected-branch | runner-policy |
-	// job-image-missing), never
-	// user content. Included only when present so success lines stay clean; a shutdown-aborted job logs
-	// { outcome: "policy", reason: "worker-abort" }, making a restart-dropped job visible.
-	// BOTH workers, or a cron job on the host queue produces no `job_completed` line at all -- and
-	// REQ-LOCAL-JOB-VISIBILITY's whole point is that a missing line is what tells a human a run did nothing.
-	const allWorkers = [worker, ...(worker.hostWorker ? [worker.hostWorker] : [])];
-	for (const w of allWorkers) w.on("completed", (job, result) =>
-		log("job_completed", { jobId: job?.id, outcome: result?.outcome, ...(result?.reason ? { reason: result.reason } : {}) }),
-	);
-	for (const w of allWorkers) w.on("failed", (job, err) =>
-		log("job_failed", { jobId: job?.id, attempt: job?.attemptsMade, reason: String(err?.message ?? err).slice(0, 120) }),
-	);
+	// FROM HERE TO THE RETURN, THE WORKER IS LIVE AND THE BOOT CAN STILL REFUSE (issue #299). The
+	// Worker starts consuming at construction, so everything below runs beside a paid drain --
+	// registrations, the stall guard, the boot reconcile (the reachable refusal, reproduced), the
+	// watcher pushes, the retention sweep's construction and start. A refusal that merely threw left
+	// the process printing an error while taking jobs, because `cli.mjs` sets `process.exitCode` and
+	// the live Worker held the loop forever. The catch below covers the REGION, not a list of calls,
+	// so a step added tomorrow is covered the day it is added.
+	try {
 
-	// CONST-RETRY-INFRA-ONLY money backstop: BullMQ's maxStalledCount does not bound scheduler jobs, so a
-	// wedged scheduled run is re-paid on every stall. The guard counts stalls per scheduler and tears the
-	// scheduler down past the threshold. Keyed on "stalled", not "failed" -- only a stall is the unbounded re-run.
-	const onStalled = makeStallGuard({
-		redis,
-		threshold: config.schedulerStallMax,
-		// The queue the schedulers were actually INSTALLED on. Torn down from `runtimeQueue` on a named
-		// host, this money backstop -- a wedged scheduled run is re-paid on every stall -- silently no-ops.
-		removeJobScheduler: (id) => cronQueue.removeJobScheduler(id),
-		log,
-	});
-	// `makeStallGuard` returns the LISTENER, not an object holding one -- hence the name of the local. It was
-	// called as `guard.onStalled(jobId)` here for the whole life of the feature, which is `undefined(jobId)`,
-	// so every stall threw a TypeError and the money backstop never counted one (issue #267).
-	for (const w of allWorkers) w.on("stalled", (jobId) => void onStalled(jobId));
+		// REQ-LOCAL-JOB-VISIBILITY: exactly one terminal line per job, carrying the job id and outcome,
+		// where the operator is already looking. This is the local counterpart of the GitHub issue
+		// comment and the signal for CONST-PI-VERSION-PINNED's silent-no-op mode -- a missing line is
+		// what tells a human a run did nothing. The container's own output already streams via
+		// runContainer's onOutput during the run.
+		// `reason` is a fixed enum (worker-abort | over-budget | unprotected-branch | runner-policy |
+		// job-image-missing), never
+		// user content. Included only when present so success lines stay clean; a shutdown-aborted job logs
+		// { outcome: "policy", reason: "worker-abort" }, making a restart-dropped job visible.
+		// BOTH workers, or a cron job on the host queue produces no `job_completed` line at all -- and
+		// REQ-LOCAL-JOB-VISIBILITY's whole point is that a missing line is what tells a human a run did nothing.
+		const allWorkers = [worker, ...(worker.hostWorker ? [worker.hostWorker] : [])];
+		for (const w of allWorkers) w.on("completed", (job, result) =>
+			log("job_completed", { jobId: job?.id, outcome: result?.outcome, ...(result?.reason ? { reason: result.reason } : {}) }),
+		);
+		for (const w of allWorkers) w.on("failed", (job, err) =>
+			log("job_failed", { jobId: job?.id, attempt: job?.attemptsMade, reason: String(err?.message ?? err).slice(0, 120) }),
+		);
 
-	// DES-CRON-VIA-BULLMQ-SCHEDULER: install the schedule set (and prune orphans) before announcing the
-	// worker is up, so schedules_installed always precedes worker_started. An empty set skips the reconcile
-	// queue entirely -- no getJobSchedulers Redis hit -- but still logs {0,0} so the operator sees cron is off.
-	// What this host will NOT be running, said once at boot and per trigger. A folder that belongs to
-	// another machine is ordinary on a fleet; a folder that belongs to NO machine is a trigger that will
-	// silently never fire, which is the silent no-op this project refuses -- and which `doctor` is the
-	// right place to catch, because it can ask the registry and this cannot.
-	const { served, unserved } = servedSchedules(schedules.current);
-	for (const s of unserved) log("schedule_unserved", { schedulerId: s.schedulerId, reason: s.unserved });
-
-	if (served.length > 0) {
-		// Onto the HOST queue when one is armed. That makes Gap 1 structural rather than merely gated: a
-		// host queue's resident schedulers are only ever that host's, so `reconcile`'s "resident minus my
-		// config" is correct again by construction and two hosts can no longer prune each other at all. The
-		// fingerprint gate stays, because it still catches the divergence itself -- including a timezone
-		// disagreement, which no queue split can detect.
-		const rq = makeQueue(parseConnection(config.valkeyUrl, { failFast: true }), { ...(hostQueue ? { name: hostQueue } : {}) });
-		try {
-			const r = await reconcileGated(rq, served, { registry, log, tz: hostTz, authored: authoredCron(config) });
-			log("schedules_installed", { installed: r.installed, removed: r.removed, ...(unserved.length > 0 && { unserved: unserved.length }) });
-		} finally {
-			await rq.close().catch(() => {});
-		}
-	} else {
-		log("schedules_installed", { installed: 0, removed: 0, ...(unserved.length > 0 && { unserved: unserved.length }) });
-	}
-
-	// DES-CRON-VIA-BULLMQ-SCHEDULER live edit (OQ-008): watch the triggers file and re-reconcile schedulers
-	// on change, so an operator's add/edit/delete of a cron trigger takes effect without a worker restart.
-	// Only when a triggers file is configured; best-effort; a bad edit keeps the running schedulers. The
-	// closer each of the three returns joins `extraClosers`, so the watch stops with the worker (issue #295).
-	if (config.triggersFile) {
-		extraClosers.push(watchTriggersFile(config, cronQueue, log, schedules, registry, hostTz, config.workerNameDeclared));
-	}
-
-	// REQ-SCOPED-PAUSE-WINDOWS live edit: watch the pause-windows file and hot-swap the in-memory windows, so
-	// an operator's add/delete of a pause window takes effect without a worker restart. A bad edit is kept out.
-	if (config.pauseWindowsFile) {
-		extraClosers.push(watchPauseWindowsFile(config, pauseWindows, log));
-	}
-
-	// Issue #242 live edit: hot-swap the scoped limits on file change, keeping last-good on a bad edit.
-	if (config.scopedLimitsFile) {
-		extraClosers.push(watchScopedLimitsFile(config, scopedLimits, log));
-	}
-
-	// issue #292 / OQ-007: re-run the three retention sweeps on a timer, because the supported deployment
-	// is a service that restarts only on failure, so the healthy worker was the one that never re-swept.
-	// Armed HERE, at the end of boot beside the watches: all three closures exist, boot's own sweeps have
-	// long finished, and the first tick lands one full interval later rather than during the schedules
-	// reconcile, which is Redis-destructive work a small test interval would otherwise land inside.
-	//
-	// NOT CONSTRUCTED AT ALL when the knob is 0. That is how "0 is byte-identical to before" is a fact
-	// rather than a claim: with no object there is no timer, no closer and no reachable second call to any
-	// reaper. It is registered in `extraClosers` for issue #295's finding that UNREF'D IS NOT CLEANED UP --
-	// this handle holds an `rmSync`, and a tick landing mid-drain could delete a retained workspace behind a
-	// worker that already reported a clean shutdown.
-	if (config.sweepIntervalHours > 0) {
-		const sweep = makeRetentionSweepFn({
-			reapers: [
-				{ name: "log", reap: reapLogs },
-				{ name: "sandbox", reap: reapSandboxes },
-				{ name: "session", reap: () => sessionStore.reapSessions() },
-			],
-			intervalMs: config.sweepIntervalHours * 3600000,
+		// CONST-RETRY-INFRA-ONLY money backstop: BullMQ's maxStalledCount does not bound scheduler jobs, so a
+		// wedged scheduled run is re-paid on every stall. The guard counts stalls per scheduler and tears the
+		// scheduler down past the threshold. Keyed on "stalled", not "failed" -- only a stall is the unbounded re-run.
+		const onStalled = makeStallGuard({
+			redis,
+			threshold: config.schedulerStallMax,
+			// The queue the schedulers were actually INSTALLED on. Torn down from `runtimeQueue` on a named
+			// host, this money backstop -- a wedged scheduled run is re-paid on every stall -- silently no-ops.
+			removeJobScheduler: (id) => cronQueue.removeJobScheduler(id),
 			log,
 		});
-		sweep.start();
-		extraClosers.push(sweep);
-	}
+		// `makeStallGuard` returns the LISTENER, not an object holding one -- hence the name of the local. It was
+		// called as `guard.onStalled(jobId)` here for the whole life of the feature, which is `undefined(jobId)`,
+		// so every stall threw a TypeError and the money backstop never counted one (issue #267).
+		for (const w of allWorkers) w.on("stalled", (jobId) => void onStalled(jobId));
 
-	log("worker_started", {
-		queue: "pi-jobs",
-		host: config.workerName, // issue #57; `log` stamps it on every line, and the boot line names it where an operator looks first
-		imageDigest: bootImage.imageDigest ?? null, // two hosts on two builds of one tag used to emit byte-identical boot lines
-		concurrency: bootConcurrency, // the slot count the Worker is actually constructed with (overlay may raise/lower it)
-		sweepIntervalHours: config.sweepIntervalHours, // 0 = boot-only sweeps, this version's pre-#292 behaviour
-		dailyCap: config.dailyCap,
-		weeklyCap: config.weeklyCap, // null when the weekly window is disabled
-		monthlyCap: config.monthlyCap, // null when the monthly window is disabled
-		softHoldPct: config.softHoldPct, // null when the soft-hold band is disabled
-		scopedLimitsFile: config.scopedLimitsFile, // null = no scoped caps/concurrency (the folder mutex holds regardless)
-		scopedLimits: scopedLimits.current.length, // row count -- money config deserves boot visibility; the watcher logs only changes
-		image: config.jobImage,
-		valkey: config.valkeyUrl,
-		logsDir: config.logsDir,
-		settingsFile: config.settingsFile,
-		captureJobLogs: config.captureJobLogs,
-		logRetentionDays: config.logRetentionDays,
-		sandboxRetentionHours: config.sandboxRetentionHours, // 0 = retention off; a run's directory is deleted as before
-	});
-	return worker;
+		// DES-CRON-VIA-BULLMQ-SCHEDULER: install the schedule set (and prune orphans) before announcing the
+		// worker is up, so schedules_installed always precedes worker_started. An empty set skips the reconcile
+		// queue entirely -- no getJobSchedulers Redis hit -- but still logs {0,0} so the operator sees cron is off.
+		// What this host will NOT be running, said once at boot and per trigger. A folder that belongs to
+		// another machine is ordinary on a fleet; a folder that belongs to NO machine is a trigger that will
+		// silently never fire, which is the silent no-op this project refuses -- and which `doctor` is the
+		// right place to catch, because it can ask the registry and this cannot.
+		const { served, unserved } = servedSchedules(schedules.current);
+		for (const s of unserved) log("schedule_unserved", { schedulerId: s.schedulerId, reason: s.unserved });
+
+		if (served.length > 0) {
+			// Onto the HOST queue when one is armed. That makes Gap 1 structural rather than merely gated: a
+			// host queue's resident schedulers are only ever that host's, so `reconcile`'s "resident minus my
+			// config" is correct again by construction and two hosts can no longer prune each other at all. The
+			// fingerprint gate stays, because it still catches the divergence itself -- including a timezone
+			// disagreement, which no queue split can detect.
+			const rq = makeQueue(parseConnection(config.valkeyUrl, { failFast: true }), { ...(hostQueue ? { name: hostQueue } : {}) });
+			try {
+				const r = await reconcileGated(rq, served, { registry, log, tz: hostTz, authored: authoredCron(config) });
+				log("schedules_installed", { installed: r.installed, removed: r.removed, ...(unserved.length > 0 && { unserved: unserved.length }) });
+			} finally {
+				await rq.close().catch(() => {});
+			}
+		} else {
+			log("schedules_installed", { installed: 0, removed: 0, ...(unserved.length > 0 && { unserved: unserved.length }) });
+		}
+
+		// DES-CRON-VIA-BULLMQ-SCHEDULER live edit (OQ-008): watch the triggers file and re-reconcile schedulers
+		// on change, so an operator's add/edit/delete of a cron trigger takes effect without a worker restart.
+		// Only when a triggers file is configured; best-effort; a bad edit keeps the running schedulers. The
+		// closer each of the three returns joins `extraClosers`, so the watch stops with the worker (issue #295).
+		if (config.triggersFile) {
+			extraClosers.push(watchTriggersFile(config, cronQueue, log, schedules, registry, hostTz, config.workerNameDeclared));
+		}
+
+		// REQ-SCOPED-PAUSE-WINDOWS live edit: watch the pause-windows file and hot-swap the in-memory windows, so
+		// an operator's add/delete of a pause window takes effect without a worker restart. A bad edit is kept out.
+		if (config.pauseWindowsFile) {
+			extraClosers.push(watchPauseWindowsFile(config, pauseWindows, log));
+		}
+
+		// Issue #242 live edit: hot-swap the scoped limits on file change, keeping last-good on a bad edit.
+		if (config.scopedLimitsFile) {
+			extraClosers.push(watchScopedLimitsFile(config, scopedLimits, log));
+		}
+
+		// issue #292 / OQ-007: re-run the three retention sweeps on a timer, because the supported deployment
+		// is a service that restarts only on failure, so the healthy worker was the one that never re-swept.
+		// Armed HERE, at the end of boot beside the watches: all three closures exist, boot's own sweeps have
+		// long finished, and the first tick lands one full interval later rather than during the schedules
+		// reconcile, which is Redis-destructive work a small test interval would otherwise land inside.
+		//
+		// NOT CONSTRUCTED AT ALL when the knob is 0. That is how "0 is byte-identical to before" is a fact
+		// rather than a claim: with no object there is no timer, no closer and no reachable second call to any
+		// reaper. It is registered in `extraClosers` for issue #295's finding that UNREF'D IS NOT CLEANED UP --
+		// this handle holds an `rmSync`, and a tick landing mid-drain could delete a retained workspace behind a
+		// worker that already reported a clean shutdown.
+		if (config.sweepIntervalHours > 0) {
+			const sweep = makeRetentionSweepFn({
+				reapers: [
+					{ name: "log", reap: reapLogs },
+					{ name: "sandbox", reap: reapSandboxes },
+					{ name: "session", reap: () => sessionStore.reapSessions() },
+				],
+				intervalMs: config.sweepIntervalHours * 3600000,
+				log,
+			});
+			sweep.start();
+			extraClosers.push(sweep);
+		}
+
+		log("worker_started", {
+			queue: "pi-jobs",
+			host: config.workerName, // issue #57; `log` stamps it on every line, and the boot line names it where an operator looks first
+			imageDigest: bootImage.imageDigest ?? null, // two hosts on two builds of one tag used to emit byte-identical boot lines
+			concurrency: bootConcurrency, // the slot count the Worker is actually constructed with (overlay may raise/lower it)
+			sweepIntervalHours: config.sweepIntervalHours, // 0 = boot-only sweeps, this version's pre-#292 behaviour
+			dailyCap: config.dailyCap,
+			weeklyCap: config.weeklyCap, // null when the weekly window is disabled
+			monthlyCap: config.monthlyCap, // null when the monthly window is disabled
+			softHoldPct: config.softHoldPct, // null when the soft-hold band is disabled
+			scopedLimitsFile: config.scopedLimitsFile, // null = no scoped caps/concurrency (the folder mutex holds regardless)
+			scopedLimits: scopedLimits.current.length, // row count -- money config deserves boot visibility; the watcher logs only changes
+			image: config.jobImage,
+			valkey: config.valkeyUrl,
+			logsDir: config.logsDir,
+			settingsFile: config.settingsFile,
+			captureJobLogs: config.captureJobLogs,
+			logRetentionDays: config.logRetentionDays,
+			sandboxRetentionHours: config.sandboxRetentionHours, // 0 = retention off; a run's directory is deleted as before
+		});
+		return worker;
+	} catch (err) {
+		// STOP WHAT WAS BUILT, THEN RETHROW, and both halves carry weight. The stop is the shutdown
+		// minus the exit -- the cancel, the close, the closer drain, the client release -- so nothing is
+		// left holding the loop and the process drains to the refusal's OWN exit code: entryExitCode
+		// turns a tagged configError into EXIT_POLICY 2 and infra into the retryable 1, and a swallow
+		// here would hand a supervisor a clean 0 for a boot that refused. `Promise.resolve`, not an
+		// optional-chained `.catch`: a test double whose recording `stop` is synchronous would otherwise
+		// raise a TypeError OVER the boot's real error, and the exit-code assertion meant to go red
+		// under mutation would go green for the wrong reason. A synchronous throw from `stop` itself
+		// still escapes, exactly as the closer loop documents for `extraClosers` -- a known bound.
+		await Promise.resolve(worker?.stop?.()).catch(() => {});
+		throw err;
+	}
 }

--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -74,18 +74,30 @@ function fakeHost(overrides = {}) {
 // Drive startWorker with injected fakes and capture the exact object handed to createWorker
 // (deps are nested under `deps`). No real Redis: createWorkerFn is faked. The real ioredis client
 // startWorker constructs via makeRedisClient is torn down so it leaves no dangling handle.
-async function runStart({ env = {}, makeAuth, makeHost, makeGitLabAuth, makeGitLabHost, makeReaper, makeLogSink, makeRecordWriter, makeLogReaper, makeSandboxReaper, makeRetentionSweep, makeRunContainer, makeHostRegistry, makeScopeClaimSweeper, makeBackendRegistry, extraBackends, order, now, authResolveTimeoutMs } = {}) {
+async function runStart({ env = {}, makeAuth, makeHost, makeGitLabAuth, makeGitLabHost, makeReaper, makeLogSink, makeRecordWriter, makeLogReaper, makeSandboxReaper, makeRetentionSweep, makeRunContainer, makeHostRegistry, makeScopeClaimSweeper, makeBackendRegistry, extraBackends, order, stops, now, authResolveTimeoutMs } = {}) {
 	const secretsResolverCalls = [];
 	const calls = [];
 	const registered = {};
+	const stopCalls = [];
 	const createWorkerFn = (arg) => {
 		if (order) order.push("createWorker");
 		calls.push(arg);
 		// Record every worker.on(...) registration so tests can drive the completed/failed handlers
 		// (inspecting the emitted log line) and assert the scheduler stall guard's "stalled" listener.
+		// `stop` records too (issue #299): a boot that refuses after this handoff must stop what it was
+		// handed, and the recording is how a test tells the PRODUCT did it rather than this harness's own
+		// teardown, which drains closers and disconnects but never calls stop. ASYNC deliberately -- the
+		// wrap spells `Promise.resolve(worker?.stop?.())` precisely so a synchronous double cannot
+		// TypeError over the boot's real error, and this double must not hide that spelling's job.
 		return {
 			on(evt, fn) {
 				registered[evt] = fn;
+			},
+			stop: async () => {
+				stopCalls.push("stop");
+				// Into the CALLER'S array too, like `order`: a refusing boot rejects, so its caller never
+				// sees runStart's return value and this is the only wire out.
+				stops?.push("stop");
 			},
 		};
 	};
@@ -243,7 +255,7 @@ async function runStart({ env = {}, makeAuth, makeHost, makeGitLabAuth, makeGitL
 	const logs = parseLines(bootLines.slice(from));
 	// Expose the registration map under both names: `handlers` for the completed/failed handler tests,
 	// `registered` for the scheduler stall-guard test. Same object, one capture path.
-	return { captured, deps: captured?.deps, logs, handlers: registered, registered, logSinkCalls, recordWriterCalls, logReaperCalls, sandboxReaperCalls, runContainerCalls, imagePreflightCalls, secretsResolverCalls };
+	return { captured, stopCalls, deps: captured?.deps, logs, handlers: registered, registered, logSinkCalls, recordWriterCalls, logReaperCalls, sandboxReaperCalls, runContainerCalls, imagePreflightCalls, secretsResolverCalls };
 }
 
 // Capture the JSON log lines a synchronous fn emits through the injected writer.
@@ -1318,10 +1330,12 @@ test("a boot that refuses AFTER the handoff still drains what it opened", { skip
 			JSON.stringify({ triggers: [{ on: { type: "cron", id: "nightly", pattern: "0 3 * * *" }, run: { kind: "local", folder, flow: "tidy", task: "t" } }] }),
 		);
 		let registryClosed = false;
+		const stops = [];
 		await assert.rejects(
 			() =>
 				runStart({
 					env: { VALKEY_URL, PI_TRIGGERS_FILE: triggersPath },
+					stops,
 					makeAuth: async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" }),
 					makeHost: () => fakeHost(),
 					makeHostRegistry: (args) => {
@@ -1342,10 +1356,39 @@ test("a boot that refuses AFTER the handoff still drains what it opened", { skip
 			"the boot refusal must still reach the caller -- the teardown may not replace it",
 		);
 		assert.equal(registryClosed, true, "what the refused boot had already opened is drained anyway");
+		// The PRODUCT half (issue #299). The drain above is this harness's own finally; this is
+		// `startWorker`'s catch calling stop() on the worker it built, which is what a real deployment
+		// gets -- the harness never calls stop, so a recording here can only have come from the product.
+		assert.deepEqual(stops, ["stop"], "the refusing boot must STOP the worker it built before the rejection surfaces: a live Worker keeps taking paid jobs behind a printed error");
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 		rmSync(folder, { recursive: true, force: true });
 	}
+});
+
+test("a refusal from a DIFFERENT post-handoff point stops the worker too -- the catch covers the region", { skip }, async () => {
+	// The reconcile refusal above is the reachable one issue #299 reproduced; this one throws from the
+	// retention sweep's arming at the far end of the region, so the pair pins the WRAP rather than one
+	// call site. A guard that only covered the reconcile would go green above and red here.
+	const stops = [];
+	await assert.rejects(
+		() =>
+			runStart({
+				env: { VALKEY_URL },
+				stops,
+				makeAuth: async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" }),
+				makeHost: () => fakeHost(),
+				makeRetentionSweep: () => ({
+					start: () => {
+						throw new Error("sweep arm blew up");
+					},
+					close: () => {},
+				}),
+			}),
+		/sweep arm blew up/,
+		"the region's own error must surface -- entryExitCode reads it, and a swallow would exit 0 on a refusal",
+	);
+	assert.deepEqual(stops, ["stop"], "stopped from this refusal point too");
 });
 
 // --- host identity (issue #57) --------------------------------------------------------------------------

--- a/worker/test/start-wiring.test.mjs
+++ b/worker/test/start-wiring.test.mjs
@@ -1370,25 +1370,36 @@ test("a refusal from a DIFFERENT post-handoff point stops the worker too -- the 
 	// The reconcile refusal above is the reachable one issue #299 reproduced; this one throws from the
 	// retention sweep's arming at the far end of the region, so the pair pins the WRAP rather than one
 	// call site. A guard that only covered the reconcile would go green above and red here.
+	//
+	// A pause-windows file rides along so a live-edit WATCHER is armed inside the region before the
+	// refusal: armed-then-refused is the interaction neither test exercised, and this file's own
+	// silence canaries watch what a leaked watch would write. The harness drains the closers either way.
+	const dir = mkdtempSync(join(tmpdir(), "pi-sweep-refuse-"));
+	const pausePath = join(dir, "pause-windows.json");
+	writeFileSync(pausePath, `${JSON.stringify({ windows: [] })}\n`);
 	const stops = [];
-	await assert.rejects(
-		() =>
-			runStart({
-				env: { VALKEY_URL },
-				stops,
-				makeAuth: async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" }),
-				makeHost: () => fakeHost(),
-				makeRetentionSweep: () => ({
-					start: () => {
-						throw new Error("sweep arm blew up");
-					},
-					close: () => {},
+	try {
+		await assert.rejects(
+			() =>
+				runStart({
+					env: { VALKEY_URL, PI_PAUSE_WINDOWS_FILE: pausePath },
+					stops,
+					makeAuth: async () => ({ mintToken: async () => "tok", selfId: 1, source: "gh" }),
+					makeHost: () => fakeHost(),
+					makeRetentionSweep: () => ({
+						start: () => {
+							throw new Error("sweep arm blew up");
+						},
+						close: () => {},
+					}),
 				}),
-			}),
-		/sweep arm blew up/,
-		"the region's own error must surface -- entryExitCode reads it, and a swallow would exit 0 on a refusal",
-	);
-	assert.deepEqual(stops, ["stop"], "stopped from this refusal point too");
+			/sweep arm blew up/,
+			"the region's own error must surface -- entryExitCode reads it, and a swallow would exit 0 on a refusal",
+		);
+		assert.deepEqual(stops, ["stop"], "stopped from this refusal point too");
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
 });
 
 // --- host identity (issue #57) --------------------------------------------------------------------------

--- a/worker/test/wiring.test.mjs
+++ b/worker/test/wiring.test.mjs
@@ -194,6 +194,47 @@ test("shutdown releases the shared redis client AFTER every closer, by disconnec
 	}
 });
 
+test("createWorker exposes stop(): the shutdown minus the exit, for a boot that must undo itself", { skip }, async () => {
+	// ISSUE #299. A refusal landing after the Worker exists has to stop a live, paid drain WITHOUT
+	// exiting: the refusal's own error must reach the entry point's entryExitCode, and with every handle
+	// released the process drains to that code on its own -- measured, worker.close() plus
+	// redis.disconnect() reaches beforeExit where every other combination still holds the loop at 8s.
+	const origExit = process.exit;
+	const beforeTerm = new Set(process.listeners("SIGTERM"));
+	const beforeInt = new Set(process.listeners("SIGINT"));
+	const order = [];
+	let exits = 0;
+	let worker;
+	try {
+		process.exit = () => {
+			exits += 1;
+		};
+		worker = mod.createWorker({
+			connection: { host: "127.0.0.1", port: 1 },
+			concurrency: 1,
+			getSettings: () => ({ provider: "anthropic", model: "m", maxTurns: 30, dailyCap: 10, concurrency: 3 }),
+			redis: { disconnect: () => order.push("redis") },
+			deps: {},
+			stopContainer: async () => {},
+			extraClosers: [{ close: async () => order.push("closer") }],
+		});
+		worker.on("error", () => {});
+		assert.equal(typeof worker.stop, "function", "stop rides the returned worker the way hostWorker does -- no caller's contract moves");
+		await worker.stop();
+		assert.deepEqual(order, ["closer", "redis"], "stop is the WHOLE teardown in the shutdown's own order: drain, then release");
+		assert.equal(exits, 0, "and it does NOT exit -- an exit here would hand a supervisor 0 for a refused boot");
+
+		const shutdown = process.listeners("SIGTERM").find((l) => !beforeTerm.has(l));
+		await shutdown();
+		assert.equal(exits, 1, "the signal path is stop() then exit, and a stop that already ran does not disarm it");
+	} finally {
+		process.exit = origExit;
+		for (const l of process.listeners("SIGTERM")) if (!beforeTerm.has(l)) process.removeListener("SIGTERM", l);
+		for (const l of process.listeners("SIGINT")) if (!beforeInt.has(l)) process.removeListener("SIGINT", l);
+		await Promise.resolve(worker?.close()).catch(() => {});
+	}
+});
+
 test("a closer pushed AFTER createWorker returns is still closed by the shutdown", { skip }, async () => {
 	// `start.mjs` hands this array over BEFORE its three live-edit watches exist, then pushes their closers in
 	// once they are armed -- which it may only do because this shutdown reads the array LATE, at signal time,


### PR DESCRIPTION
Closes #299.

The bad one of the four lifecycle defects, because it spends. `createWorker` starts consuming at construction, so everything after the handoff in `startWorker` runs beside a live, paid drain, and `cli.mjs` sets `process.exitCode` without exiting. A refusal landing in that window printed its error and kept taking jobs against a paid provider: fail loud, then silently continue.

## What changed

* `createWorker`'s shutdown splits into `stop()` (the cancel, the per-worker close, the `extraClosers` drain, the shared client release) and the signal handler, which is `stop()` then `process.exit(0)` under its unchanged name, because the source pin in `wiring.test.mjs` deliberately reads the registration lines. `stop` rides the returned worker beside `hostWorker`, so no caller's contract moves.
* The whole post-handoff region sits in a catch that stops what was built and rethrows: `entryExitCode` turns a tagged configError into `EXIT_POLICY` 2 and infra into the retryable 1, and a swallow would hand a supervisor a clean 0 for a refused boot. The catch covers the region, not a list of calls. The bulk of the diff is that region moving one tab right; `git diff -w` shows the honest 22-line view.
* `cli.mjs` is deliberately untouched, measured rather than argued: with the stop plus #300's release nothing holds the loop and the process drains to the refusal's own code, while a `process.exit` in the shared catch would fire for every subcommand, truncate a pipe's pending stdout, and mask a leaked handle instead of closing it. That measured pairing is why #300 landed first.
* The stop call is spelled `await Promise.resolve(worker?.stop?.()).catch(() => {})`, and the spelling is mutation-checked in both directions: a synchronous test double stays green under this form and goes red under the optional-chained one, where a TypeError replaces the boot's real error.

One pre-existing corner, named not changed: a SIGTERM landing inside a refused boot's short drain window still exits 0, exactly as it did before this change; the window is seconds and a supervisor only signals a process that lingers.

## Tests

The existing refuses-after-the-handoff test proved only that the test file's own teardown drained; its double now records `stop` through a caller-provided array (a rejecting boot never returns, so the return value cannot carry it), and a second test refuses from the opposite end of the region, the retention sweep's arming, so the pair pins the wrap rather than one call site. A new contract test drives `stop()` directly: the whole teardown in the shutdown's own order, no exit, and the signal path intact afterwards. Five mutation checks, all as required.

## Specs

New `DES-BOOT-REFUSAL-STOPS-THE-WORKER` records the window, the rethrow, the measured `cli.mjs` decision, and why no requirements row is minted (the boot-refusal acceptances each own a specific refusal; none owns the post-construction window; mirroring a design mechanism there would restate rather than require). `CONST-BUDGET-BEFORE-TOKENS`, `CONST-RETRY-INFRA-ONLY`, `DES-SHUTDOWN-RELEASES-THE-SHARED-CLIENT`, `INT-RUNNER-EXIT-CODE-PROTOCOL` UNCHANGED, checked. No version bump, so `release.yml` skips every publish.

## Verification

Full suite in the CI posture (live Valkey, all three REQUIRE flags): 3455 tests, 0 fail, 1 skipped (the macOS reading of the systemd unit test only Linux runs).

This closes the #295 follow-up cluster: #302, #301, #300 and #299 have each landed as their own PR, with no version moved anywhere, so nothing publishes until a release PR bumps the versions.

A second commit carries the review finding, test-only: the sweep-refusal test now arms a live-edit watcher inside the region before the throw, so armed-then-refused is walked rather than argued. The executing pass measured the defect end to end: on main the driven refusal took an enqueued job in 9ms behind the printed error and handed SIGTERM a clean exit 0; the fixed boot held zero consumers on both queues and drained to the refusal's own code in 11ms.
